### PR TITLE
Switching permissions templates to use workflow_id instead of workflo…

### DIFF
--- a/app/actors/hyrax/default_admin_set_actor.rb
+++ b/app/actors/hyrax/default_admin_set_actor.rb
@@ -36,7 +36,7 @@ module Hyrax
       # rubocop:disable Lint/HandleExceptions
       def create_default_admin_set
         AdminSet.create!(id: DEFAULT_ID, title: ['Default Admin Set']).tap do |_as|
-          PermissionTemplate.create!(admin_set_id: DEFAULT_ID, workflow_name: 'default')
+          PermissionTemplate.create!(admin_set_id: DEFAULT_ID)
         end
       rescue ActiveFedora::IllegalOperation
         # It is possible that another thread created the AdminSet just before this method

--- a/app/controllers/hyrax/admin/permission_templates_controller.rb
+++ b/app/controllers/hyrax/admin/permission_templates_controller.rb
@@ -20,7 +20,7 @@ module Hyrax
 
         def update_params
           params.require(:permission_template)
-                .permit(:release_date, :release_period, :release_varies, :release_embargo, :visibility, :workflow_name,
+                .permit(:release_date, :release_period, :release_varies, :release_embargo, :visibility, :workflow_id,
                         access_grants_attributes: [:access, :agent_id, :agent_type, :id])
         end
 

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -5,7 +5,7 @@ module Hyrax
 
       self.model_class = PermissionTemplate
       self.terms = []
-      delegate :access_grants, :access_grants_attributes=, :release_date, :release_period, :visibility, :workflow_name, to: :model
+      delegate :access_grants, :access_grants_attributes=, :release_date, :release_period, :visibility, :workflow_id, to: :model
 
       # Stores which radio button under release "Varies" option is selected
       attr_accessor :release_varies
@@ -46,8 +46,8 @@ module Hyrax
         # If the workflow has been changed, ensure that all the AdminSet managers
         # have all the roles for the new workflow
         def grant_workflow_roles
-          return unless model.previous_changes.include?("workflow_name")
-          workflow = Sipity::Workflow.find_by!(name: model.workflow_name)
+          return unless model.previous_changes.include?("workflow_id")
+          workflow = Sipity::Workflow.find_by!(id: model.workflow_id)
           model.access_grants.select { |g| g.access == 'manage' }.each do |grant|
             agent = case grant.agent_type
                     when 'user'

--- a/app/models/sipity/workflow.rb
+++ b/app/models/sipity/workflow.rb
@@ -10,10 +10,16 @@ module Sipity
     has_many :workflow_states, dependent: :destroy, class_name: 'Sipity::WorkflowState'
     has_many :workflow_actions, dependent: :destroy, class_name: 'Sipity::WorkflowAction'
     has_many :workflow_roles, dependent: :destroy, class_name: 'Sipity::WorkflowRole'
+    has_many :permission_templates, dependent: :restrict_with_exception, class_name: 'Hyrax::PermissionTemplate'
 
     DEFAULT_INITIAL_WORKFLOW_STATE = 'new'.freeze
     def initial_workflow_state
       workflow_states.find_or_create_by!(name: DEFAULT_INITIAL_WORKFLOW_STATE)
+    end
+
+    def self.default_workflow
+      log_and_raise('No workflows found') if Sipity::Workflow.none?
+      Sipity::Workflow.order('id ASC').first!
     end
   end
 end

--- a/app/services/hyrax/workflow/default_workflow_strategy.rb
+++ b/app/services/hyrax/workflow/default_workflow_strategy.rb
@@ -3,9 +3,9 @@ module Hyrax
     class DefaultWorkflowStrategy
       def initialize(_work, _attributes); end
 
-      # @return [String] The name of the workflow to use
-      def workflow_name
-        'default'
+      # @return [String] The id of the workflow to use
+      def workflow_id
+        Sipity::Workflow.default_workflow.id
       end
     end
   end

--- a/app/services/hyrax/workflow/workflow_by_admin_set_strategy.rb
+++ b/app/services/hyrax/workflow/workflow_by_admin_set_strategy.rb
@@ -6,9 +6,9 @@ module Hyrax
       end
 
       # @return [String] The name of the workflow by admin_set to use
-      def workflow_name
-        return 'default' unless @admin_set_id
-        Hyrax::PermissionTemplate.find_by!(admin_set_id: @admin_set_id).workflow_name
+      def workflow_id
+        return unless @admin_set_id
+        Hyrax::PermissionTemplate.find_by!(admin_set_id: @admin_set_id).workflow_id
       end
     end
   end

--- a/app/services/hyrax/workflow/workflow_factory.rb
+++ b/app/services/hyrax/workflow/workflow_factory.rb
@@ -44,12 +44,12 @@ module Hyrax
       # then load the workflows in config/workflows/*.json and try again.
       # @return [Sipity::Workflow]
       def workflow
-        @workflow ||= Sipity::Workflow.find_by(name: workflow_name) ||
+        @workflow ||= Sipity::Workflow.find_by(id: workflow_id) ||
                       (Hyrax::Workflow::WorkflowImporter.load_workflows &&
-                       Sipity::Workflow.find_by!(name: workflow_name))
+                       Sipity::Workflow.default_workflow)
       end
 
-      delegate :workflow_name, to: :strategy
+      delegate :workflow_id, to: :strategy
 
       # Find an action that has no starting state. This is the deposit action.
       # # @return [Sipity::WorkflowAction]

--- a/app/views/hyrax/admin/admin_sets/_form_workflow.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_workflow.erb
@@ -6,7 +6,7 @@
                       <% if f.object.workflows.any? %>
                         <div class="panel-body">
                           <p><%= t('.page_description') %></p>
