### PR TITLE
Move url_for_document to SearchState

### DIFF
--- a/app/controllers/concerns/hyrax/controller.rb
+++ b/app/controllers/concerns/hyrax/controller.rb
@@ -28,6 +28,11 @@ module Hyrax::Controller
     super.merge(locale: I18n.locale)
   end
 
+  # Override Blacklight to use the Hyrax::SearchState
+  def search_state
+    @search_state ||= Hyrax::SearchState.new(params, blacklight_config)
+  end
+
   private
 
     def set_locale

--- a/app/helpers/hyrax/blacklight_override.rb
+++ b/app/helpers/hyrax/blacklight_override.rb
@@ -4,12 +4,5 @@ module Hyrax
     def application_name
       t('hyrax.product_name', default: super)
     end
-
-    # Override Blacklight so we can use the per-worktype routes
-    # @param doc [#collection?, #model_name]
-    def url_for_document(doc, _options = {})
-      return [hyrax, doc] if doc.collection?
-      [main_app, doc]
-    end
   end
 end

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -24,6 +24,7 @@ module Hyrax
       require 'hydra/derivatives'
       require 'hyrax/name'
       require 'hyrax/controller_resource'
+      require 'hyrax/search_state'
       require 'hyrax/single_use_error'
       require 'hyrax/workflow_authorization_exception'
       require 'power_converters'

--- a/lib/hyrax/search_state.rb
+++ b/lib/hyrax/search_state.rb
@@ -1,0 +1,12 @@
+module Hyrax
+  class SearchState < Blacklight::SearchState
+    include ActionDispatch::Routing::RouteSet::MountedHelpers
+
+    # Override Blacklight so we can use the per-worktype routes
+    # @param doc [#collection?, #model_name]
+    def url_for_document(doc, _options = {})
+      return [hyrax, doc] if doc.collection?
+      [main_app, doc]
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,7 @@ require 'capybara/rails'
 require 'equivalent-xml'
 require 'equivalent-xml/rspec_matchers'
 require 'database_cleaner'
+require 'support/controller_level_helpers'
 require 'support/features'
 require 'support/factory_helpers'
 require 'support/rake'
@@ -176,6 +177,9 @@ RSpec.configure do |config|
       DatabaseCleaner.start
     end
   end
+
+  config.include(ControllerLevelHelpers, type: :view)
+  config.before(:each, type: :view) { initialize_controller_helpers(view) }
 
   config.before(:all, type: :feature) do
     # Assets take a long time to compile. This causes two problems:

--- a/spec/support/controller_level_helpers.rb
+++ b/spec/support/controller_level_helpers.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+module ControllerLevelHelpers
+  # This provides some common mock methods for view tests.
+  # These are normally provided by the controller.
+  module ControllerViewHelpers
+    def search_state
+      @search_state ||= Hyrax::SearchState.new(params, blacklight_config)
+    end
+
+    # This allows you to set the configuration
+    # @example: view.blacklight_config = Blacklight::Configuration.new
+    attr_writer :blacklight_config
+
+    def blacklight_config
+      @blacklight_config ||= CatalogController.blacklight_config
+    end
+
+    def blacklight_configuration_context
+      @blacklight_configuration_context ||= Blacklight::Configuration::Context.new(controller)
+    end
+  end
+
+  def initialize_controller_helpers(helper)
+    helper.extend ControllerViewHelpers
+  end
+end

--- a/spec/views/catalog/_index_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_list_default.html.erb_spec.rb
@@ -12,13 +12,8 @@ describe 'catalog/_index_list_default', type: :view do
       'lease_expiration_date_dtsi' => 'a date' }
   end
   let(:document) { SolrDocument.new(attributes) }
-  let(:blacklight_configuration_context) do
-    Blacklight::Configuration::Context.new(controller)
-  end
   let(:presenter) { double }
   before do
-    allow(view).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
-    allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
     allow(view).to receive(:index_presenter).and_return(presenter)
     allow(presenter).to receive(:field_value) { |field| "Test #{field}" }
     render 'catalog/index_list_default', document: document

--- a/spec/views/catalog/index.html.erb_spec.rb
+++ b/spec/views/catalog/index.html.erb_spec.rb
@@ -1,16 +1,10 @@
 describe 'catalog/index.html.erb', type: :view do
   let(:collection) { build(:collection, id: "abc123") }
   let(:doc) { SolrDocument.new(collection.to_solr) }
-  let(:search_state) { double('SearchState', to_h: {}) }
-  let(:blacklight_configuration_context) do
-    Blacklight::Configuration::Context.new(controller)
-  end
 
   before do
     view.extend Hyrax::CollectionsHelper
     allow(view).to receive(:current_users_collections).and_return([])
