### PR TITLE
Admin Set Permissions Notifications & Routing

### DIFF
--- a/app/controllers/hyrax/admin/permission_templates_controller.rb
+++ b/app/controllers/hyrax/admin/permission_templates_controller.rb
@@ -6,8 +6,9 @@ module Hyrax
       def update
         authorize! :update, @permission_template
         Forms::PermissionTemplateForm.new(@permission_template).update(update_params)
-        # Ensure we redirect to currently active tab
-        redirect_to hyrax.edit_admin_admin_set_path(params[:admin_set_id], anchor: current_tab), notice: "Permissions updated"
+        # Ensure we redirect to currently active tab with the appropriate notice
+        current_tab = current_tab_selector
+        redirect_to hyrax.edit_admin_admin_set_path(params[:admin_set_id], anchor: current_tab), notice: I18n.t(current_tab, scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
       end
 
       private
@@ -23,7 +24,7 @@ module Hyrax
                         access_grants_attributes: [:access, :agent_id, :agent_type, :id])
         end
 
-        def current_tab
+        def current_tab_selector
           return 'participants' if params[:permission_template][:access_grants_attributes].present?
           return 'workflow' if params[:permission_template][:workflow_name].present?
           'visibility'

--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -1,6 +1,14 @@
 module Hyrax
   # Creates AdminSets
   class AdminSetCreateService
+    # Creates an admin set, setting the creator and the default access controls.
+    # @param admin_set [AdminSet] the admin set to operate on
+    # @param creating_user [User] the user who created the admin set.
+    # @return [TrueClass, FalseClass] true if it was successful
+    def self.call(admin_set, creating_user)
+      new(admin_set, creating_user).create
+    end
+
     # @param admin_set [AdminSet] the admin set to operate on
     # @param creating_user [User] the user who created the admin set.
     def initialize(admin_set, creating_user)

--- a/app/views/hyrax/admin/admin_sets/_form_workflow.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_workflow.erb
@@ -3,18 +3,23 @@
                     <%= simple_form_for @form.permission_template,
                       url: [hyrax, :admin, @form, :permission_template],
                       html: { id: 'form_workflows' } do |f| %>
