### PR TITLE
Breaking out visibility notes into a different I18n string

### DIFF
--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -10,7 +10,7 @@
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' }  %>
             <%= t('hyrax.visibility.open.label_html') %>
-            <%= t('hyrax.visibility.open.note', type: f.object.human_readable_type).html_safe %>
+            <%= t('hyrax.visibility.open.note_html', type: f.object.human_readable_type) %>
             <div class="collapse" id="collapsePublic">
               <p>
                 <strong>Please note</strong>, making something visible to the world (i.e.
@@ -32,7 +32,7 @@
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
             <%= t('hyrax.visibility.authenticated.label_html', institution: t('hyrax.institution_name')) %>
-            <%= t('hyrax.visibility.authenticated.note', institution: t('hyrax.institution_name')) %>
+            <%= t('hyrax.visibility.authenticated.note_html', institution: t('hyrax.institution_name')) %>
           </label>
         </li>
         <li class="radio">
@@ -65,7 +65,7 @@
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
             <%= t('hyrax.visibility.private.label_html') %>
-            <%= t('hyrax.visibility.private.note') %>
+            <%= t('hyrax.visibility.private.note_html') %>
           </label>
         </li>
       </ul>

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -10,6 +10,7 @@
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' }  %>
             <%= t('hyrax.visibility.open.label_html') %>
+            <%= t('hyrax.visibility.open.note', type: f.object.human_readable_type).html_safe %>
             <div class="collapse" id="collapsePublic">
               <p>
                 <strong>Please note</strong>, making something visible to the world (i.e.
@@ -31,6 +32,7 @@
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
             <%= t('hyrax.visibility.authenticated.label_html', institution: t('hyrax.institution_name')) %>
+            <%= t('hyrax.visibility.authenticated.note', institution: t('hyrax.institution_name')) %>
           </label>
         </li>
         <li class="radio">
@@ -63,6 +65,7 @@
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
             <%= t('hyrax.visibility.private.label_html') %>
+            <%= t('hyrax.visibility.private.note') %>
           </label>
         </li>
       </ul>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -553,7 +553,7 @@ en:
         text: *INSTITUTION_NAME
         class: "label-info"
         label_html: <span class="label label-info">%{institution}</span>
-        note: Restrict access to only users and/or groups from %{institution}
+        note_html: Restrict access to only users and/or groups from %{institution}
       embargo:
         text: "Embargo"
         class: "label-warning"
@@ -566,12 +566,12 @@ en:
         text: "Open Access"
         class: "label-success"
         label_html: <span class="label label-success">Open Access</span>
-        note:  Everyone. Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for specific publishers' copyright policies if you plan to patent and/or publish your %{type} in a journal.
+        note_html:  Everyone. Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for specific publishers' copyright policies if you plan to patent and/or publish your %{type} in a journal.
       open_title_attr: "Change the visibility of this resource"
       private:
         text: "Private"
         label_html: <span class="label label-danger">Private</span>
-        note: Only users and/or groups that have been given specific access in the "Share With" section.
+        note_html: Only users and/or groups that have been given specific access in the "Share With" section.
       private_title_attr: "Change the visibility of this resource"
       restricted:
         text: "Private"

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -552,7 +552,8 @@ en:
       authenticated:
         text: *INSTITUTION_NAME
         class: "label-info"
-        label_html: <span class="label label-info">%{institution}</span> Restrict access to only users and/or groups from %{institution}
+        label_html: <span class="label label-info">%{institution}</span>
+        note: Restrict access to only users and/or groups from %{institution}
       embargo:
         text: "Embargo"
         class: "label-warning"
@@ -564,11 +565,13 @@ en:
       open:
         text: "Open Access"
         class: "label-success"
-        label_html: <span class="label label-success">Open Access</span> Everyone. Check out <a href="">SHERPA/RoMEO</a> for specific publishers' copyright policies if you plan to patent and/or publish your %{type} in a journal.
+        label_html: <span class="label label-success">Open Access</span>
+        note:  Everyone. Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for specific publishers' copyright policies if you plan to patent and/or publish your %{type} in a journal.
       open_title_attr: "Change the visibility of this resource"
       private:
         text: "Private"
-        label_html: <span class="label label-danger">Private</span> Only users and/or groups that have been given specific access in the "Share With" section.
+        label_html: <span class="label label-danger">Private</span>
+        note: Only users and/or groups that have been given specific access in the "Share With" section.
       private_title_attr: "Change the visibility of this resource"
       restricted:
         text: "Private"


### PR DESCRIPTION
Fixes #32 ; refs #32

Fixing interpolation of internationalization terms for visibility labels. Bonus: removing descriptive text from the `label_html` term. Now you can call `label_html` and just get the label. 🎉 

@projecthydra/hyrax-code-reviewers

