### PR TITLE
Removing some rubocop todos

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,15 +16,6 @@ Metrics/BlockLength:
     - 'lib/hyrax/rails/routes.rb'
     - 'spec/**/*'
 
-Metrics/CyclomaticComplexity:
-  Exclude:
-    - 'app/services/hyrax/file_set_audit_service.rb'
-    - 'lib/hyrax/arkivo/metadata_munger.rb'
-
-Metrics/PerceivedComplexity:
-  Exclude:
-    - 'app/services/hyrax/file_set_audit_service.rb'
-
 Metrics/ClassLength:
   Exclude:
     - 'app/presenters/hyrax/work_show_presenter.rb'
@@ -44,7 +35,6 @@ Metrics/AbcSize:
     - 'app/indexers/hyrax/file_set_indexer.rb'
     - 'app/services/hyrax/user_stat_importer.rb'
     - 'app/services/hyrax/workflow/permission_query.rb'
-    - 'lib/hyrax/arkivo/metadata_munger.rb'
 
 Metrics/ModuleLength:
   Exclude:
@@ -72,7 +62,6 @@ Metrics/MethodLength:
     - 'app/services/hyrax/workflow/permission_query.rb'
     - 'lib/generators/hyrax/templates/migrations/create_local_authorities.rb'
     - 'lib/generators/hyrax/install_generator.rb'
-    - 'lib/hyrax/arkivo/metadata_munger.rb'
     - 'lib/hyrax/configuration.rb'
     - 'lib/hyrax/rails/routes.rb'
     - 'spec/support/**/*'

--- a/app/services/hyrax/file_set_audit_service.rb
+++ b/app/services/hyrax/file_set_audit_service.rb
@@ -71,6 +71,10 @@ module Hyrax
         audit_results = audit_file(file).collect { |result| result['pass'] }
         # check how many non runs we had
         non_runs = audit_results.reduce(0) { |sum, value| value == NO_RUNS ? sum + 1 : sum }
+        build_audit_stat_message(audit_results, non_runs)
+      end
+
+      def build_audit_stat_message(audit_results, non_runs)
         if non_runs.zero?
           result = audit_results.reduce(true) { |sum, value| sum && value }
           stat_to_string(result)
@@ -81,6 +85,7 @@ module Hyrax
           'Audits have not yet been run on this file.'
         end
       end
+      private :build_audit_stat_message
 
       # Retrieve or generate the audit check for a specific version of a file
       # @param [String] file_id used to find the file within its parent object (usually "original_file")


### PR DESCRIPTION
## Cleaning up CyclomaticComplexity for Audit

## Refactoring MetadataMunger to remove cop warnings

In this refactoring:

* Removing the Metrics/CyclomaticComplexity exclusion
* Removing the Metrics/ModuleLength exclusion
* Removing the Metrics/PerceivedComplexity exclusion
* Removing extra processing loops

This should improve the readability of what this class is doing
