### PR TITLE
Add workflow tab

### DIFF
--- a/app/controllers/hyrax/admin/permission_templates_controller.rb
+++ b/app/controllers/hyrax/admin/permission_templates_controller.rb
@@ -6,10 +6,8 @@ module Hyrax
       def update
         authorize! :update, @permission_template
         Forms::PermissionTemplateForm.new(@permission_template).update(update_params)
-        # Ensure we redirect to active tab
-        current_tab = params[:permission_template][:access_grants_attributes].present? ? 'participants' : 'visibility'
-        redirect_to hyrax.edit_admin_admin_set_path(params[:admin_set_id], anchor: current_tab),
-                    notice: 'Permissions updated'
+        # Ensure we redirect to currently active tab
+        redirect_to hyrax.edit_admin_admin_set_path(params[:admin_set_id], anchor: current_tab), notice: "Permissions updated"
       end
 
       private
@@ -21,8 +19,14 @@ module Hyrax
 
         def update_params
           params.require(:permission_template)
-                .permit(:release_date, :release_period, :release_varies, :release_embargo, :visibility,
+                .permit(:release_date, :release_period, :release_varies, :release_embargo, :visibility, :workflow_name,
                         access_grants_attributes: [:access, :agent_id, :agent_type, :id])
+        end
+
+        def current_tab
+          return 'participants' if params[:permission_template][:access_grants_attributes].present?
+          return 'workflow' if params[:permission_template][:workflow_name].present?
+          'visibility'
         end
     end
   end

--- a/app/forms/hyrax/forms/admin_set_form.rb
+++ b/app/forms/hyrax/forms/admin_set_form.rb
@@ -25,10 +25,6 @@ module Hyrax
         @permission_template.workflow_name
       end
 
-      def workflows
-        Sipity::Workflow.all.map { |workflow| [workflow.label, workflow.name] }
-      end
-
       class << self
         # This determines whether the allowed parameters are single or multiple.
         # By default it delegates to the model.

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -2,9 +2,10 @@ module Hyrax
   module Forms
     class PermissionTemplateForm
       include HydraEditor::Form
+
       self.model_class = PermissionTemplate
       self.terms = []
-      delegate :access_grants, :access_grants_attributes=, :release_date, :release_period, :visibility, to: :model
+      delegate :access_grants, :access_grants_attributes=, :release_date, :release_period, :visibility, :workflow_name, to: :model
 
       # Stores which radio button under release "Varies" option is selected
       attr_accessor :release_varies
@@ -31,10 +32,6 @@ module Hyrax
       end
 
       def initialize(model)
-        # This is a temporary way to make sure all new PermissionTemplates have
-        # a workflow assigned to them. Ultimately we want to expose workflows in
-        # the UI and have users choose a workflow for their PermissionTemplate.
-        model.workflow_name = 'one_step_mediated_deposit'
         super(model)
         # Ensure proper form options selected, based on model
         select_release_varies_option(model)
@@ -45,6 +42,10 @@ module Hyrax
         grant_admin_set_access(manage_grants) if manage_grants.present?
         update_release_attributes(attributes)
         model.update(attributes)
+      end
+
+      def workflows
+        Sipity::Workflow.all
       end
 
       private

--- a/app/views/hyrax/admin/admin_sets/_form.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form.html.erb
@@ -10,6 +10,9 @@
           <li>
             <a href="#visibility" role="tab" data-toggle="tab"><%= t('.tabs.visibility') %></a>
           </li>
+          <li>
+            <a href="#workflow" role="tab" data-toggle="tab"><%= t('.tabs.workflow') %></a>
+          </li>
         <% end %>
       </ul>
       <div class="tab-content">
@@ -23,11 +26,11 @@
                 <% if f.object.persisted? && f.object.member_ids.present? %>
                   <%= f.input :thumbnail_id, collection: @form.select_files %>
                 <% end %>
-                <%= f.input :workflow_name, as: :select, collection: f.object.workflows %>
+
               </div>
 
               <div class="panel-footer">
-                <%= link_to 'Cancel', hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
+                <%= link_to t('.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
                 <%= f.button :submit, class: 'btn btn-primary pull-right'%>
               </div>
             <% end %>
@@ -36,6 +39,7 @@
         <% if @form.persisted? %>
           <%= render 'form_participants' %>
           <%= render 'form_visibility' %>
+          <%= render 'form_workflow' %>
         <% end %>
       </div>
     </div>

--- a/app/views/hyrax/admin/admin_sets/_form_workflow.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_workflow.erb
@@ -1,0 +1,20 @@
+                <div id="workflow" class="tab-pane">
+                  <div class="panel panel-default labels">
+                    <%= simple_form_for @form.permission_template,
+                      url: [hyrax, :admin, @form, :permission_template],
+                      html: { id: 'form_workflows' } do |f| %>
+                      <div class="panel-body">
+
+                      <p><%= t('.page_description') %></p>
+                        <%= f.collection_radio_buttons :workflow_name, f.object.workflows, :name, :label, item_wrapper_tag: :div, item_wrapper_class: "radio" do |b| %>
+                          <span><%= b.radio_button + b.object.label %></span>
+                          <p><%= b.object.description %></p>
+                        <% end %>
+                      </div>
+                      <div class="panel-footer">
+                        <%= link_to t('.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
+                        <%= f.button :submit, class: 'btn btn-primary pull-right'%>
+                      </div>
+                    <% end %>
+                  </div>
+                </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -14,6 +14,8 @@ en:
             description:        "Description"
             participants:       "Participants"
             visibility:         "Release and Visibility"
+            workflow:           "Workflow"
+          cancel:               "Cancel"  
         form_participants:
           add_group:            "Add group:"
           add_user:             "Add user:"
@@ -64,6 +66,9 @@ en:
             varies:             "Varies -- default is public, but depositors can restrict the visibility of individual works"
             institution:        "Institution -- all works will be visible only to authenticated users of this institution"
             restricted:         "Restricted -- all works will be visible only to repository managers and managers and reviewers of this administrative set"
+          cancel:               "Cancel"
+        form_workflow:
+          page_description:     "Each administrative set has a workflow associated with it. This workflow is applied to all works added to the administrative set. Select the workflow to be used for this administrative set below."
           cancel:               "Cancel"
         show:
           header:           "Administrative Set"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -36,6 +36,8 @@ es:
             description:        "Descripción"
             participants:       "Participantes"
             visibility:         "Lanzamiento y Visibilidad"
+            workflow:           "Flujo de trabajo"
+          cancel:               "Cancelar"
         form_participant_table:
           depositors:
             action:             "Acción"
@@ -87,6 +89,9 @@ es:
             restricted:         "Restringido -- todos los trabajos sólo serán visibles para los administradores y gestores de repositorios y los revisores de este conjunto administrativo"
             title:              "Visibilidad"
             varies:             "Varía -- por defecto es público, pero los depositantes pueden restringir la visibilidad de las obras individuales"
+        form_workflow: # TODO: verify text; added via google translate
+          page_description:     "Cada conjunto administrativo tiene un flujo de trabajo asociado con él. Este flujo de trabajo se aplica a todos los trabajos agregados al conjunto administrativo. Seleccione el flujo de trabajo que se utilizará para este conjunto de administración a continuación."
+          cancel:         "Cancelar"
         new:
           header:         "Crear nuevo conjunto Administrativo"
         show:

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -190,4 +190,15 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
       end
     end
   end
+
+  describe "#workflows" do
+    let(:admin_set) { create(:admin_set) }
+    let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
+    let(:form) { described_class.new(permission_template) }
+
+    it "returns all of the workflows" do
+      expect(Sipity::Workflow).to receive(:all).and_return(:the_workflows)
+      expect(form.workflows).to eq(:the_workflows)
+    end
+  end
 end

--- a/spec/views/hyrax/admin/admin_sets/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/_form.html.erb_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe 'hyrax/admin/admin_sets/_form.html.erb', type: :view do
     @form = Hyrax::Forms::AdminSetForm.new(admin_set, permission_template)
     render
   end
-  it "has the edit form" do
-    expect(rendered).to have_select('admin_set[workflow_name]', selected: 'default')
+  it "has 4 tabs" do
+    expect(rendered).to have_selector('#description')
+    expect(rendered).to have_selector('#participants')
+    expect(rendered).to have_selector('#visibility')
+    expect(rendered).to have_selector('#workflow')
   end
 end

--- a/spec/views/hyrax/admin/admin_sets/_form_workflow.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/_form_workflow.html.erb_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe 'hyrax/admin/admin_sets/_form_workflow.html.erb', type: :view do
+  let(:admin_set) { create(:admin_set) }
+  let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by(admin_set_id: admin_set.id) }
+  before do
+    create(:workflow, name: "my_name", description: "random workflow", label: "my label")
+    @form = Hyrax::Forms::AdminSetForm.new(admin_set, permission_template)
+    render
+  end
+  it "has the radio button for workflow" do
+    expect(rendered).to have_selector('#workflow label[for="permission_template_workflow_name_my_name"] input[type=radio][name="permission_template[workflow_name]"][value="my_name"]')
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/projecthydra-labs/hyku/issues/455

Add workflow tab to administrative sets edit

The workflow selection was previously part of a dropdown selection on the "Description" tab within the edit Administrative Sets. This request moves workflow selection into a separate tab, allowing the workflow to be linked to an administrative set via radio buttons. 

Changes proposed in this pull request:
* add new "workflow" tab with radio buttons
* remove dropdown workflow selection from "description" test
* add specs for new form
* add specs to test the workflow method, to ensure that future changes do not break the form

@projecthydra-labs/hyrax-code-reviewers
