### PR TITLE
AdminSetSearch builder matches AdminSets with group access

### DIFF
--- a/app/search_builders/hyrax/admin_set_search_builder.rb
+++ b/app/search_builders/hyrax/admin_set_search_builder.rb
@@ -4,6 +4,8 @@ module Hyrax
     # This skips the filter added by FilterSuppressed
     self.default_processor_chain -= [:only_active_works]
 
+    # @param [#repository,#blacklight_config,#current_ability] context
+    # @param [Symbol] access one of :edit, :read, or :deposit
     def initialize(context, access)
       @access = access
       super(context)
@@ -23,7 +25,9 @@ module Hyrax
       end
     end
 
-    # We're going to check the permission_templates
+    # If :deposit access is requested, check to see which admin sets the user has
+    # deposit or manage access to.
+    # @return [Array<String>] a list of filters to apply to the solr query
     def gated_discovery_filters
       return super if @access != :deposit
       ["{!terms f=id}#{admin_set_ids.join(',')}"]
@@ -38,7 +42,12 @@ module Hyrax
                                 .where(agent_type: 'user',
                                        agent_id: user,
                                        access: ['deposit', 'manage'])
-                                .pluck('DISTINCT admin_set_id')
+                                .or(
+                                  PermissionTemplateAccess.joins(:permission_template)
+                                                          .where(agent_type: 'group',
+                                                                 agent_id: current_ability.user_groups,
+                                                                 access: ['deposit', 'manage'])
+                                ).pluck('DISTINCT admin_set_id')
       end
 
       def user


### PR DESCRIPTION
Previously you could only choose an admin set that you had been granted
access to as a user. Now it can check for group membership as well.
This affects the admin set dropdown on the create work form.