-    allow(view).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
-    allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
     stub_template 'catalog/_search_sidebar.html.erb' => ''
     stub_template 'catalog/_search_header.html.erb' => ''
     allow(view).to receive(:render_opensearch_response_metadata).and_return('')
@@ -18,7 +12,6 @@ describe 'catalog/index.html.erb', type: :view do
     allow(view).to receive(:search_session).and_return({})
     allow(view).to receive(:current_search_session).and_return(nil)
     allow(view).to receive(:document_counter_with_offset).and_return(5)
-    allow(view).to receive(:search_state).and_return(search_state)
     allow(controller).to receive(:render_bookmarks_control?).and_return(false)
 
     params[:view] = 'gallery'

--- a/spec/views/hyrax/base/_items.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_items.html.erb_spec.rb
@@ -23,17 +23,12 @@ describe 'hyrax/base/items', type: :view do
       )
     )
   end
-  let(:blacklight_config) { CatalogController.new.blacklight_config }
-  let(:blacklight_configuration_context) do
-    Blacklight::Configuration::Context.new(controller)
-  end
 
   context "when children are present" do
     before do
       stub_template 'hyrax/base/_actions.html.erb' => 'Actions'
       allow(presenter).to receive(:member_presenters).and_return([file_set, member])
-      allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
-      allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
+      view.blacklight_config = Blacklight::Configuration.new
       allow(view).to receive(:contextual_path).and_return("/whocares")
       allow(ability).to receive(:can?).and_return(true)
       render 'hyrax/base/items', presenter: presenter

--- a/spec/views/hyrax/base/_member.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_member.html.erb_spec.rb
@@ -13,14 +13,9 @@ describe 'hyrax/base/_member.html.erb' do
   # Ability is checked in FileSetPresenter#link_name
   let(:ability) { double(can?: true) }
   let(:presenter) { Hyrax::FileSetPresenter.new(solr_document, ability) }
-  let(:blacklight_configuration_context) do
-    Blacklight::Configuration::Context.new(controller)
-  end
 
   before do
     assign(:presenter, presenter)
-    allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
-    allow(view).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
     allow(view).to receive(:current_search_session).and_return nil
     allow(view).to receive(:search_session).and_return({})
     # abilities called in _actions.html.erb

--- a/spec/views/hyrax/base/file_manager.html.erb_spec.rb
+++ b/spec/views/hyrax/base/file_manager.html.erb_spec.rb
@@ -34,15 +34,11 @@ RSpec.describe "hyrax/base/file_manager.html.erb" do
     Hyrax::WorkShowPresenter.new(parent_solr_doc, nil, view)
   end
 
-  let(:blacklight_config) { CatalogController.new.blacklight_config }
-
   before do
     allow(parent_presenter).to receive(:member_presenters).and_return([file_set, member])
     assign(:presenter, parent_presenter)
     # Blacklight nonsense
     allow(view).to receive(:dom_class) { '' }
-    allow(view).to receive(:blacklight_config).and_return(blacklight_config)
-    allow(view).to receive(:blacklight_configuration_context).and_return(CatalogController.new.send(:blacklight_configuration_context))
     allow(view).to receive(:search_session).and_return({})
     allow(view).to receive(:current_search_session).and_return(nil)
     allow(view).to receive(:curation_concern).and_return(parent)

--- a/spec/views/hyrax/collections/_show_document_list.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_document_list.html.erb_spec.rb
@@ -11,14 +11,9 @@ describe 'hyrax/collections/_show_document_list.html.erb', type: :view do
 
   let(:documents) { [file] }
 
-  let(:blacklight_configuration_context) do
-    Blacklight::Configuration::Context.new(controller)
-  end
-
   context 'when not logged in' do
     before do
-      allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
-      allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
+      view.blacklight_config = Blacklight::Configuration.new
       allow(view).to receive(:current_user).and_return(nil)
       allow(file).to receive(:title_or_label).and_return("One Hundred Years of Solitude")
       allow(file).to receive(:edit_people).and_return([])

--- a/spec/views/hyrax/collections/_show_document_list_row.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_document_list_row.html.erb_spec.rb
@@ -10,14 +10,9 @@ describe 'hyrax/collections/_show_document_list_row.html.erb', type: :view do
 
   let(:collection) { mock_model(Collection, title: 'My awesome collection', members: [work]) }
 
-  let(:blacklight_configuration_context) do
-    Blacklight::Configuration::Context.new(controller)
-  end
-
   context 'when not logged in' do
     before do
