### PR TITLE
Rename reviews to workflows on admin menu

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -94,7 +94,7 @@ en:
         settings:   "Settings"
         statistics: "Statistics"
         workflow: "Workflows"
-        workflow_review: "Review"
+        workflow_review: "Workflows"
         workflow_roles: "Roles"
       stats:
         registered: "Registered"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -120,7 +120,7 @@ es:
         settings:   "Ajustes"
         statistics: "Estadísticas"
         workflow: "Flujos de trabajo"
-        workflow_review: "Repaso"
+        workflow_review: "Flujos de trabajo"
         workflow_roles: "Roles"
       stats:
         deposited_form:


### PR DESCRIPTION
Related to issue https://github.com/projecthydra-labs/hyku/issues/634

This PR renames the "Reviews" menu item on the admin sidebar to say "Workflows".

@projecthydra-labs/hyrax-code-reviewers
