### PR TITLE
Don't display the transfer link when they can't use it.

### DIFF
--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -30,11 +30,14 @@
         <i class='glyphicon glyphicon-star'></i> <%= text %>
       <% end %>
     </li>
-    <li role="menuitem" tabindex="-1">
-      <%= link_to(hyrax.new_work_transfer_path(document.id), class: 'itemicon itemtransfer', title: t("hyrax.dashboard.my.action.transfer")) do %>
-        <i aria-hidden="true" class='glyphicon glyphicon-transfer'></i>
-        <span> <%= t("hyrax.dashboard.my.action.transfer") %> </span>
-      <% end %>
-    </li>
+
+    <% if can? :transfer, document.id %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to(hyrax.new_work_transfer_path(document.id), class: 'itemicon itemtransfer', title: t("hyrax.dashboard.my.action.transfer")) do %>
+          <i aria-hidden="true" class='glyphicon glyphicon-transfer'></i>
+          <span> <%= t("hyrax.dashboard.my.action.transfer") %> </span>
+        <% end %>
+      </li>
+    <% end %>
   </ul>
 </div>

--- a/spec/views/hyrax/my/_list_works.html.erb_spec.rb
+++ b/spec/views/hyrax/my/_list_works.html.erb_spec.rb
@@ -17,25 +17,20 @@ describe 'hyrax/my/_index_partials/_list_works.html.erb', type: :view do
   end
 
   before do
-    allow(doc).to receive(:to_model).and_return(stub_model(GenericWork, id: id))
     allow(view).to receive(:current_user).and_return(stub_model(User))
     allow(view).to receive(:render_collection_links).with(doc).and_return("<a href=\"collection/1\">Collection Title</a>".html_safe)
     allow(view).to receive(:render_visibility_link).with(doc).and_return("<a class=\"visibility-link\">Private</a>".html_safe)
     allow(view).to receive(:blacklight_config) { config }
     allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
-    view.lookup_context.prefixes.push 'hyrax/my'
-    view.extend Hyrax::TrophyHelper
-
+    stub_template 'hyrax/my/_index_partials/_work_action_menu.html.erb' => 'actions'
     render 'hyrax/my/_index_partials/list_works', document: doc, presenter: presenter
   end
 
   it 'the line item displays the work and its actions' do
     expect(rendered).to have_selector("tr#document_#{id}")
     expect(rendered).to have_link 'Work Title', href: hyrax_generic_work_path(id)
-    expect(rendered).to have_link 'Edit Work', href: edit_hyrax_generic_work_path(id)
-    expect(rendered).to have_link 'Delete Work', href: hyrax_generic_work_path(id)
+    expect(rendered).to have_content 'actions'
     expect(rendered).to have_css 'a.visibility-link', text: 'Private'
     expect(rendered).to have_link 'Collection Title', href: 'collection/1'
-    expect(rendered).to have_link 'Highlight Work on Profile'
   end
 end

--- a/spec/views/hyrax/my/_work_action_menu.html.erb_spec.rb
+++ b/spec/views/hyrax/my/_work_action_menu.html.erb_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'hyrax/my/_work_action_menu.html.erb' do
+  let(:id) { '123' }
+  let(:document) { SolrDocument.new(id: id, has_model_ssim: 'GenericWork') }
+  let(:user) { build(:user) }
+
+  before do
+    allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:display_trophy_link).and_return("Highlight Work on Profile")
+  end
+
+  context "When the user can transfer works" do
+    before do
+      allow(view).to receive(:can?).with(:transfer, id).and_return(true)
+      render 'hyrax/my/work_action_menu', document: document
+    end
+
+    it "draws the page" do
+      expect(rendered).to have_link "Transfer Ownership of Work"
+      expect(rendered).to have_link 'Edit Work', href: edit_hyrax_generic_work_path(id)
+      expect(rendered).to have_link 'Delete Work', href: hyrax_generic_work_path(id)
+      expect(rendered).to have_content 'Highlight Work on Profile'
+    end
+  end
+
+  context "when the user can't transfer works" do
+    before do
+      allow(view).to receive(:can?).with(:transfer, id).and_return(false)
+      render 'hyrax/my/work_action_menu', document: document
+    end
+
+    it "draws the page" do
+      expect(rendered).not_to have_link "Transfer Ownership of Work"
+      expect(rendered).to have_link 'Edit Work', href: edit_hyrax_generic_work_path(id)
+      expect(rendered).to have_link 'Delete Work', href: hyrax_generic_work_path(id)
+      expect(rendered).to have_content 'Highlight Work on Profile'
+    end
+  end
+end


### PR DESCRIPTION
If the transfers have been disabled, don't show the link to transfer a
work.  Fixes https://github.com/projecthydra-labs/hyku/issues/558

