### PR TITLE
Tidying up rubocop violations and extracting a service class

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -54,7 +54,6 @@ Metrics/MethodLength:
     - 'app/helpers/hyrax/citations_behaviors/formatters/endnote_formatter.rb'
     - 'app/indexers/hyrax/file_set_indexer.rb'
     - 'app/inputs/multi_value_select_input.rb'
-    - 'app/models/concerns/hyrax/file_set/derivatives.rb'
     - 'app/models/concerns/hyrax/solr_document/export.rb'
     - 'app/services/hyrax/workflow/permission_query.rb'
     - 'lib/generators/hyrax/templates/migrations/create_local_authorities.rb'

--- a/app/models/concerns/hyrax/file_set/derivatives.rb
+++ b/app/models/concerns/hyrax/file_set/derivatives.rb
@@ -15,34 +15,49 @@ module Hyrax
       # before derivatives so that we have a credible mime_type field to work with.
       def create_derivatives(filename)
         case mime_type
-        when *self.class.pdf_mime_types
+        when *self.class.pdf_mime_types             then create_pdf_derivatives(filename)
+        when *self.class.office_document_mime_types then create_office_document_derivatives(filename)
+        when *self.class.audio_mime_types           then create_audio_derivatives(filename)
+        when *self.class.video_mime_types           then create_video_derivatives(filename)
+        when *self.class.image_mime_types           then create_image_derivatives(filename)
+        end
+      end
+
+      private
+
+        def create_pdf_derivatives(filename)
           Hydra::Derivatives::PdfDerivatives.create(filename,
                                                     outputs: [{ label: :thumbnail, format: 'jpg', size: '338x493', url: derivative_url('thumbnail') }])
           Hydra::Derivatives::FullTextExtract.create(filename,
                                                      outputs: [{ url: uri, container: "extracted_text" }])
-        when *self.class.office_document_mime_types
+        end
+
+        def create_office_document_derivatives(filename)
           Hydra::Derivatives::DocumentDerivatives.create(filename,
                                                          outputs: [{ label: :thumbnail, format: 'jpg',
                                                                      size: '200x150>',
                                                                      url: derivative_url('thumbnail') }])
           Hydra::Derivatives::FullTextExtract.create(filename,
                                                      outputs: [{ url: uri, container: "extracted_text" }])
-        when *self.class.audio_mime_types
+        end
+
+        def create_audio_derivatives(filename)
           Hydra::Derivatives::AudioDerivatives.create(filename,
                                                       outputs: [{ label: 'mp3', format: 'mp3', url: derivative_url('mp3') },
                                                                 { label: 'ogg', format: 'ogg', url: derivative_url('ogg') }])
-        when *self.class.video_mime_types
+        end
+
+        def create_video_derivatives(filename)
           Hydra::Derivatives::VideoDerivatives.create(filename,
                                                       outputs: [{ label: :thumbnail, format: 'jpg', url: derivative_url('thumbnail') },
                                                                 { label: 'webm', format: 'webm', url: derivative_url('webm') },
                                                                 { label: 'mp4', format: 'mp4', url: derivative_url('mp4') }])
-        when *self.class.image_mime_types
+        end
+
+        def create_image_derivatives(filename)
           Hydra::Derivatives::ImageDerivatives.create(filename,
                                                       outputs: [{ label: :thumbnail, format: 'jpg', size: '200x150>', url: derivative_url('thumbnail') }])
         end
-      end
-
-      private
 
         # The destination_name parameter has to match up with the file parameter
         # passed to the DownloadsController

