### PR TITLE
Mark flash notices as safe using view context

### DIFF
--- a/app/controllers/concerns/hyrax/batch_uploads_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/batch_uploads_controller_behavior.rb
@@ -21,7 +21,8 @@ module Hyrax
       raise CanCan::AccessDenied, "Cannot create an object of class '#{unsafe_pc}'" unless safe_pc
       # authorize! :create, safe_pc
       create_update_job(safe_pc)
-      flash[:notice] = t('hyrax.works.new.after_create_html', application_name: view_context.application_name)
+      # Calling `#t` in a controller context does not mark _html keys as html_safe
+      flash[:notice] = view_context.t('hyrax.works.new.after_create_html', application_name: view_context.application_name)
       redirect_after_update
     end
 

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -37,7 +37,8 @@ module Hyrax
       def after_create_response
         respond_to do |wants|
           wants.html do
-            flash[:notice] = t('hyrax.works.new.after_create_html', application_name: view_context.application_name)
+            # Calling `#t` in a controller context does not mark _html keys as html_safe
+            flash[:notice] = view_context.t('hyrax.works.new.after_create_html', application_name: view_context.application_name)
             redirect_to [main_app, curation_concern]
           end
           wants.json { render :show, status: :created, location: polymorphic_path([main_app, curation_concern]) }

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -244,6 +244,7 @@ describe Hyrax::GenericWorksController do
           },
           uploaded_files: ['777', '888']
         }
+        expect(flash[:notice]).to be_html_safe
         expect(flash[:notice]).to eq "Your files are being processed by Hyrax in the background. The metadata and access controls you specified are being applied. Files will be marked <span class=\"label label-danger\" title=\"Private\">Private</span> until this process is complete (shouldn't take too long, hang in there!). You may need to refresh this page to see these updates."
         expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
       end


### PR DESCRIPTION
Fixes projecthydra-labs/hyku#694. Follows #315, which fixed one part of the problem but not all of it.

Using i18n _html-suffixed keys does not automatically mark strings as html_safe in the controller context, so use the view context to achieve the same effect. HT to @jcoyne.

@projecthydra-labs/hyrax-code-reviewers
