### PR TITLE
Refactor FileSetAttachedEventJob

### DIFF
--- a/app/jobs/file_set_attached_event_job.rb
+++ b/app/jobs/file_set_attached_event_job.rb
@@ -7,10 +7,26 @@ class FileSetAttachedEventJob < ContentEventJob
   end
 
   def action
-    "User #{link_to_profile depositor} has attached #{link_to repo_object.title.first, polymorphic_path(repo_object)} to #{link_to curation_concern.title.first, polymorphic_path(curation_concern)}"
+    "User #{link_to_profile depositor} has attached #{file_link} to #{work_link}"
   end
 
   private
+
+    def file_link
+      link_to file_title, polymorphic_path(repo_object)
+    end
+
+    def work_link
+      link_to work_title, polymorphic_path(curation_concern)
+    end
+
+    def file_title
+      repo_object.title.first
+    end
+
+    def work_title
+      curation_concern.title.first
+    end
 
     def curation_concern
       repo_object.in_works.first


### PR DESCRIPTION
This should enable us to see which object was nil with respect to
https://github.com/projecthydra-labs/hyku/issues/521
