### PR TITLE
Adding documentation concerning permission template and admin set

### DIFF
--- a/app/actors/hyrax/apply_permission_template_actor.rb
+++ b/app/actors/hyrax/apply_permission_template_actor.rb
@@ -1,4 +1,6 @@
 module Hyrax
+  # Responsible for "applying" the various edit and read attributes to the given curation concern.
+  # @see Hyrax::AdminSetService for release_date interaction
   class ApplyPermissionTemplateActor < Hyrax::Actors::AbstractActor
     def create(attributes)
       add_edit_users(attributes)

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -45,6 +45,7 @@ module Hyrax
       end
 
       def workflows
+        # TODO: Scope the workflows only to admin sets see https://github.com/projecthydra-labs/hyrax/issues/256
         Sipity::Workflow.all
       end
 

--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -1,3 +1,5 @@
+# There is an interplay between an AdminSet and a PermissionTemplate.
+# @see Hyrax::AdminSetBehavior for further discussion
 class AdminSet < ActiveFedora::Base
   include Hyrax::AdminSetBehavior
 end

--- a/app/models/concerns/hyrax/admin_set_behavior.rb
+++ b/app/models/concerns/hyrax/admin_set_behavior.rb
@@ -1,4 +1,22 @@
 module Hyrax
+  # There is an interplay between an AdminSet and a PermissionTemplate. Given
+  # that AdminSet is an ActiveFedora::Base and PermissionTemplate is ActiveRecord::Base
+  # we don't have the usual :has_many or :belongs_to methods to assist in defining that
+  # relationship. However, from a conceptual standpoint:
+  #
+  # * An AdminSet has_one :permission_tempate
+  # * A PermissionTemplate belongs_to :admin_set
+  #
+  # When an object is added as a member of an AdminSet, the AdminSet's associated
+  # PermissionTemplate is applied to that object (e.g. some of the object's attributes
+  # are updated as per the rules of the permission template)
+  #
+  # @see AdminSet
+  # @see Hyrax::PermissionTemplate
+  # @see Hyrax::AdminSetService
+  # @see Hyrax::Forms::PermissionTemplateForm for validations and creation process
+  # @see Hyrax::DefaultAdminSetActor
+  # @see Hyrax::ApplyPermissionTemplateActor  module AdminSetBehavior
   module AdminSetBehavior
     extend ActiveSupport::Concern
 

--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -1,4 +1,12 @@
 module Hyrax
+  # Defines behavior that is applied to objects added as members of an AdminSet
+  #
+  #  * access rights to stamp on each object
+  #  * calculate embargo/lease release dates
+  #
+  # There is an interplay between an AdminSet and a PermissionTemplate.
+  #
+  # @see Hyrax::AdminSetBehavior for further discussion
   class PermissionTemplate < ActiveRecord::Base
     self.table_name = 'permission_templates'
 
@@ -53,6 +61,7 @@ module Hyrax
     # Override release_date getter to return a dynamically calculated date of release
     # based one release requirements. Returns embargo date when release_max_embargo?==true.
     # Returns today's date when release_no_delay?==true.
+    # @see Hyrax::AdminSetService for usage
     def release_date
       # If no release delays allowed, return today's date as release date
       return Time.zone.today if release_no_delay?

--- a/app/services/hyrax/admin_set_service.rb
+++ b/app/services/hyrax/admin_set_service.rb
@@ -57,6 +57,7 @@ module Hyrax
       def data_attributes(admin_set)
         attrs = {}
         # Get permission template associated with this AdminSet (if any)
+        # TODO: Should this be a `find_by!` as per https://github.com/projecthydra-labs/hyrax/issues/256
         permission_template = PermissionTemplate.find_by(admin_set_id: admin_set.id)
 
         # Only add data attributes if permission template exists


### PR DESCRIPTION
## Adding a TODO note concenring 256

@38846b5ac1ac57e843456691bab952edc6e0abfd


## Updating AdminSet documentation

@eb70dc52b71fb6d70ec73304fde3fa875e0ba7e2

This is an effort to help explain the relation between AdminSet and
PermissionTemplate. It also incorporates documentation related to
services, actors, and forms that directly relate to the AdminSet and
PermissionTemplate.
