### PR TITLE
Refactor BatchCreateJob spec

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -125,6 +125,8 @@ RSpec/ExampleLength:
     - 'spec/indexers/hyrax/file_set_indexer_spec.rb'
     - 'spec/javascripts/jasmine_spec.rb'
     - 'spec/jobs/file_set_attached_event_job_spec.rb'
+    - 'spec/jobs/batch_create_job_spec.rb'
+    - 'spec/jobs/create_work_job_spec.rb'
     - 'spec/jobs/content_update_event_job_spec.rb'
     - 'spec/jobs/content_restored_version_event_job_spec.rb'
     - 'spec/jobs/content_new_version_event_job_spec.rb'

--- a/spec/jobs/batch_create_job_spec.rb
+++ b/spec/jobs/batch_create_job_spec.rb
@@ -1,18 +1,7 @@
 describe BatchCreateJob do
   let(:user) { create(:user) }
   let(:log) { create(:batch_create_operation, user: user) }
-
-  before do
-    allow(CharacterizeJob).to receive(:perform_later)
-    allow(Hyrax.config.callback).to receive(:run)
-    allow(Hyrax.config.callback).to receive(:set?)
-      .with(:after_batch_create_success)
-      .and_return(true)
-    allow(Hyrax.config.callback).to receive(:set?)
-      .with(:after_batch_create_failure)
-      .and_return(true)
-  end
-
+  let(:child_log) { double }
   describe "#perform" do
     let(:file1) { File.open(fixture_path + '/world.png') }
     let(:file2) { File.open(fixture_path + '/image.jp2') }
@@ -22,9 +11,6 @@ describe BatchCreateJob do
     let(:resource_types) { { upload1.id.to_s => 'Article', upload2.id.to_s => 'Image' } }
     let(:metadata) { { keyword: [] } }
     let(:uploaded_files) { [upload1.id.to_s, upload2.id.to_s] }
-    let(:errors) { double(full_messages: "It's broke!") }
-    let(:work) { double(errors: errors) }
-    let(:actor) { double(curation_concern: work) }
 
     subject do
       described_class.perform_later(user,
@@ -35,46 +21,32 @@ describe BatchCreateJob do
                                     log)
     end
 
-    it "updates work metadata" do
-      expect(Hyrax::CurationConcern).to receive(:actor).and_return(actor).twice
-      expect(actor).to receive(:create).with(keyword: [], title: ['File One'], resource_type: ["Article"], uploaded_files: ['1']).and_return(true)
-      expect(actor).to receive(:create).with(keyword: [], title: ['File Two'], resource_type: ["Image"], uploaded_files: ['2']).and_return(true)
-      expect(Hyrax.config.callback).to receive(:run).with(:after_batch_create_success, user)
+    before do
+      allow(Hyrax::Operation).to receive(:create!).with(user: user,
+                                                        operation_type: "Create Work",
+                                                        parent: log).and_return(child_log)
+    end
+
+    it "spawns CreateWorkJobs for each work" do
+      expect(CreateWorkJob).to receive(:perform_later).with(user,
+                                                            "GenericWork",
+                                                            {
+                                                              keyword: [],
+                                                              title: ['File One'],
+                                                              resource_type: ["Article"],
+                                                              uploaded_files: ['1']
+                                                            },
+                                                            child_log).and_return(true)
+      expect(CreateWorkJob).to receive(:perform_later).with(user,
+                                                            "GenericWork",
+                                                            {
+                                                              keyword: [],
+                                                              title: ['File Two'],
+                                                              resource_type: ["Image"],
+                                                              uploaded_files: ['2']
+                                                            },
+                                                            child_log).and_return(true)
       subject
-      expect(log.status).to eq 'pending'
-      expect(log.reload.status).to eq 'success'
-    end
-
-    context "when permissions_attributes are passed" do
-      let(:metadata) do
-        { "permissions_attributes" => [{ "type" => "group", "name" => "public", "access" => "read" }] }
-      end
-      it "sets the groups" do
-        subject
-        work = GenericWork.last
-        expect(work.read_groups).to include "public"
-      end
-    end
-
-    context "when visibility is passed" do
-      let(:metadata) do
-        { "visibility" => 'open' }
-      end
-      it "sets public read access" do
-        subject
-        work = GenericWork.last
-        expect(work.reload.read_groups).to eq ['public']
-      end
-    end
-
-    context "when user does not have permission to edit all of the works" do
-      it "sends the failure message" do
-        expect(Hyrax::CurationConcern).to receive(:actor).and_return(actor).twice
-        expect(actor).to receive(:create).and_return(true, false)
-        expect(Hyrax.config.callback).to receive(:run).with(:after_batch_create_failure, user)
-        subject
-        expect(log.reload.status).to eq 'failure'
-      end
     end
   end
 end

--- a/spec/jobs/create_work_job_spec.rb
+++ b/spec/jobs/create_work_job_spec.rb
@@ -1,0 +1,57 @@
+describe CreateWorkJob do
+  let(:user) { create(:user) }
+  let(:log) do
+    Hyrax::Operation.create!(user: user,
+                             operation_type: "Create Work")
+  end
+
+  describe "#perform" do
+    let(:file1) { File.open(fixture_path + '/world.png') }
+    let(:upload1) { Hyrax::UploadedFile.create(user: user, file: file1) }
+    let(:metadata) do
+      { keyword: [],
+        "permissions_attributes" => [{ "type" => "group", "name" => "public", "access" => "read" }],
+        "visibility" => 'open',
+        uploaded_files: [upload1.id],
+        title: ['File One'],
+        resource_type: ['Article'] }
+    end
+    let(:errors) { double(full_messages: ["It's broke!"]) }
+    let(:work) { double(errors: errors) }
+    let(:actor) { double(curation_concern: work) }
+
+    subject do
+      described_class.perform_later(user,
+                                    'GenericWork',
+                                    metadata,
+                                    log)
+    end
+    before do
+      allow(Hyrax::CurationConcern).to receive(:actor).and_return(actor)
+      allow(GenericWork).to receive(:new).and_return(work)
+    end
+
+    context "when the update is successful" do
+      it "logs the success" do
+        expect(actor).to receive(:create).with(keyword: [],
+                                               title: ['File One'],
+                                               resource_type: ["Article"],
+                                               "permissions_attributes" =>
+                                                 [{ "type" => "group", "name" => "public", "access" => "read" }],
+                                               "visibility" => "open",
+                                               uploaded_files: [upload1.id]).and_return(true)
+        subject
+        expect(log.reload.status).to eq 'success'
+      end
+    end
+
+    context "when the actor does not create the work" do
+      it "logs the failure" do
+        expect(actor).to receive(:create).and_return(false)
+        subject
+        expect(log.reload.status).to eq 'failure'
+        expect(log.message).to eq "It's broke!"
+      end
+    end
+  end
+end


### PR DESCRIPTION
@projecthydra/hyrax-code-reviewers

So that it tests just the job and doesn't call the whole stack (which is
slow). Also added CreateWorkJob spec to cover that previously untested
class.

Fixes #17