--- a/app/services/hyrax/file_set_derivatives_service.rb
+++ b/app/services/hyrax/file_set_derivatives_service.rb
@@ -1,0 +1,75 @@
+module Hyrax
+  # Responsible for creating and cleaning up the derivatives of a file_set
+  class FileSetDerivativesService
+    attr_reader :file_set
+    delegate :uri, :mime_type, to: :file_set
+
+    # @param file_set [Hyrax::FileSet] At least for this class, it must have #uri and #mime_type
+    def initialize(file_set)
+      @file_set = file_set
+    end
+
+    def cleanup_derivatives
+      derivative_path_factory.derivatives_for_reference(file_set).each do |path|
+        FileUtils.rm_f(path)
+      end
+    end
+
+    def create_derivatives(filename)
+      case mime_type
+      when *file_set.class.pdf_mime_types             then create_pdf_derivatives(filename)
+      when *file_set.class.office_document_mime_types then create_office_document_derivatives(filename)
+      when *file_set.class.audio_mime_types           then create_audio_derivatives(filename)
+      when *file_set.class.video_mime_types           then create_video_derivatives(filename)
+      when *file_set.class.image_mime_types           then create_image_derivatives(filename)
+      end
+    end
+
+    private
+
+      def create_pdf_derivatives(filename)
+        Hydra::Derivatives::PdfDerivatives.create(filename,
+                                                  outputs: [{ label: :thumbnail, format: 'jpg', size: '338x493', url: derivative_url('thumbnail') }])
+        Hydra::Derivatives::FullTextExtract.create(filename,
+                                                   outputs: [{ url: uri, container: "extracted_text" }])
+      end
+
+      def create_office_document_derivatives(filename)
+        Hydra::Derivatives::DocumentDerivatives.create(filename,
+                                                       outputs: [{ label: :thumbnail, format: 'jpg',
+                                                                   size: '200x150>',
+                                                                   url: derivative_url('thumbnail') }])
+        Hydra::Derivatives::FullTextExtract.create(filename,
+                                                   outputs: [{ url: uri, container: "extracted_text" }])
+      end
+
+      def create_audio_derivatives(filename)
+        Hydra::Derivatives::AudioDerivatives.create(filename,
+                                                    outputs: [{ label: 'mp3', format: 'mp3', url: derivative_url('mp3') },
+                                                              { label: 'ogg', format: 'ogg', url: derivative_url('ogg') }])
+      end
+
+      def create_video_derivatives(filename)
+        Hydra::Derivatives::VideoDerivatives.create(filename,
+                                                    outputs: [{ label: :thumbnail, format: 'jpg', url: derivative_url('thumbnail') },
+                                                              { label: 'webm', format: 'webm', url: derivative_url('webm') },
+                                                              { label: 'mp4', format: 'mp4', url: derivative_url('mp4') }])
+      end
+
+      def create_image_derivatives(filename)
+        Hydra::Derivatives::ImageDerivatives.create(filename,
+                                                    outputs: [{ label: :thumbnail, format: 'jpg', size: '200x150>', url: derivative_url('thumbnail') }])
+      end
+
+      # The destination_name parameter has to match up with the file parameter
+      # passed to the DownloadsController
+      def derivative_url(destination_name)
+        path = derivative_path_factory.derivative_path_for_reference(file_set, destination_name)
+        URI("file://#{path}").to_s
+      end
+
+      def derivative_path_factory
+        Hyrax::DerivativePath
+      end
+  end
+end


### PR DESCRIPTION
## Removing MethodLength exclusion

@4849cb548dd61664c2ae7547192548808ec408cb

In a perfect world, a Hyrax::FileSet::CreateDerivativesService would be
created, then we would delegate the public facing methods (e.g.
:cleanup_derivatives and :create_derivatives) to the underlying class.

However, this is not a perfect world.

## Extracting a class for FileSetDerivativesService

@7eb62f0e7d36ddc438d1328ce3a0274f9c864cfe

The purpose of this refactor is to build towards a more perfect world
by:

1) Reducing the number of methods added to a model, thus narrowing its
   interface (both public and private)
2) Exposing a clear collaborating class with a narrow purpose
3) To show a methodology for not abusing ActiveSupport::Concern
4) To be explicit in how a module is dependent on the class it mixes
   into, as well as what methods are important for that class to get
   from the module - see the delegate methods for how the service and
   FileSet are to interact.

Related to projecthydra/hydra-works#315
