### PR TITLE
Rename BatchUploadItem to BatchUpload to match rails conventions

### DIFF
--- a/app/controllers/concerns/hyrax/batch_uploads_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/batch_uploads_controller_behavior.rb
@@ -7,7 +7,7 @@ module Hyrax
     included do
       self.work_form_service = BatchUploadFormService
       self.curation_concern_type = work_form_service.form_class.model_class # includes CanCan side-effects
-      # We use BatchUploadItem as a null stand-in curation_concern_type.
+      # We use BatchUpload as a null stand-in curation_concern_type.
       # The actual permission is checked dynamically during #create.
     end
 
@@ -15,7 +15,7 @@ module Hyrax
     # @note we don't call `authorize!` directly, since `authorized_models` already checks `user.can? :create, ...`
     def create
       authenticate_user!
-      unsafe_pc = params.fetch(:batch_upload_item, {})[:payload_concern]
+      unsafe_pc = params.fetch(:batch_upload, {})[:payload_concern]
       # Calling constantize on user params is disfavored (per brakeman), so we sanitize by matching it against an authorized model.
       safe_pc = Hyrax::SelectTypeListPresenter.new(current_user).authorized_models.map(&:to_s).find { |x| x == unsafe_pc }
       raise CanCan::AccessDenied, "Cannot create an object of class '#{unsafe_pc}'" unless safe_pc

--- a/app/forms/hyrax/forms/batch_upload_form.rb
+++ b/app/forms/hyrax/forms/batch_upload_form.rb
@@ -1,7 +1,7 @@
 module Hyrax
   module Forms
     class BatchUploadForm < Hyrax::Forms::WorkForm
-      self.model_class = BatchUploadItem
+      self.model_class = BatchUpload
       include HydraEditor::Form::Permissions
 
       self.terms -= [:title, :resource_type]
@@ -21,11 +21,6 @@ module Hyrax
       def primary_terms
         super - [:title]
       end
-
-      # # On the batch upload, title is set per-file.
-      # def secondary_terms
-      #   super - [:title]
-      # end
 
       # Override of ActiveModel::Model name that allows us to use our custom name class
       def self.model_name

--- a/app/models/batch_upload.rb
+++ b/app/models/batch_upload.rb
@@ -1,7 +1,7 @@
 # This stands in for an object to be created from the BatchUploadForm.
 # It should never actually be persisted in the repository.
 # The properties on this form should be copied to a real work type.
-class BatchUploadItem < ActiveFedora::Base
+class BatchUpload < ActiveFedora::Base
   include ::Hyrax::BasicMetadata
   include Hyrax::WorkBehavior
 

--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -42,9 +42,9 @@ module Hyrax
 
       def uploaded_file_abilities
         return unless registered_user?
-        can :create, [UploadedFile, BatchUploadItem]
+        can :create, [UploadedFile, BatchUpload]
         can :destroy, UploadedFile, user: current_user
-        # BatchUploadItem permissions depend on the kind of objects being made by the batch,
+        # BatchUpload permissions depend on the kind of objects being made by the batch,
         # but it must be authorized directly in the controller, not here.
         # Note: cannot call `authorized_models` without going recursive.
       end

--- a/spec/controllers/hyrax/batch_uploads_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_uploads_controller_spec.rb
@@ -9,7 +9,7 @@ describe Hyrax::BatchUploadsController do
   let(:expected_shared_params) do
     { 'keyword' => [], 'visibility' => 'open', :model => 'GenericWork' }
   end
-  let(:batch_upload_item) do
+  let(:batch_upload) do
     { keyword: [""], visibility: 'open', payload_concern: 'GenericWork' }
   end
   let(:post_params) do
@@ -17,7 +17,7 @@ describe Hyrax::BatchUploadsController do
       title: expected_individual_params,
       resource_type: expected_types,
       uploaded_files: ['1'],
-      batch_upload_item: batch_upload_item
+      batch_upload: batch_upload
     }
   end
 
@@ -52,7 +52,7 @@ describe Hyrax::BatchUploadsController do
     end
 
     describe "when submiting works on behalf of another user" do
-      let(:batch_upload_item) do
+      let(:batch_upload) do
         {
           payload_concern: Atlas,
           permissions_attributes: [

--- a/spec/forms/hyrax/forms/batch_upload_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_upload_form_spec.rb
@@ -22,7 +22,7 @@ describe Hyrax::Forms::BatchUploadForm do
       expect(subject.route_key).to eq 'batch_uploads'
     end
     it "has a param_key" do
-      expect(subject.param_key).to eq 'batch_upload_item'
+      expect(subject.param_key).to eq 'batch_upload'
     end
   end
 


### PR DESCRIPTION
The controller is `BatchUploadsController`.  Therefore the model should be
`BatchUpload`.

Fixes #298