### PR TITLE
Flash messages must be marked as html_safe, else HTML is unescaped

### DIFF
--- a/app/views/_flash_msg.html.erb
+++ b/app/views/_flash_msg.html.erb
@@ -2,7 +2,7 @@
   <% if flash[type].present? %>
     <div class="alert <%= flash_dom_class %> alert-dismissable" role="alert">
       <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-      <%= safe_join(Array.wrap(flash[type]), '<br/>') %>
+      <%= safe_join(Array.wrap(flash[type]), '<br/>'.html_safe) %>
     </div>
     <% flash.delete(type) %>
   <% end %>

--- a/spec/views/_flash_msg.html.erb_spec.rb
+++ b/spec/views/_flash_msg.html.erb_spec.rb
@@ -1,0 +1,31 @@
+# coding: utf-8
+describe '/_flash_msg.html.erb', type: :view do
+  before do
+    allow(view).to receive(:flash).and_return(flash)
+  end
+
+  let(:flash) { { notice: notice } }
+  let(:i18n_html) { t('hyrax.works.new.after_create_html', application_name: 'Whatever') }
+
+  context 'with a single flash notice' do
+    let(:notice) { i18n_html }
+    it 'renders with HTML unescaped' do
+      render
+      expect(rendered).not_to have_content '</span>'
+    end
+  end
+
+  context 'with multiple flash notices' do
+    let(:notice) do
+      [
+        i18n_html,
+        'Lorem ipsum!'
+      ]
+    end
+    it 'renders the notice joined with unescaped line break' do
+      render
+      expect(rendered).not_to have_content '<br/>'
+      expect(rendered).not_to have_content '</span>'
+    end
+  end
+end


### PR DESCRIPTION
Fixes projecthydra-labs/hyku#694

Bug introduced in https://github.com/projecthydra-labs/hyrax/commit/be4a648f9e0f9191f514a241780dabab29c73777 because `<br/>` was not marked as html_safe.

@projecthydra-labs/hyrax-code-reviewers