-      allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
-      allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
+      view.blacklight_config = Blacklight::Configuration.new
       allow(view).to receive(:current_user).and_return(nil)
       allow(work).to receive(:title_or_label).and_return("One Hundred Years of Solitude")
       allow(work).to receive(:edit_people).and_return([])

--- a/spec/views/hyrax/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/show.html.erb_spec.rb
@@ -6,15 +6,9 @@ describe 'hyrax/collections/show.html.erb', type: :view do
   end
   let(:ability) { double }
   let(:presenter) { Hyrax::CollectionPresenter.new(document, ability) }
-  let(:blacklight_config) { CatalogController.blacklight_config }
-  let(:blacklight_configuration_context) do
-    Blacklight::Configuration::Context.new(controller)
-  end
 
   before do
     view.extend FileSetHelper
-    allow(view).to receive(:blacklight_config).and_return(blacklight_config)
-    allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
     allow(document).to receive(:hydra_model).and_return(::Collection)
     allow(controller).to receive(:current_user).and_return(stub_model(User))
     allow(view).to receive(:can?).with(:edit, document).and_return(true)

--- a/spec/views/hyrax/my/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/my/_list_collections.html.erb_spec.rb
@@ -11,15 +11,9 @@ describe 'hyrax/my/_index_partials/_list_collections.html.erb', type: :view do
 
   let(:doc) { SolrDocument.new(attributes) }
   let(:collection) { mock_model(Collection) }
-  let(:config) { My::WorksController.blacklight_config }
-  let(:blacklight_configuration_context) do
-    Blacklight::Configuration::Context.new(controller)
-  end
 
   before do
     allow(view).to receive(:current_user).and_return(stub_model(User))
-    allow(view).to receive(:blacklight_config) { config }
-    allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
     allow(doc).to receive(:to_model).and_return(stub_model(Collection, id: id))
     view.lookup_context.prefixes.push 'hyrax/my'
 

--- a/spec/views/hyrax/my/_list_works.html.erb_spec.rb
+++ b/spec/views/hyrax/my/_list_works.html.erb_spec.rb
@@ -10,18 +10,12 @@ describe 'hyrax/my/_index_partials/_list_works.html.erb', type: :view do
 
   let(:doc) { SolrDocument.new(work_data) }
   let(:collection) { mock_model(Collection) }
-  let(:config) { Hyrax::My::WorksController.blacklight_config }
   let(:presenter) { Hyrax::WorkShowPresenter.new(doc, nil) }
-  let(:blacklight_configuration_context) do
-    Blacklight::Configuration::Context.new(controller)
-  end
 
   before do
     allow(view).to receive(:current_user).and_return(stub_model(User))
     allow(view).to receive(:render_collection_links).with(doc).and_return("<a href=\"collection/1\">Collection Title</a>".html_safe)
     allow(view).to receive(:render_visibility_link).with(doc).and_return("<a class=\"visibility-link\">Private</a>".html_safe)
-    allow(view).to receive(:blacklight_config) { config }
-    allow(view).to receive(:blacklight_configuration_context).and_return(blacklight_configuration_context)
     stub_template 'hyrax/my/_index_partials/_work_action_menu.html.erb' => 'actions'
     render 'hyrax/my/_index_partials/list_works', document: doc, presenter: presenter
   end

--- a/spec/views/hyrax/users/index.html.erb_spec.rb
+++ b/spec/views/hyrax/users/index.html.erb_spec.rb
@@ -1,6 +1,5 @@
 describe 'hyrax/users/index.html.erb', type: :view do
   let(:join_date) { 5.days.ago }
-  let(:search_state) { double('SearchState', params_for_search: {}) }
   before do
     users = []
     (1..25).each { |i| users << stub_model(User, name: "name#{i}", user_key: "user#{i}", created_at: join_date) }
@@ -10,7 +9,6 @@ describe 'hyrax/users/index.html.erb', type: :view do
     allow(relation).to receive(:current_page).and_return(1)
     allow(relation).to receive(:total_pages).and_return(3)
     assign(:users, relation)
-    allow(view).to receive(:search_state).and_return(search_state)
   end
 
   it "draws user list" do


### PR DESCRIPTION
The override in the helper will not get called all the time, as the
helper is just delegating to the search state (see
https://github.com/projectblacklight/blacklight/blob/3c175c032652256ede44b0ec83b23040e78b09e6/app/helpers/blacklight/url_helper_behavior.rb#L10)

This is one aspect required for fixing https://github.com/projecthydra-labs/hyku/issues/584
