### PR TITLE
Adding support for i18n-debug

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -79,5 +79,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'shoulda-matchers', '~> 3.1'
   spec.add_development_dependency 'rails-controller-testing', '~> 0'
   spec.add_development_dependency 'webmock'
-  spec.add_development_dependency 'i18n-debug'
+  spec.add_development_dependency 'i18n-debug' unless ENV['TRAVIS']
 end

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -79,4 +79,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'shoulda-matchers', '~> 3.1'
   spec.add_development_dependency 'rails-controller-testing', '~> 0'
   spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'i18n-debug'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,7 @@ require 'support/speedup'
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
 
+require 'i18n/debug' unless ENV['TRAVIS']
 require 'byebug' unless ENV['TRAVIS']
 
 Capybara.default_driver = :rack_test      # This is a faster driver

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,7 +51,7 @@ require 'support/speedup'
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
 
-require 'i18n/debug' unless ENV['TRAVIS']
+require 'i18n/debug' if ENV['I18N_DEBUG']
 require 'byebug' unless ENV['TRAVIS']
 
 Capybara.default_driver = :rack_test      # This is a faster driver
@@ -80,7 +80,7 @@ ActiveJob::Base.queue_adapter = :inline
 # HttpLogger.ignore = [/localhost:8983\/solr/]
 # HttpLogger.colorize = false
 
-if ENV['TRAVIS'] == 'true'
+if ENV['TRAVIS']
   # Monkey-patches the FITS runner to return the PDF FITS fixture
   module Hydra::Works
     class CharacterizationService


### PR DESCRIPTION
See https://github.com/fphilipe/i18n-debug. We may need to observe if
this adds any significant time to builds.

Below is example output that is written to
`.internal_test_app/log/test.log`:

```console
[i18n-debug] en.simple_form.labels.file_set.files => nil
[i18n-debug] en.simple_form.labels.file_set.files => nil
[i18n-debug] en.simple_form.labels.defaults.files => "Upload a file"
[i18n-debug] en.simple_form.required.text => "required"
[i18n-debug] en.simple_form.required.mark => "*"
[i18n-debug] en.simple_form.required.html => "<span class=\"label label-info required-tag\">required</span>"
[i18n-debug] en.simple_form.hints.file_set.files => nil
[i18n-debug] en.simple_form.hints.file_set.files => nil
[i18n-debug] en.simple_form.hints.defaults.files => nil
[i18n-debug] en.simple_form.hints.defaults.files => nil
[i18n-debug] en.simple_form.hints.file_set.files => nil
[i18n-debug] en.simple_form.hints.file_set.files => nil
[i18n-debug] en.simple_form.hints.defaults.files => nil
[i18n-debug] en.simple_form.hints.defaults.files => nil
[i18n-debug] en.activemodel.models.file_set => nil
[i18n-debug] en.activemodel.models.active_fedora/base => nil
[i18n-debug] en.helpers.submit.file_set.update => nil
[i18n-debug] en.helpers.submit.update => "Save"
```

While the specs are running, I was running the following command to see
what translation keys was hit or missed:

```console
tail -f .internal_test_app/log/test.log
```

@projecthydra-labs/hyrax-code-reviewers
