### PR TITLE
Move admin set relationship

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,6 +1,5 @@
 <%= presenter.attribute_to_html(:creator, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:admin_set, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted) %>

--- a/app/views/hyrax/base/_relationships_parent_rows.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_rows.html.erb
@@ -21,3 +21,5 @@
     <% end %>
   <% end %>
 <% end %>
+
+<%= presenter.attribute_to_html(:admin_set, render_as: :faceted) %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -677,6 +677,7 @@ en:
     search:
       fields:
         show:
+          admin_set: "In Admin Set:"
           based_near: Location
           contributor: Contributors
           keyword: Keyword

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -3,9 +3,11 @@ es:
     search:
       fields:
         show:
+          admin_set: "En Conjunto Administrativo:"
           based_near: "Ubicación"
           contributor: "Colaboradores"
           keyword: "Palabra Clave"
+
   helpers:
     action:
       admin_set:

--- a/spec/views/hyrax/base/_relationships.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_relationships.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'hyrax/base/relationships', type: :view do
   let(:ability) { double }
-  let(:solr_doc) { instance_double(SolrDocument, id: '123', human_readable_type: 'Work') }
+  let(:solr_doc) { instance_double(SolrDocument, id: '123', human_readable_type: 'Work', admin_set: nil) }
   let(:presenter) { Hyrax::WorkShowPresenter.new(solr_doc, ability) }
   let(:generic_work) do
     Hyrax::WorkShowPresenter.new(
@@ -105,6 +105,14 @@ describe 'hyrax/base/relationships', type: :view do
     it "does not show the empty messages" do
       expect(page).not_to have_content "There are no Collection relationships."
       expect(page).not_to have_content "There are no Generic work relationships."
+    end
+  end
+
+  context "admin sets" do
+    it "will render through the attribute_to_html" do
+      allow(solr_doc).to receive(:member_of_collection_ids).and_return([])
+      expect(presenter).to receive(:attribute_to_html).with(:admin_set, render_as: :faceted)
+      render 'hyrax/base/relationships', presenter: presenter
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/projecthydra-labs/hyrax/issues/235
Moves the admin set from the descriptions section to the
relationships section of the show work page.

@projecthydra-labs/hyrax-code-reviewers
