### PR TITLE
Make the user search form generic

### DIFF
--- a/app/views/hyrax/users/_search_form.html.erb
+++ b/app/views/hyrax/users/_search_form.html.erb
@@ -1,5 +1,6 @@
 <div>
-  <%= form_tag hyrax.profiles_path, method: :get, class: "form-search" do %>
+  <% # this form is used on the public users page and the admin users page, so submit to current path %>
+  <%= form_tag request.path, method: :get, class: "form-search" do %>
     <label class="sr-only" for="user_search">Search Users</label>
     <%= text_field_tag :uq, params[:uq], class: "q", placeholder: "Search Users", size: '30', type: "search", id: "user_search" %>
     <%= hidden_field_tag :sort, params[:sort], id: 'user_sort' %>


### PR DESCRIPTION
This allows it to be used for multiple controllers like
Admin::UsersController (in Hyku) as well as the UsersController.
Fixes #257
