### PR TITLE
Updating workflow load to delete removed states and actions.

### DIFF
--- a/app/models/sipity/workflow_state.rb
+++ b/app/models/sipity/workflow_state.rb
@@ -15,8 +15,8 @@ module Sipity
              class_name: 'Sipity::WorkflowAction',
              foreign_key: :resulting_workflow_state_id
 
-    # TODO: What should be done with entities in the given state if the WorkflowState is destroyed?
-    has_many :entities, class_name: 'Sipity::Entity'
+    # It is not acceptable to delete a WorkflowState if there are associated entities.
+    has_many :entities, class_name: 'Sipity::Entity', dependent: :restrict_with_exception
 
     has_many :notifiable_contexts,
              dependent: :destroy,

--- a/app/services/hyrax/workflow/invalid_state_removal_exception.rb
+++ b/app/services/hyrax/workflow/invalid_state_removal_exception.rb
@@ -1,11 +1,10 @@
 module Hyrax
   module Workflow
     class InvalidStateRemovalException < ::RuntimeError
-      attr_reader :state
-
-      def initialize(message, state)
+      attr_reader :states
+      def initialize(message, states)
         super(message)
-        @state = state
+        @states = states
       end
     end
   end

--- a/app/services/hyrax/workflow/invalid_state_removal_exception.rb
+++ b/app/services/hyrax/workflow/invalid_state_removal_exception.rb
@@ -1,0 +1,12 @@
+module Hyrax
+  module Workflow
+    class InvalidStateRemovalException < ::RuntimeError
+      attr_reader :state
+
+      def initialize(message, state)
+        super(message)
+        @state = state
+      end
+    end
+  end
+end

--- a/app/services/hyrax/workflow/sipity_actions_generator.rb
+++ b/app/services/hyrax/workflow/sipity_actions_generator.rb
@@ -9,6 +9,7 @@ module Hyrax
       # @param workflow [Sipity::Workflow]
       # @param actions_configuration [Hash] as defined in Hyrax::Workflow::WorkflowSchema
       # @return [Sipity::Workflow]
+      # @raise [Hyrax::Workflow::InvalidStateRemovalException] Trying to remove a state that is in use
       def self.call(**keywords, &block)
         new(**keywords, &block).call
       end
@@ -30,7 +31,8 @@ module Hyrax
 
       public
 
-      # @raises [Hyrax::Workflow::InvalidStateRemovalException] Trying to remove a state that is in use
+      # @return [Sipity::Workflow]
+      # @raise [Hyrax::Workflow::InvalidStateRemovalException] Trying to remove a state that is in use
       def call
         generate_state_diagram!
         workflow
@@ -40,10 +42,10 @@ module Hyrax
 
         def generate_state_diagram!
           # look for old states that need to be removed and validate the states can be removed.
-          removed_states = validate_states_to_be_removed
+          unused_states_to_remove = validate_states_to_be_removed
 
           # remove any actions that will no longer be needed by the workflow
-          remove_unused_actions
+          remove_unused_actions!
 
           actions_configuration.each do |configuration|
             Array.wrap(configuration.fetch(:name)).each do |name|
@@ -54,24 +56,31 @@ module Hyrax
           # remove any states that are no longer needed by the workflow
           #  Note I am doing this after the update so nothing is still linking to the
           #       state to keep it from being deleted.
-          removed_states.each(&:delete)
+          unused_states_to_remove.each(&:destroy)
         end
 
         def validate_states_to_be_removed
-          new_states = actions_configuration.map { |a| a[:transition_to] }
-          removed_states = workflow.workflow_states.reject { |state| new_states.include?(state.name) }
-          removed_states.each do |state|
-            # a state  must have been removed, we should remove it only if there is not entities currently in that state
-            raise InvalidStateRemovalException.new("can not delete a state with entites", state) if state.entities.count > 0
+          new_state_names = actions_configuration.map { |a| a[:transition_to] }.flatten
+          states_to_remove = []
+          states_that_cannot_be_destroyed = []
+          workflow.workflow_states.each do |state|
+            next if new_state_names.include?(state.name)
+            states_to_remove << state
+            states_that_cannot_be_destroyed << state if state.entities.count > 0 # Choosing count so we pre-warm the query
           end
-          removed_states
+          if states_that_cannot_be_destroyed.any?
+            exception_message = "Cannot delete one or more states because they have one or more entities associated with them."
+            raise InvalidStateRemovalException.new(exception_message, states_that_cannot_be_destroyed)
+          end
+          states_to_remove
         end
 
-        def remove_unused_actions
+        def remove_unused_actions!
           # clear any actions from the workflow that do not exists in the new configuration
-          new_actions = actions_configuration.map { |a| a[:name] }
-          remove_actions = workflow.workflow_actions.reject { |action| new_actions.include?(action.name) }
-          remove_actions.each(&:delete)
+          new_action_names = actions_configuration.map { |a| a[:name] }.flatten
+          workflow.workflow_actions.each do |workflow_action|
+            workflow_action.destroy unless new_action_names.include?(workflow_action.name)
+          end
         end
     end
   end

