### PR TITLE
Ensuring up to date system gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
     - "travis_phantomjs"
 
 before_install:
+  - gem update --system
   - gem install bundler
   - "phantomjs --version"
   - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"


### PR DESCRIPTION
This fixes the following error:

```console
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    can't modify frozen String
```

Related to sickill/rainbow#48

Referencing Blacklight's workaround

https://github.com/projectblacklight/blacklight/blob/master/.travis.yml#L21

@projecthydra-labs/hyrax-code-reviewers
