### PR TITLE
Adding no_state_change action to default workflow

### DIFF
--- a/lib/generators/hyrax/templates/mediated_deposit_workflow.json.erb
+++ b/lib/generators/hyrax/templates/mediated_deposit_workflow.json.erb
@@ -58,6 +58,12 @@
                             "to": ["approving"]
                         }
                     ]
+                }, {
+                    "name": "no_state_change",
+                    "from_states": [
+                        { "names": ["pending_review", "deposited"], "roles": ["approving"] },
+                        { "names": ["changes_required"], "roles": ["depositing"] }
+                    ]
                 }
             ]
         }

--- a/spec/features/workflow_state_changes_spec.rb
+++ b/spec/features/workflow_state_changes_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.describe "Workflow state changes", type: :feature do
+  let(:workflow_name) { 'with_comment' }
+  let(:approving_user) { create(:user) }
+  let(:depositing_user) { create(:user) }
+  let(:admin_set) { create(:admin_set, edit_users: [depositing_user.user_key]) }
+  let(:one_step_workflow) do
+    {
+      workflows: [
+        {
+          name: workflow_name,
+          label: "One-step mediated deposit workflow",
+          description: "A single-step workflow for mediated deposit",
+          actions: [
+            {
+              name: "deposit", from_states: [], transition_to: "pending_review"
+            }, {
+              name: "approve", from_states: [{ names: ["pending_review"], roles: ["approving"] }],
+              transition_to: "deposited",
+              methods: ["Hyrax::Workflow::ActivateObject"]
+            }, {
+              name: "leave_a_comment", from_states: [{ names: ["pending_review"], roles: ["approving"] }]
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+  let(:workflow) { Sipity::Workflow.find_by_name(workflow_name) }
+  let(:work) { create(:work, user: depositing_user, admin_set: admin_set) }
+  let(:workflow_strategy) { double(workflow_name: workflow.name) }
+  before do
+    allow(RoleMapper).to receive(:byname).and_return(depositing_user.user_key => ['admin'], approving_user.user_key => ['admin'])
+    Hyrax::Workflow::WorkflowImporter.new(data: one_step_workflow.as_json).call
+    Hyrax::Workflow::PermissionGenerator.call(roles: 'approving', workflow: workflow, agents: approving_user)
+    # Need to instantiate the Sipity::Entity for the given work. This is necessary as I'm not creating the work via the UI.
+    Hyrax::Workflow::WorkflowFactory.create(work, {}, depositing_user, workflow_strategy)
+  end
+
+  describe 'leaving a comment for non-state changing' do
+    it 'will not advance the state' do
+      login_as(approving_user, scope: :user)
+      visit hyrax_generic_work_path(work)
+
+      expect do
+        the_comment = 'I am leaving a great comment. A bigly comment. The best comment.'
+        page.choose('workflow_action[name]', option: 'leave_a_comment')
+
+        page.within('.workflow-comments') do
+          page.fill_in('workflow_action_comment', with: the_comment)
+          page.click_on('Submit')
+        end
+        expect(page).to have_content(the_comment)
+      end.not_to change { work.to_sipity_entity.reload.workflow_state_name }
+    end
+  end
+end


### PR DESCRIPTION
For states in which the role can make a state change, add a new action
that allows is non-state changing.

Closes #244
