### PR TITLE
20 my works visibility

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -222,9 +222,9 @@ module Hyrax
         if document.registered?
           content_tag :span, institution_name, class: "label label-info", title: institution_name
         elsif document.public?
-          content_tag :span, t('hyrax.visibility.open'), class: "label label-success", title: t('hyrax.visibility.open_title_attr')
+          content_tag :span, t('hyrax.visibility.open.text'), class: "label label-success", title: t('hyrax.visibility.open_title_attr')
         else
-          content_tag :span, t('hyrax.visibility.private'), class: "label label-danger", title: t('hyrax.visibility.private_title_attr')
+          content_tag :span, t('hyrax.visibility.private.text'), class: "label label-danger", title: t('hyrax.visibility.private_title_attr')
         end
       end
 

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -200,9 +200,12 @@ module Hyrax
     def render_visibility_link(document)
       # Anchor must match with a tab in
       # https://github.com/projecthydra/hyrax/blob/master/app/views/hyrax/base/_guts4form.html.erb#L2
-      link_to render_visibility_label(document),
-              edit_polymorphic_path([main_app, document], anchor: "share"),
-              id: "permission_" + document.id, class: "visibility-link"
+      link_to(
+        render_visibility_label(document),
+        edit_polymorphic_path([main_app, document], anchor: 'share'),
+        id: "permission_#{document.id}",
+        class: 'visibility-link'
+      )
     end
 
     def user_display_name_and_key(user_key)
@@ -220,11 +223,11 @@ module Hyrax
 
       def render_visibility_label(document)
         if document.registered?
-          content_tag :span, institution_name, class: "label label-info", title: institution_name
+          content_tag(:span, institution_name, class: 'label label-info', title: institution_name)
         elsif document.public?
-          content_tag :span, t('hyrax.visibility.open.text'), class: "label label-success", title: t('hyrax.visibility.open_title_attr')
+          content_tag(:span, t('hyrax.visibility.open.text'), class: 'label label-success', title: t('hyrax.visibility.open_title_attr'))
         else
-          content_tag :span, t('hyrax.visibility.private.text'), class: "label label-danger", title: t('hyrax.visibility.private_title_attr')
+          content_tag(:span, t('hyrax.visibility.private.text'), class: 'label label-danger', title: t('hyrax.visibility.private_title_attr'))
         end
       end
 

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -543,6 +543,7 @@ en:
         label_html: <span class="label label-success">Open Access</span> Everyone. Check out <a href="">SHERPA/RoMEO</a> for specific publishers' copyright policies if you plan to patent and/or publish your %{type} in a journal.
       open_title_attr: "Change the visibility of this resource"
       private:
+        text: "Private"
         label_html: <span class="label label-danger">Private</span> Only users and/or groups that have been given specific access in the "Share With" section.
       private_title_attr: "Change the visibility of this resource"
       restricted:


### PR DESCRIPTION
Fixes #20; refs #20; refs projecthydra-labs/hyku#522

Permission badges in the "My Works" dashboard were not human-readable

- Changed the I8n lookup to reference the text value of a permission option, rather than a hash of several values

@projecthydra/hyrax-code-reviewers
