### PR TITLE
Provide an exception when the response is malformed

### DIFF
--- a/app/services/hyrax/statistics/depositors/summary.rb
+++ b/app/services/hyrax/statistics/depositors/summary.rb
@@ -18,6 +18,7 @@ module Hyrax
           # step through the array by twos to get each pair
           results.map do |key, deposits|
             user = ::User.find_by_user_key(key)
+            raise "Unable to find user '#{key}'\nResults was: #{results.inspect}" unless user
             { key: key, deposits: deposits, user: user }
           end
         end

--- a/app/views/hyrax/admin/stats/_deposits.html.erb
+++ b/app/views/hyrax/admin/stats/_deposits.html.erb
@@ -3,8 +3,7 @@
   <% @presenter.depositors.each do |usr| %>
     <li>
       <a href="<%= hyrax.profile_path(usr[:key]) %>" title="View user's profile"><%= usr[:user].name %></a>
-      <% num_files = usr[:deposits]%>
-      deposited <%= pluralize(num_files, "file") %>
+      deposited <%= pluralize(usr[:deposits], "file") %>
     </li>
   <% end %>
 </ul>

--- a/spec/services/hyrax/statistics/depositors/summary_spec.rb
+++ b/spec/services/hyrax/statistics/depositors/summary_spec.rb
@@ -35,6 +35,16 @@ describe Hyrax::Statistics::Depositors::Summary do
                                         { key: user2.user_key, deposits: 1, user: user2 }]
       end
     end
+
+    context "when a depositor is not found" do
+      before do
+        allow(service).to receive(:results).and_return('bob' => '')
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error "Unable to find user 'bob'\nResults was: {\"bob\"=>\"\"}"
+      end
+    end
   end
 
   describe "#query" do


### PR DESCRIPTION
We had an exception where the user was nil.  This change traps for that
situation and provides an earlier exception with some logging.

Ref https://github.com/projecthydra-labs/hyku/issues/698
