### PR TITLE
Include ContentBlockHelper on PagesController

### DIFF
--- a/app/controllers/hyrax/pages_controller.rb
+++ b/app/controllers/hyrax/pages_controller.rb
@@ -1,5 +1,6 @@
 module Hyrax
   class PagesController < ApplicationController
+    helper Hyrax::ContentBlockHelper
     def show
       @page = ContentBlock.find_or_create_by(name: params[:id])
     end

--- a/spec/features/static_pages_spec.rb
+++ b/spec/features/static_pages_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe "The static pages" do
+  scenario do
+    visit root_path
+    click_link "About"
+    click_link "Help"
+  end
+end


### PR DESCRIPTION
Fixes a problem where the template can't find the helper method
```
ActionView::Template::Error:
       undefined method `editable_content_block' for
       #<#<Class:0x007f9e9678aff0>:0x007f9e96789880>
              Did you mean?  edit_collection_path
```

@projecthydra-labs/hyrax-code-reviewers
