### PR TITLE
Remove extraneous "Edit Your Profile" button

### DIFF
--- a/app/views/hyrax/users/_profile_actions.html.erb
+++ b/app/views/hyrax/users/_profile_actions.html.erb
@@ -1,6 +1,0 @@
-<!-- profile and view buttons -->
-<% if signed_in? && presenter.current_user? %>
-  <%= link_to hyrax.edit_profile_path(@user), class: "btn btn-default" do %>
-    <i class="glyphicon glyphicon-edit"></i> Edit Your Profile
-  <% end %>
-<% end %>

--- a/app/views/hyrax/users/show.html.erb
+++ b/app/views/hyrax/users/show.html.erb
@@ -1,7 +1,4 @@
-<div class="col-xs-12 profile">
-  <div class="pull-right">
-    <%= render 'profile_actions', presenter: @presenter %>
-  </div>
+<div class="row profile">
   <div class="col-xs-3">
     <%= render 'left_sidebar' %>
   </div>

--- a/spec/features/proxy_spec.rb
+++ b/spec/features/proxy_spec.rb
@@ -7,7 +7,7 @@ describe 'proxy', type: :feature do
       sign_in user
       visit "/"
       go_to_user_profile
-      click_link "Edit Your Profile"
+      click_link "Edit Profile"
       expect(first("td.depositor-name")).to be_nil
       create_proxy_using_partial(second_user)
       expect(page).to have_css('td.depositor-name', text: second_user.user_key)

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -5,14 +5,6 @@ describe "User Profile", type: :feature do
   let(:user) { create(:user) }
   let(:profile_path) { Hyrax::Engine.routes.url_helpers.profile_path(user, locale: 'en') }
 
-  context 'when visiting user profile' do
-    it 'renders page properly' do
-      visit profile_path
-      expect(page).to have_content(user.email)
-      expect(page).to have_content('Edit Your Profile')
-    end
-  end
-
   context 'when clicking all users' do
     # TODO: Move this to a view test
     it 'displays all users' do
@@ -25,7 +17,10 @@ describe "User Profile", type: :feature do
   context 'when visiting user profile' do
     it 'page should be editable' do
       visit profile_path
-      click_link 'Edit Your Profile'
+      expect(page).to have_content(user.email)
+      within '.panel-user' do
+        click_link 'Edit Profile'
+      end
       fill_in 'user_twitter_handle', with: 'curatorOfData'
       click_button 'Save Profile'
       expect(page).to have_content 'Your profile has been updated'


### PR DESCRIPTION
There is already an "Edit Profile" button on the page (as well as a link
to edit the profile in the header).

Ref projecthydra-labs/hyku#687
