### PR TITLE
JSON encode User with Jbuilder

### DIFF
--- a/app/assets/javascripts/hyrax/proxy_rights.js
+++ b/app/assets/javascripts/hyrax/proxy_rights.js
@@ -7,14 +7,14 @@
 
     var $container = this;
 
-    function addContributor(name, id, grantor) {
-      data = {name: name, id: id}
+    function addContributor(name, user_key, grantor) {
+      data = {name: name, user_key: user_key}
 
       $.ajax({
         type: "POST",
         url: '/users/'+grantor+'/depositors',
         dataType: 'json',
-        data: {grantee_id: id},
+        data: {grantee_key: user_key},
         success: function (data) {
           if (data.name !== undefined) {
             row = rowTemplate(data);
@@ -54,7 +54,7 @@
       obj = $("#user").select2("data")
       grantor = $('#user').data('grantor')
       $("#user").select2("val", '')
-      addContributor(obj.text, obj.id, grantor);
+      addContributor(obj.text, obj.user_key, grantor);
     });
 
     $('body').on('click', 'a.remove-proxy-button', removeContributor);

--- a/app/assets/javascripts/hyrax/proxy_rights.js
+++ b/app/assets/javascripts/hyrax/proxy_rights.js
@@ -14,7 +14,7 @@
         type: "POST",
         url: '/users/'+grantor+'/depositors',
         dataType: 'json',
-        data: {grantee_key: user_key},
+        data: {grantee_id: user_key},
         success: function (data) {
           if (data.name !== undefined) {
             row = rowTemplate(data);

--- a/app/assets/javascripts/hyrax/user_search.js
+++ b/app/assets/javascripts/hyrax/user_search.js
@@ -24,7 +24,7 @@
           },
           results: function (data, page) { // parse the results into the format expected by Select2.
             // since we are using custom formatting functions we do not need to alter remote JSON data
-            return {results: data};
+            return {results: data.users};
           }
         },
       }).select2('data', null);

--- a/app/assets/javascripts/hyrax/user_search.js
+++ b/app/assets/javascripts/hyrax/user_search.js
@@ -1,30 +1,30 @@
 (function( $ ){
 
-  $.fn.userSearch = function( options ) {
-    // Create some defaults, extending them with any options that were provided
-    var settings = $.extend( { }, options);
-
-    var $container = this;
-
+  $.fn.userSearch = function() {
     return this.each(function() {
       $(this).select2( {
-        placeholder: $(this).attr('value') || "Search for a user",
+        placeholder: $(this).attr("value") || "Search for a user",
         minimumInputLength: 2,
-        initSelection : function (element, callback) {
-          var data = {id: element.val(), text: element.val()};
+        id: function(object) {
+          return object.user_key;
+        },
+        initSelection: function(element, callback) {
+          var data = {
+            id: element.val(),
+            text: element.val()
+          };
           callback(data);
         },
-        ajax: { // instead of writing the function to execute the request we use Select2's convenient helper
+        ajax: { // Use the jQuery.ajax wrapper provided by Select2
           url: "/users.json",
-          dataType: 'json',
+          dataType: "json",
           data: function (term, page) {
             return {
-              uq: term // search term
+              uq: term // Search term
             };
           },
-          results: function (data, page) { // parse the results into the format expected by Select2.
-            // since we are using custom formatting functions we do not need to alter remote JSON data
-            return {results: data.users};
+          results: function(data, page) {
+            return { results: data.users };
           }
         },
       }).select2('data', null);

--- a/app/controllers/concerns/hyrax/depositors_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/depositors_controller_behavior.rb
@@ -10,7 +10,7 @@ module Hyrax
 
     def create
       grantor = authorize_and_return_grantor
-      grantee = ::User.from_url_component(params[:grantee_key])
+      grantee = ::User.from_url_component(params[:grantee_id])
       if grantor.can_receive_deposits_from.include?(grantee)
         head :ok
       else

--- a/app/controllers/concerns/hyrax/depositors_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/depositors_controller_behavior.rb
@@ -10,7 +10,7 @@ module Hyrax
 
     def create
       grantor = authorize_and_return_grantor
-      grantee = ::User.from_url_component(params[:grantee_id])
+      grantee = ::User.from_url_component(params[:grantee_key])
       if grantor.can_receive_deposits_from.include?(grantee)
         head :ok
       else

--- a/app/controllers/concerns/hyrax/users_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/users_controller_behavior.rb
@@ -12,10 +12,6 @@ module Hyrax::UsersControllerBehavior
 
   def index
     @users = search(params[:uq])
-    respond_to do |format|
-      format.html
-      format.json { render json: @users.to_json }
-    end
   end
 
   # Display user profile

--- a/app/views/hyrax/users/index.json.jbuilder
+++ b/app/views/hyrax/users/index.json.jbuilder
@@ -1,4 +1,5 @@
 json.users @users do |user|
   json.id user.id
+  json.user_key user.user_key
   json.text user.to_s
 end

--- a/app/views/hyrax/users/index.json.jbuilder
+++ b/app/views/hyrax/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.users @users do |user|
+  json.id user.id
+  json.text user.to_s
+end

--- a/spec/controllers/hyrax/users_controller_spec.rb
+++ b/spec/controllers/hyrax/users_controller_spec.rb
@@ -50,11 +50,13 @@ describe Hyrax::UsersController, type: :controller do
     end
 
     describe "requesting json" do
+      render_views
+
       it "displays users" do
         get :index, params: { format: :json }
         expect(response).to be_successful
-        json = JSON.parse(response.body)
-        expect(json.map { |u| u['id'] }).to include(u1.email, u2.email)
+        json = JSON.parse(response.body).fetch('users')
+        expect(json.map { |u| u['id'] }).to include(u1.id, u2.id)
         expect(json.map { |u| u['text'] }).to include(u1.email, u2.email)
       end
     end


### PR DESCRIPTION
Required by projecthydra-labs/hyku#421

In `Hyrax::UsersControllerBehavior` JSON serialization was performed by `@users.to_json`; this PR uses [Jbuilder](https://github.com/rails/jbuilder) instead. This makes it easier to change the JSON serialization in implementing applications; it can be altered like any other view. It also exposes the assumption that a `User` object returns the value of `.user_key` rather than `.id` when `.to_param` is called.

Changes proposed in this pull request:
* User Jbuilder to define the JSON serialization in `/users` rather than relying on `.to_json`
  * Wraps JSON output of a collection of `User` objects under a `users` property similar to the guidelines in [JSON API](http://jsonapi.org/)
* Expose `.id` in JSON serialization of a `User` object

---

@37229eeb6676a4d88a10adbfee82bc5a5f0c0302 **Use Jbuilder to encode users as JSON**

When using the `respond_to` block in the controller the default behavior for rendering JSON is to use ActiveSupport to serialize the objects. By removing the `respond_to` block we change the behavior to look for templates to render the view. Enter Jbuilder.

By using Jbuilder rather than an ActiveSupport serializer we can render different encodings of User objects in different contexts. It is also easy to override in implementations of Hyrax like Hyku.

@7ab3568918467ca2582a18e05113e5ae486c0abf **Updating proxy granting JS to use new user serialization**

This also makes referencing the :user_key explicit instead of relying on :user_key being returned as :id when the `User` object is serialized.


@017e23b26d276b8fb1b2a75969cdae37d243ee09 **Explicitly declaring the value for User select control**

- This 'id' function determines what to set the value of the original
  control when a selection is made in the Select2 list
- Removing comments taken from the Select2 examples page
- Removing unused configuration variables taken from proxy_rights.js
- Quibble: prefer multi-line object literals
- Quibble: prefer double quotes (as advocated by jsHint)


@63785c7bff37814fefd2501c6be52f6d534589cf **Reverting :grantee_key back to :grantee_id**

This property name gets passed all the way down into the database. Changing it isn't really necessary.

Consolidating hash literals in test cases to better highlight how they change between different assertions.

---

@projecthydra-labs/hyrax-code-reviewers 