--- a/app/services/hyrax/workflow/sipity_actions_generator.rb
+++ b/app/services/hyrax/workflow/sipity_actions_generator.rb
@@ -30,6 +30,7 @@ module Hyrax
 
       public
 
+      # @raises [Hyrax::Workflow::InvalidStateRemovalException] Trying to remove a state that is in use
       def call
         generate_state_diagram!
         workflow
@@ -38,11 +39,39 @@ module Hyrax
       private
 
         def generate_state_diagram!
+          # look for old states that need to be removed and validate the states can be removed.
+          removed_states = validate_states_to_be_removed
+
+          # remove any actions that will no longer be needed by the workflow
+          remove_unused_actions
+
           actions_configuration.each do |configuration|
             Array.wrap(configuration.fetch(:name)).each do |name|
               StateMachineGenerator.generate_from_schema(workflow: workflow, name: name, **configuration.except(:name))
             end
           end
+
+          # remove any states that are no longer needed by the workflow
+          #  Note I am doing this after the update so nothing is still linking to the
+          #       state to keep it from being deleted.
+          removed_states.each(&:delete)
+        end
+
+        def validate_states_to_be_removed
+          new_states = actions_configuration.map { |a| a[:transition_to] }
+          removed_states = workflow.workflow_states.reject { |state| new_states.include?(state.name) }
+          removed_states.each do |state|
+            # a state  must have been removed, we should remove it only if there is not entities currently in that state
+            raise InvalidStateRemovalException.new("can not delete a state with entites", state) if state.entities.count > 0
+          end
+          removed_states
+        end
+
+        def remove_unused_actions
+          # clear any actions from the workflow that do not exists in the new configuration
+          new_actions = actions_configuration.map { |a| a[:name] }
+          remove_actions = workflow.workflow_actions.reject { |action| new_actions.include?(action.name) }
+          remove_actions.each(&:delete)
         end
     end
   end

--- a/app/services/hyrax/workflow/workflow_importer.rb
+++ b/app/services/hyrax/workflow/workflow_importer.rb
@@ -38,12 +38,20 @@ module Hyrax
       def self.generate_from_json_file(path:, **keywords)
         contents = path.respond_to?(:read) ? path.read : File.read(path)
         data = JSON.parse(contents)
+        generate_from_hash(data: data, **keywords)
+      end
+
+      # @api public
+      #
+      # Responsible for generating the work type and corresponding processing entries based on given pathname or JSON document.
+      #
+      # @return [Array<Sipity::Workflow>]
+      def self.generate_from_hash(data:, **keywords)
         importer = new(data: data, **keywords)
-        workflow = importer.call
+        workflows = importer.call
         self.load_errors ||= []
         load_errors.concat(importer.errors)
-
-        workflow
+        workflows
       end
 
       # @param data [#deep_symbolize_keys] the configuration information from which we will generate all the data entries

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -595,7 +595,7 @@ en:
         deposit: "Deposit"
       unauthorized: "The work is not currently available because it has not yet completed the approval process"
       load:
-        state_error: "The workflow: %{workflow_name} has not been updated.  You are removing a state: %{state_name} with %{entity_count} entitie(s).  A state may not be removed while it has active enities!"
+        state_error: "The workflow: %{workflow_name} has not been updated.  You are removing a state: %{state_name} with %{entity_count} entity/ies.  A state may not be removed while it has active entities!"
     works:
       new:
         header: "Add New %{type}"

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -594,6 +594,8 @@ en:
       default:
         deposit: "Deposit"
       unauthorized: "The work is not currently available because it has not yet completed the approval process"
+      load:
+        state_error: "The workflow: %{workflow_name} has not been updated.  You are removing a state: %{state_name} with %{entity_count} entitie(s).  A state may not be removed while it has active enities!"
     works:
       new:
         header: "Add New %{type}"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -614,7 +614,7 @@ es:
       default:
         deposit: "Depositar"
       load:
-        state_error: "El flujo de trabajo por %{workflow_name} no se ha actualizado.  Estás eliminando un estado: %{state_name} con %{entity_count} entitie(s).  ¡Un estado no puede ser removido mientras tiene enidades activas!"
+        state_error: "El flujo de trabajo por %{workflow_name} no se ha actualizado.  Estás eliminando un estado: %{state_name} con %{entity_count} enidades.  ¡Un estado no puede ser removido mientras tiene enidades activas!"
     works:
       edit:
         additional_fields: "Campos adicionales"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -613,6 +613,8 @@ es:
     workflow:
       default:
         deposit: "Depositar"
