### PR TITLE
Addressing rubocop todo

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -30,7 +30,6 @@ Metrics/ParameterLists:
 
 Metrics/AbcSize:
   Exclude:
-    - 'app/controllers/concerns/hyrax/admin/depositor_stats.rb'
     - 'app/controllers/concerns/hyrax/my_controller_behavior.rb'
     - 'app/indexers/hyrax/file_set_indexer.rb'
     - 'app/services/hyrax/user_stat_importer.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -31,7 +31,6 @@ Metrics/ParameterLists:
 Metrics/AbcSize:
   Exclude:
     - 'app/indexers/hyrax/file_set_indexer.rb'
-    - 'app/services/hyrax/user_stat_importer.rb'
     - 'app/services/hyrax/workflow/permission_query.rb'
 
 Metrics/ModuleLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -30,7 +30,6 @@ Metrics/ParameterLists:
 
 Metrics/AbcSize:
   Exclude:
-    - 'app/controllers/concerns/hyrax/my_controller_behavior.rb'
     - 'app/indexers/hyrax/file_set_indexer.rb'
     - 'app/services/hyrax/user_stat_importer.rb'
     - 'app/services/hyrax/workflow/permission_query.rb'


### PR DESCRIPTION
## Removing Rubocop exclusion for depositor_stats.rb

@9024a9b8ab4a0e8f9a733381afd11274646f88f0

The file no longer exists…so no sense excluding it.

## Removing exclusion for my_controller_behavior.rb

@ed0fb478de2f2ea49e915d704fb6e04d21f6d8c0

The Metrics/AbcSize cop was no longer applicable.

## Removing exclusion for user_stat_importer.rb

@e812234203183369d21ece4c289079e9dfcc6ee7

The Metrics/AbcSize cop was no longer applicable.
