### PR TITLE
Adjusting flash_msg rendering

### DIFF
--- a/app/views/_flash_msg.html.erb
+++ b/app/views/_flash_msg.html.erb
@@ -1,13 +1,8 @@
-<% flash_types_to_classes = { notice: 'alert-success', error: 'alert-danger', alert: 'alert-warning' } %>
-<% [:notice, :error, :alert].each do |type| %>
-  <% if flash[type] %>
-    <div class="alert <%= flash_types_to_classes[type] rescue '' %> alert-dismissable" role="alert">
+<% { notice: 'alert-success', error: 'alert-danger', alert: 'alert-warning' }.each do |type, flash_dom_class| %>
+  <% if flash[type].present? %>
+    <div class="alert <%= flash_dom_class %> alert-dismissable" role="alert">
       <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-      <% if flash[type].respond_to? :join %>
-        <%= flash[type].join("<br/>").html_safe %>
-      <% else %>
-        <%= flash[type].html_safe %>
-      <% end %>
+      <%= safe_join(Array.wrap(flash[type]), '<br/>') %>
     </div>
     <% flash.delete(type) %>
   <% end %>


### PR DESCRIPTION
There were a few duplications of knowledge:

1) A local variable was declared and then a separate variable was used
   for iteration.
2) There was different handling of the flash message if it was string
   or an array.
3) An empty array or string would trigger rendering the flash div.

This is an attempt to remove a duplication of knowledge.