### PR TITLE
Show a work if it doesn't have a Sipity::Entity

### DIFF
--- a/app/search_builders/hyrax/filter_suppressed_with_roles.rb
+++ b/app/search_builders/hyrax/filter_suppressed_with_roles.rb
@@ -25,6 +25,9 @@ module Hyrax
 
       def user_has_active_workflow_role?
         Workflow::PermissionQuery.scope_permitted_workflow_actions_available_for_current_state(user: current_ability.current_user, entity: current_work).any?
+      rescue PowerConverter::ConversionError
+        # The current_work doesn't have a sipity workflow entity
+        false
       end
   end
 end

--- a/app/search_builders/hyrax/work_search_builder.rb
+++ b/app/search_builders/hyrax/work_search_builder.rb
@@ -1,4 +1,8 @@
 module Hyrax
+  # Finds a single work result. It returns no result if you don't have
+  # access to the requested work.  If the work is suppressed (due to being in a
+  # workflow), then it checks to see if the current_user has any workflow role
+  # on the given work.
   class WorkSearchBuilder < ::SearchBuilder
     include SingleResult
     include FilterSuppressedWithRoles

--- a/spec/search_builder/hyrax/work_search_builder_spec.rb
+++ b/spec/search_builder/hyrax/work_search_builder_spec.rb
@@ -1,0 +1,65 @@
+describe Hyrax::WorkSearchBuilder do
+  let(:me) { create(:user) }
+  let(:config) { CatalogController.blacklight_config }
+  let(:scope) do
+    double('The scope',
+           blacklight_config: config,
+           current_ability: Ability.new(me),
+           current_user: me)
+  end
+  let(:builder) { described_class.new(scope).with(params) }
+  let(:params) { { id: '123abc' } }
+
+  before do
+    allow(builder).to receive(:gated_discovery_filters).and_return(["access_filter1", "access_filter2"])
+
+    # This prevents any generated classes from interfering with this test:
+    allow(builder).to receive(:work_classes).and_return([GenericWork])
+  end
+
+  describe "#query" do
+    subject { builder.query }
+    let(:doc) { instance_double(SolrDocument) }
+    before do
+      allow(SolrDocument).to receive(:find).and_return(doc)
+    end
+
+    context "when the current_work has a workflow entity" do
+      before do
+        expect(Hyrax::Workflow::PermissionQuery).to receive(:scope_permitted_workflow_actions_available_for_current_state)
+          .with(user: me,
+                entity: doc).and_return(roles)
+      end
+      context "and the current user has a role" do
+        let(:roles) { [double] }
+        it "filters for id, access, suppressed and type" do
+          expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
+                                      "{!terms f=has_model_ssim}GenericWork,Collection",
+                                      "{!raw f=id}123abc"]
+        end
+      end
+      context "and the current user doesn't have a role" do
+        let(:roles) { [] }
+        it "filters for id, access, suppressed and type" do
+          expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
+                                      "{!terms f=has_model_ssim}GenericWork,Collection",
+                                      "-suppressed_bsi:true",
+                                      "{!raw f=id}123abc"]
+        end
+      end
+    end
+
+    context "when the current_work doesn't have a workflow entity" do
+      before do
+        expect(Hyrax::Workflow::PermissionQuery).to receive(:scope_permitted_workflow_actions_available_for_current_state)
+          .and_raise(PowerConverter::ConversionError.new(double, {}))
+      end
+      it "filters for id, access, suppressed and type" do
+        expect(subject[:fq]).to eq ["access_filter1 OR access_filter2",
+                                    "{!terms f=has_model_ssim}GenericWork,Collection",
+                                    "-suppressed_bsi:true",
+                                    "{!raw f=id}123abc"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows legacy objects (that didn't go through workflow to be viewed).

This may need to be backported to curation_concerns.
@projecthydra/hyrax-code-reviewers

