### PR TITLE
Adding a link to the work into the notification message

### DIFF
--- a/app/services/hyrax/workflow/abstract_notification.rb
+++ b/app/services/hyrax/workflow/abstract_notification.rb
@@ -13,6 +13,7 @@ module Hyrax
         @comment = comment.respond_to?(:comment) ? comment.comment.to_s : ''
         @recipients = recipients
         @user = user
+        @entity = entity
       end
 
       def call
@@ -27,6 +28,16 @@ module Hyrax
 
         def message
           "#{title} (#{work_id}) was advanced in the workflow by #{user.user_key} and is awaiting approval #{comment}"
+        end
+
+        # @return [ActiveFedora::Base] the document (work) the the Abstract WorkFlow is creating a notification for
+        def document
+          @entity.proxy_for
+        end
+
+        def document_path
+          key = document.model_name.singular_route_key
+          Rails.application.routes.url_helpers.send(key + "_path", document.id)
         end
 
       private

--- a/app/services/hyrax/workflow/changes_required_notification.rb
+++ b/app/services/hyrax/workflow/changes_required_notification.rb
@@ -1,6 +1,8 @@
 module Hyrax
   module Workflow
     class ChangesRequiredNotification < AbstractNotification
+      include ActionView::Helpers::UrlHelper
+
       protected
 
         def subject
@@ -8,13 +10,13 @@ module Hyrax
         end
 
         def message
-          "#{title} (#{work_id}) requires additional changes before approval.\n\n '#{comment}'"
+          "#{title} (#{link_to work_id, document_path}) requires additional changes before approval.\n\n '#{comment}'"
         end
 
       private
 
         def users_to_notify
-          user_key = ActiveFedora::Base.find(work_id).depositor
+          user_key = document.depositor
           super << ::User.find_by(email: user_key)
         end
     end

--- a/spec/services/hyrax/workflow/changes_required_notification_spec.rb
+++ b/spec/services/hyrax/workflow/changes_required_notification_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hyrax::Workflow::ChangesRequiredNotification do
 
   describe ".send_notification" do
     it 'sends a message to all users' do
-      expect(approver).to receive(:send_message).once.and_call_original
+      expect(approver).to receive(:send_message).with(anything, "Test title (<a href=\"/concern/generic_works/#{work.id}\">#{work.id}</a>) requires additional changes before approval.\n\n 'A pleasant read'", anything).once.and_call_original
 
       expect { described_class.send_notification(entity: entity, user: approver, comment: comment, recipients: recipients) }
         .to change { depositor.mailbox.inbox.count }.by(1)


### PR DESCRIPTION
Fixes #197 

Includes a link to the work in the workflow change request notification

![screen shot 2017-01-05 at 1 57 15 pm](https://cloud.githubusercontent.com/assets/1599081/21693438/f4be5588-d34e-11e6-90af-24697c5fc85e.png)

@projecthydra-labs/hyrax-code-reviewers