-                              <%= f.collection_radio_buttons :workflow_name, f.object.workflows, :name, :label, item_wrapper_tag: :div, item_wrapper_class: "radio" do |b| %>
+                              <%= f.collection_radio_buttons :workflow_id, f.object.workflows, :id, :label, item_wrapper_tag: :div, item_wrapper_class: "radio" do |b| %>
                                 <span><%= b.radio_button + b.object.label %></span>
                                 <p><%= b.object.description %></p>
                               <% end %>

--- a/db/migrate/20161021175854_create_permission_template.rb
+++ b/db/migrate/20161021175854_create_permission_template.rb
@@ -1,9 +1,9 @@
 class CreatePermissionTemplate < ActiveRecord::Migration
   def change
     create_table :permission_templates do |t|
+      t.belongs_to :workflow
       t.string :admin_set_id
       t.string :visibility
-      t.string :workflow_name
       t.timestamps
     end
     add_index :permission_templates, :admin_set_id

--- a/spec/features/workflow_state_changes_spec.rb
+++ b/spec/features/workflow_state_changes_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Workflow state changes", type: :feature do
 
   let(:workflow) { Sipity::Workflow.find_by_name(workflow_name) }
   let(:work) { create(:work, user: depositing_user, admin_set: admin_set) }
-  let(:workflow_strategy) { double(workflow_name: workflow.name) }
+  let(:workflow_strategy) { double(workflow_id: workflow.id) }
   before do
     allow(::User.group_service).to receive(:byname).and_return(depositing_user.user_key => ['admin'], approving_user.user_key => ['admin'])
     Hyrax::Workflow::WorkflowImporter.new(data: one_step_workflow.as_json).call

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
 
   describe "#grant_workflow_roles" do
     subject { form.send(:grant_workflow_roles) }
+    let(:admin_set) { create(:admin_set) }
     let(:workflow) { create(:workflow) }
     let(:user) { create(:user) }
     let(:role1) { Sipity::Role.create!(name: 'hello') }
@@ -150,7 +151,8 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
 
     let(:permission_template) do
       create(:permission_template,
-             workflow_name: workflow.name,
+             workflow_id: workflow.id,
+             admin_set_id: admin_set.id,
              access_grants_attributes:
                [{ agent_type: 'user',
                   agent_id: user.user_key,
@@ -167,7 +169,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
 
     context "when a new workflow has been chosen" do
       before do
-        allow(permission_template).to receive(:previous_changes).and_return("workflow_name" => [nil, workflow.name])
+        allow(permission_template).to receive(:previous_changes).and_return("workflow_id" => [nil, workflow.id])
       end
 
       it "gives the managers workflow roles" do

--- a/spec/services/hyrax/workflow/workflow_by_admin_set_strategy_spec.rb
+++ b/spec/services/hyrax/workflow/workflow_by_admin_set_strategy_spec.rb
@@ -2,21 +2,21 @@ describe Hyrax::Workflow::WorkflowByAdminSetStrategy, :no_clean do
   context "when using default workflow strategy" do
     let(:workflow_strategy) { described_class.new(nil, {}) }
 
-    describe '#workflow_name' do
-      subject { workflow_strategy.workflow_name }
-      it { is_expected.to eq 'default' }
+    describe '#workflow_id' do
+      subject { workflow_strategy.workflow_id }
+      it { is_expected.to eq nil }
     end
   end
 
   context "when using a non-default workflow strategy" do
     let!(:admin_set) { AdminSet.create(title: ["test"]) }
-    let!(:permission_template) { Hyrax::PermissionTemplate.create(workflow_name: workflow_name, admin_set_id: admin_set.id) }
-    let(:workflow_name) { 'work' }
+    let!(:workflow) { Sipity::Workflow.create(name: "default", label: "default") }
+    let!(:permission_template) { Hyrax::PermissionTemplate.create(workflow_id: workflow.id, admin_set_id: admin_set.id) }
     let(:workflow_strategy) { described_class.new(nil, admin_set_id: admin_set.id) }
 
-    describe '#workflow_name' do
-      subject { workflow_strategy.workflow_name }
-      it { is_expected.to eq workflow_name }
+    describe '#workflow_id' do
+      subject { workflow_strategy.workflow_id }
+      it { is_expected.to eq workflow.id }
     end
   end
 end

--- a/spec/views/hyrax/admin/admin_sets/_form_workflow.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/_form_workflow.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'hyrax/admin/admin_sets/_form_workflow.html.erb', type: :view do
                     persisted?: template.persisted?,
                     to_key: template.to_key,
                     workflows: [workflow],
-                    workflow_name: nil)
+                    workflow_id: workflow.id)
   end
   before do
     @form = instance_double(Hyrax::Forms::AdminSetForm,
@@ -18,6 +18,6 @@ RSpec.describe 'hyrax/admin/admin_sets/_form_workflow.html.erb', type: :view do
     render
   end
   it "has the radio button for workflow" do
-    expect(rendered).to have_selector('#workflow label[for="permission_template_workflow_name_my_name"] input[type=radio][name="permission_template[workflow_name]"][value="my_name"]')
+    expect(rendered).to have_selector("#workflow label[for=\"permission_template_workflow_id_#{workflow.id}\"] input[type=radio][name=\"permission_template[workflow_id]\"][value=\"#{workflow.id}\"]")
   end
 end


### PR DESCRIPTION
Updates to use workflow_id instead of workflow_name.

Fixes #191; refs #issuenumber

Changes proposed in this pull request:
*  Switched workflow_id in place of workflow_name throughout
*  Added has_many relationship to Sipity::Workflow
*  Added belongs_to relationship to PremissionTemplate for Workflow

@projecthydra-labs/hyrax-code-reviewers
