### PR TITLE
Fix rails template link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Generate a new Rails application. We recommend the latest Rails 5.0 release.
 ```
 # If you don't already have Rails at your disposal...
 gem install rails -v 5.0.0.1
-rails new my_app -m https://raw.githubusercontent.com/projecthydra/hyrax/master/template.rb
+rails new my_app -m https://raw.githubusercontent.com/projecthydra-labs/hyrax/master/template.rb
 ```
 
 Generating a new Rails application using Hyrax's template above takes cares of a number of steps for you, including:


### PR DESCRIPTION
The rails template link had fallen out of date, pointing to `projecthydra` instead of `projecthydra-labs`. The update fixes the app generation instructions.

@projecthydra-labs/hyrax-code-reviewers
