### PR TITLE
Adding link to referenced work in all workflow notifications

### DIFF
--- a/app/services/hyrax/workflow/abstract_notification.rb
+++ b/app/services/hyrax/workflow/abstract_notification.rb
@@ -1,6 +1,8 @@
 module Hyrax
   module Workflow
     class AbstractNotification
+      include ActionView::Helpers::UrlHelper
+
       def self.send_notification(entity:, comment:, user:, recipients:)
         new(entity, comment, user, recipients).call
       end
@@ -27,7 +29,7 @@ module Hyrax
         end
 
         def message
-          "#{title} (#{work_id}) was advanced in the workflow by #{user.user_key} and is awaiting approval #{comment}"
+          "#{title} (#{link_to work_id, document_path}) was advanced in the workflow by #{user.user_key} and is awaiting approval #{comment}"
         end
 
         # @return [ActiveFedora::Base] the document (work) the the Abstract WorkFlow is creating a notification for

--- a/app/services/hyrax/workflow/changes_required_notification.rb
+++ b/app/services/hyrax/workflow/changes_required_notification.rb
@@ -1,8 +1,6 @@
 module Hyrax
   module Workflow
     class ChangesRequiredNotification < AbstractNotification
-      include ActionView::Helpers::UrlHelper
-
       protected
 
         def subject

--- a/app/services/hyrax/workflow/complete_notification.rb
+++ b/app/services/hyrax/workflow/complete_notification.rb
@@ -8,7 +8,7 @@ module Hyrax
         end
 
         def message
-          "#{title} (#{work_id}) was approved by #{user.user_key}. #{comment}"
+          "#{title} (#{link_to work_id, document_path}) was approved by #{user.user_key}. #{comment}"
         end
 
       private

--- a/app/services/hyrax/workflow/pending_review_notification.rb
+++ b/app/services/hyrax/workflow/pending_review_notification.rb
@@ -8,7 +8,7 @@ module Hyrax
         end
 
         def message
-          "#{title} (#{work_id}) was deposited by #{user.user_key} and is awaiting approval #{comment}"
+          "#{title} (#{link_to work_id, document_path}) was deposited by #{user.user_key} and is awaiting approval #{comment}"
         end
 
       private

--- a/spec/services/hyrax/workflow/complete_notification_spec.rb
+++ b/spec/services/hyrax/workflow/complete_notification_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hyrax::Workflow::CompleteNotification do
 
   describe ".send_notification" do
     it 'sends a message to all users' do
-      expect(approver).to receive(:send_message).once.and_call_original
+      expect(approver).to receive(:send_message).with(anything, "Test title (<a href=\"/concern/generic_works/#{work.id}\">#{work.id}</a>) was approved by #{approver.user_key}. A pleasant read", anything).once.and_call_original
 
       expect { described_class.send_notification(entity: entity, user: approver, comment: comment, recipients: recipients) }
         .to change { depositor.mailbox.inbox.count }.by(1)

--- a/spec/services/hyrax/workflow/pending_review_notification_spec.rb
+++ b/spec/services/hyrax/workflow/pending_review_notification_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::Workflow::PendingReviewNotification do
 
   describe ".send_notification" do
     it 'sends a message to all users except depositor' do
-      expect(depositor).to receive(:send_message).once.and_call_original
+      expect(depositor).to receive(:send_message).with(anything, "Test title (<a href=\"/concern/generic_works/#{work.id}\">#{work.id}</a>) was deposited by #{depositor.user_key} and is awaiting approval A pleasant read", anything).once.and_call_original
 
       expect { described_class.send_notification(entity: entity, user: depositor, comment: comment, recipients: recipients) }
         .to change { depositor.mailbox.inbox.count }.by(1)


### PR DESCRIPTION
Fixes #216 

Adds a link to the workflow notifications instead of just the work id.

![screen shot 2017-01-09 at 1 25 37 pm](https://cloud.githubusercontent.com/assets/1599081/21777923/27a6e47e-d66f-11e6-921f-ef0919d40108.png)


@projecthydra-labs/hyrax-code-reviewers
