### PR TITLE
Use the correct parameters for a isolated engine

### DIFF
--- a/app/controllers/hyrax/admin/permission_templates_controller.rb
+++ b/app/controllers/hyrax/admin/permission_templates_controller.rb
@@ -7,7 +7,7 @@ module Hyrax
         authorize! :update, @permission_template
         Forms::PermissionTemplateForm.new(@permission_template).update(update_params)
         # Ensure we redirect to active tab
-        current_tab = params[:hyrax_permission_template][:access_grants_attributes].present? ? 'participants' : 'visibility'
+        current_tab = params[:permission_template][:access_grants_attributes].present? ? 'participants' : 'visibility'
         redirect_to hyrax.edit_admin_admin_set_path(params[:admin_set_id], anchor: current_tab),
                     notice: 'Permissions updated'
       end
@@ -20,7 +20,7 @@ module Hyrax
         end
 
         def update_params
-          params.require(:hyrax_permission_template)
+          params.require(:permission_template)
                 .permit(:release_date, :release_period, :release_varies, :release_embargo, :visibility,
                         access_grants_attributes: [:access, :agent_id, :agent_type, :id])
         end

--- a/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplatesController do
       let(:grant_attributes) { [{ "agent_type" => "user", "agent_id" => "bob", "access" => "view" }] }
       let(:input_params) do
         { admin_set_id: admin_set.id,
-          hyrax_permission_template: form_attributes }
+          permission_template: form_attributes }
       end
       let(:form_attributes) { { visibility: 'open', access_grants_attributes: grant_attributes } }
 


### PR DESCRIPTION
In an isolated engine, the parameters are not preceded by a namespace.