+      load:
+        state_error: "El flujo de trabajo por %{workflow_name} no se ha actualizado.  Estás eliminando un estado: %{state_name} con %{entity_count} entitie(s).  ¡Un estado no puede ser removido mientras tiene enidades activas!"
     works:
       edit:
         additional_fields: "Campos adicionales"

--- a/lib/tasks/workflow.rake
+++ b/lib/tasks/workflow.rake
@@ -3,6 +3,8 @@ namespace :hyrax do
     desc "Load workflow configuration into the database"
     task load: :environment do
       Hyrax::Workflow::WorkflowImporter.load_workflows
+      errors = Hyrax::Workflow::WorkflowImporter.load_errors
+      abort("Failed to process all workflows:\n  #{errors.join('\n  ')}") unless errors.empty?
     end
   end
 end

--- a/spec/services/hyrax/workflow/workflow_importer_spec.rb
+++ b/spec/services/hyrax/workflow/workflow_importer_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe Hyrax::Workflow::WorkflowImporter do
   end
 
   context 'data generation' do
+    before do
+      described_class.clear_load_errors
+    end
+
     it 'creates the requisite data from the configuration' do
       expect(Hyrax::Workflow::WorkflowPermissionsGenerator).to receive(:call).and_call_original
       expect(Hyrax::Workflow::SipityActionsGenerator).to receive(:call).and_call_original
@@ -49,8 +53,67 @@ RSpec.describe Hyrax::Workflow::WorkflowImporter do
         result = described_class.generate_from_json_file(path: path)
       end.to change { Sipity::Workflow.count }.by(1)
       expect(result).to match_array(kind_of(Sipity::Workflow))
+      expect(described_class.load_errors).to be_empty
       expect(result.first.label).to eq "This is the label"
       expect(result.first.description).to eq "This description could get really long"
+    end
+  end
+  context "when I load twice" do
+    let!(:workflow1) { described_class.generate_from_json_file(path: path)[0] }
+    let(:workflow2) { described_class.generate_from_json_file(path: path)[0] }
+    let(:workflow2_errors) { described_class.load_errors }
+    it "creates the same results" do
+      expect(workflow2).to eq(workflow1)
+      expect(workflow2_errors).to be_empty
+    end
+    context "When the json changes" do
+      let(:workflow_name) { "awsome workflow" }
+      let(:action_name)  { "awesome action" }
+      let(:state_name)   { "awesome state" }
+      let(:second_path) { double(read: json2) }
+      let(:workflow2) { described_class.generate_from_json_file(path: second_path)[0] }
+      let(:json2) do
+        doc = <<-HERE
+        {
+          "workflows": [
+            {
+              "name": "#{workflow_name}",
+              "label": "This is the label for the second json",
+              "description": "This description could get really long",
+              "actions": [{
+                "name": "#{action_name}",
+                "transition_to": "#{state_name}",
+                "from_states": [{ "names": ["under_review"], "roles": ["ulra_reviewing"] }]
+              }]
+            }
+          ]
+        }
+        HERE
+        doc.strip
+      end
+      it "creates another workflow" do
+        expect(workflow2).not_to eq(workflow1)
+        expect(Sipity::Workflow.count).to eq(2)
+        expect(workflow2_errors).to be_empty
+      end
+      context "when the workflow name stays the same" do
+        let(:workflow_name) { "ulra_submission" }
+        it "modifies the same workflow" do
+          expect(workflow2.label).not_to eq(workflow1.label)
+          expect(Sipity::Workflow.count).to eq(1)
+          expect(workflow2_errors).to be_empty
+          expect(Sipity::WorkflowAction.count).to eq(1)
+          expect(Sipity::WorkflowState.count).to eq(1)
+        end
+        context "when entites are in the state" do
+          let!(:entity) { Sipity::Entity.create(workflow_state: workflow1.reload.workflow_states[0], proxy_for_global_id: "abc123", workflow_id: workflow1.id) }
+          it "can not modify the same workflow" do
+            expect(workflow2.label).to eq(workflow1.label)
+            expect(Sipity::Workflow.count).to eq(1)
+            expect(workflow2_errors).to eq(["The workflow: ulra_submission has not been updated.  You are removing a state: reviewed with 1 entitie(s).  A state may not be removed while it has active enities!"])
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
 Also to error if a state has active entities and is being deleted.

Fixes #171

This PR does two things: remove unused actions and remove unused states.  It stemmed from not wanting to update a workflow and remove a state if it had any items currently in that state.  While looking into that problem I realized load was only additive and old actions and old states just remained after a load.

The deletion code for the states is what actually solves #171.  Before a workflow is updated the states that the workflow transition to are checked against the new configuration transition to.  If any transition to state is removed from the new configuration the state.entities.count is checked to make sure there are no active entities in the state. 

If there are any spanish speaking code reviewers that can check my es translation.  I just depended on google translate.  I was guessing it was better to have bad spanish than no spanish, but correct me if we do not want to take that stance.

@projecthydra-labs/hyrax-code-reviewers