-                      <div class="panel-body">
-
-                      <p><%= t('.page_description') %></p>
-                        <%= f.collection_radio_buttons :workflow_name, f.object.workflows, :name, :label, item_wrapper_tag: :div, item_wrapper_class: "radio" do |b| %>
-                          <span><%= b.radio_button + b.object.label %></span>
-                          <p><%= b.object.description %></p>
-                        <% end %>
-                      </div>
-                      <div class="panel-footer">
-                        <%= link_to t('.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
-                        <%= f.button :submit, class: 'btn btn-primary pull-right'%>
-                      </div>
+                      <% if f.object.workflows.any? %>
+                        <div class="panel-body">
+                          <p><%= t('.page_description') %></p>
+                              <%= f.collection_radio_buttons :workflow_name, f.object.workflows, :name, :label, item_wrapper_tag: :div, item_wrapper_class: "radio" do |b| %>
+                                <span><%= b.radio_button + b.object.label %></span>
+                                <p><%= b.object.description %></p>
+                              <% end %>
+                        </div>
+                        <div class="panel-footer">
+                          <%= link_to t('.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
+                          <%= f.button :submit, class: 'btn btn-primary pull-right'%>
+                        </div>
+                      <% else %>
+                        <div class="panel-body">
+                          <p><%= t('.no_workflows') %></p>
+                        </div>
+                      <% end %>
                     <% end %>
                   </div>
                 </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -15,7 +15,12 @@ en:
             participants:       "Participants"
             visibility:         "Release and Visibility"
             workflow:           "Workflow"
-          cancel:               "Cancel"  
+          cancel:               "Cancel"
+          permission_update_notices:
+            new_admin_set:      "The administrative set '%{name}' has been created. Use the additional tabs to define other aspects of the administrative set."
+            visibility:         "The administrative set's visibilty settings have been updated."
+            workflow:           "The administrative set's workflow has been updated."
+            participants:       "The administrative set's participant rights have been updated"
         form_participants:
           add_group:            "Add group:"
           add_user:             "Add user:"
@@ -69,6 +74,7 @@ en:
           cancel:               "Cancel"
         form_workflow:
           page_description:     "Each administrative set has a workflow associated with it. This workflow is applied to all works added to the administrative set. Select the workflow to be used for this administrative set below."
+          no_workflows:         "There are no workflows to select."
           cancel:               "Cancel"
         show:
           header:           "Administrative Set"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -38,6 +38,11 @@ es:
             visibility:         "Lanzamiento y Visibilidad"
             workflow:           "Flujo de trabajo"
           cancel:               "Cancelar"
+          permission_update_notices:
+            new_admin_set:      "Se ha creado el conjunto administrativo '%{name}'. Utilice las pestañas adicionales para definir otros aspectos del conjunto administrativo."
+            visibility:         "La configuración de visibilidad del conjunto administrativo se ha actualizado."
+            workflow:           "El flujo de trabajo del conjunto administrativo se ha actualizado."
+            participants:       "Se han actualizado los derechos de participante del conjunto administrativo"
         form_participant_table:
           depositors:
             action:             "Acción"
@@ -89,8 +94,9 @@ es:
             restricted:         "Restringido -- todos los trabajos sólo serán visibles para los administradores y gestores de repositorios y los revisores de este conjunto administrativo"
             title:              "Visibilidad"
             varies:             "Varía -- por defecto es público, pero los depositantes pueden restringir la visibilidad de las obras individuales"
-        form_workflow: # TODO: verify text; added via google translate
+        form_workflow:
           page_description:     "Cada conjunto administrativo tiene un flujo de trabajo asociado con él. Este flujo de trabajo se aplica a todos los trabajos agregados al conjunto administrativo. Seleccione el flujo de trabajo que se utilizará para este conjunto de administración a continuación."
+          no_workflows:   "No hay flujos de trabajo que seleccionar."
           cancel:         "Cancelar"
         new:
           header:         "Crear nuevo conjunto Administrativo"

--- a/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
@@ -56,26 +56,29 @@ describe Hyrax::Admin::AdminSetsController do
     end
 
     describe "#create" do
-      let(:service) { instance_double(Hyrax::AdminSetCreateService) }
       before do
-        allow(Hyrax::AdminSetCreateService).to receive(:new)
-          .with(AdminSet, user)
-          .and_return(service)
+        controller.admin_set_create_service = service
       end
 
       context "when it's successful" do
+        let(:service) do
+          lambda do |admin_set, _|
+            admin_set.id = 123
+            true
+          end
+        end
         it 'creates file sets' do
-          expect(service).to receive(:create).and_return(true)
           post :create, params: { admin_set: { title: 'Test title',
                                                description: 'test description',
                                                workflow_name: 'default' } }
-          expect(response).to be_redirect
+          admin_set = assigns(:admin_set)
+          expect(response).to redirect_to(edit_admin_admin_set_path(admin_set))
         end
       end
 
       context "when it fails" do
+        let(:service) { ->(_, _) { false } }
         it 'shows the new form' do
-          expect(service).to receive(:create).and_return(false)
           post :create, params: { admin_set: { title: 'Test title',
                                                description: 'test description' } }
           expect(response).to render_template 'new'

--- a/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplatesController do
         expect(form).to receive(:update).with(ActionController::Parameters.new(form_attributes).permit!)
         put :update, params: input_params
         expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(admin_set, locale: 'en', anchor: 'participants'))
-        expect(flash[:notice]).to eq 'Permissions updated'
+        expect(flash[:notice]).to eq "The administrative set's participant rights have been updated"
       end
     end
   end

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -5,6 +5,15 @@ RSpec.describe Hyrax::AdminSetCreateService do
   let(:service) { described_class.new(admin_set, user) }
   let(:user) { create(:user) }
 
+  describe ".call" do
+    it "is a convenience method for .new#create" do
+      service = instance_double(described_class)
+      expect(described_class).to receive(:new).and_return(service)
+      expect(service).to receive(:create)
+      described_class.call(admin_set, user)
+    end
+  end
+
   describe "#create" do
     subject { service.create }
 


### PR DESCRIPTION
* Resolves https://github.com/projecthydra-labs/hyrax/issues/202 - Flash notices were not appearing after permission updates due to an issue with the inheritance from collections. This patch skips the before_action that was overriding the flash notices. (Ideally admin sets should be separated from collections, but this change allows us to move forward for now. See notes on the issue for more information.)
* Resolves https://github.com/projecthydra-labs/hyrax/issues/204 - After creating a new administrative set, this reroutes directly to the Edit Administrative Set form so the remaining permissions can be modified and the workflow assigned as necessary.
* Adds a new flash message after the admin set is added as part of the routing to the edit page.
* Changes the flash messages for each of the various permissions template changes to situationally appropriate messages rather than simply stating "Permissions updated".
* Adds Spanish translations for each of the above flash messages.
* Creates call method for AdminSetCreateService to aid in writing the specs for the admin set routing change. This helps bypass a bug where a permission template could be created without an admin set id. New issue created for this bug: https://github.com/projecthydra-labs/hyrax/issues/265

@projecthydra-labs/hyrax-code-reviewers
