### PR TITLE
include message queue basics in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Jump in: [![Slack Status](http://slack.projecthydra.org/badge.svg)](http://slack
   * [Creating a Hyrax\-based app](#creating-a-hyrax-based-app)
     * [Redis](#redis)
     * [Rails](#rails)
+    * [Message Queue](#message-queue)
     * [Generate a primary work type](#generate-a-primary-work-type)
     * [Start servers](#start-servers)
   * [Managing a Hyrax\-based app](#managing-a-hyrax-based-app)
@@ -172,6 +173,28 @@ Generating a new Rails application using Hyrax's template above takes cares of a
 * Running Hyrax's install generator, to add a number of files that Hyrax requires within your Rails app, including e.g. database migrations
 * Loading all of Hyrax's database migrations into your application's database
 * Loading Hyrax's default workflows into your application's database
+
+## Message Queue
+Many of the services performed by Hyrax are resource intensive, and therefore are well suited to running as background jobs that can be managed and executed by a Message Queue system. Examples include:
+* File ingest
+* Derivative generation
+* Characterization
+* Fixity
+* Solr indexing
+
+Hyrax implements these jobs using [ActiveJob](http://edgeguides.rubyonrails.org/active_job_basics.html), allowing you to choose the message queue system of your choice.
+
+For initial testing and development, it is recommended that you change the default ActiveJob adapter `:async` to `:inline`. This adapter will execute jobs immediately as they are received. This can be accomplished by adding the following to your `config/application.rb`
+
+```
+class Application < Rails::Application
+  # ...
+  config.active_job.queue_adapter = :inline
+  # ...
+end
+```
+
+**For production applications** you will want to setup a 3rd party system such as [Sidekiq](http://sidekiq.org/) or [Resque](https://github.com/resque/resque). The Sufia Development Guide has a detailed walkthrough of [installing and configuring Resque](https://github.com/projecthydra/sufia/wiki/Background-Workers-(Resque-in-Sufia-7). Initial Sidekiq instructions for ActiveJob are available on the [Sidekiq wiki](https://github.com/mperham/sidekiq/wiki/Active-Job).
 
 ## Generate a primary work type
 


### PR DESCRIPTION
A few folks (including us) seem to have run into issues with the default `:async` adapter for ActiveJob. This PR attempts to add a bit of context for message queue options for hyrax adopters, including a recommendation to, at least initially, set the adapter to `:inline` to mirror the test suite. 

Ideally I'd like to write up a Sidekiq document along the same lines as the [Resque documentation](https://github.com/projecthydra/sufia/wiki/Background-Workers-(Resque-in-Sufia-7)) in the Sufia Dev Guide. I haven't had the time yet, but would be happy to do so if there's interest?

@projecthydra-labs/hyrax-code-reviewers
