### PR TITLE
fix for #221

### DIFF
--- a/lib/hyrax/controlled_vocabulary/importer/language.rb
+++ b/lib/hyrax/controlled_vocabulary/importer/language.rb
@@ -23,7 +23,7 @@ module Hyrax
             'languages',
             [rdf_path],
             format: 'rdfxml',
-            predicate: RDF::Vocab::SKOS.prefLabel
+            predicate: RDF::URI('http://www.w3.org/2008/05/skos#prefLabel')
           )
           logger.info "Import complete"
         end

--- a/spec/lib/hyrax/controlled_vocabulary/importer/language_spec.rb
+++ b/spec/lib/hyrax/controlled_vocabulary/importer/language_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Hyrax::ControlledVocabulary::Importer::Language do
       'languages',
       [rdf_path],
       format: 'rdfxml',
-      predicate: RDF::Vocab::SKOS.prefLabel
+      predicate: RDF::URI('http://www.w3.org/2008/05/skos#prefLabel')
     )
     instance.import
   end


### PR DESCRIPTION
Fixes #221 

Fixes incorrect namespace in lexvo languages importer

rake hyrax:controlled_vocabularies:languages fails to import any languages because the namespace in RDF::Vocab::SKOS is different to the one in the Lexvo data dump. Switching the importer (lib/hyrax/controlled_vocabulary/importer/language.rb) to use the Lexvo skos namespace fixes this.

@projecthydra-labs/hyrax-code-reviewers