### PR TITLE
Removes duplicate chevron from facets.

### DIFF
--- a/app/assets/stylesheets/hyrax/_dashboard.scss
+++ b/app/assets/stylesheets/hyrax/_dashboard.scss
@@ -123,7 +123,7 @@ ul.collapsing > li > a {
   padding-left: 40px;
 }
 
-.collapse-toggle {
+.admin-sidebar .collapse-toggle {
   margin-bottom: 0;
 
   &::after {

--- a/app/views/hyrax/admin/_sidebar.html.erb
+++ b/app/views/hyrax/admin/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<ul class="nav nav-pills nav-stacked">
+<ul class="admin-sidebar nav nav-pills nav-stacked">
   <li class="<%= 'active' if current_page? hyrax.admin_stats_path %>">
     <%= link_to hyrax.admin_stats_path do %>
       <span class="fa fa-bar-chart"></span> <%= t('hyrax.admin.sidebar.statistics') %>


### PR DESCRIPTION
Fixes https://github.com/projecthydra-labs/hyku/issues/532 (Partially)

Current admin dashboard uses li for menus but with the same classes as the div menus in facets. Styles for the chevrons are clashing. Adding li to CSS separates the two.

Same change will be needed in hyku as well.

@projecthydra/hyrax-code-reviewers

