### PR TITLE
Adding methods to reflect relationship

### DIFF
--- a/app/actors/hyrax/actors/interpret_visibility_actor.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor.rb
@@ -96,7 +96,7 @@ module Hyrax
         # Validate against selected AdminSet's PermissionTemplate (if any)
         def validate(attributes)
           # If AdminSet was selected, look for its PermissionTemplate
-          template = PermissionTemplate.find_by(admin_set_id: attributes[:admin_set_id]) if attributes[:admin_set_id].present?
+          template = PermissionTemplate.find_by!(admin_set_id: attributes[:admin_set_id]) if attributes[:admin_set_id].present?
 
           validate_lease(template) && validate_release_type(template) && validate_visibility(attributes, template) && validate_embargo(attributes, template)
         end

--- a/app/models/concerns/hyrax/admin_set_behavior.rb
+++ b/app/models/concerns/hyrax/admin_set_behavior.rb
@@ -48,5 +48,12 @@ module Hyrax
     def to_s
       title.present? ? title : 'No Title'
     end
+
+    # A bit of an analogue for a `has_one :admin_set` as it crosses from Fedora to the DB
+    # @return [Hyrax::PermissionTemplate]
+    # @raise [ActiveRecord::RecordNotFound]
+    def permission_template
+      Hyrax::PermissionTemplate.find_by!(admin_set_id: id)
+    end
   end
 end

--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -13,6 +13,13 @@ module Hyrax
     has_many :access_grants, class_name: 'Hyrax::PermissionTemplateAccess'
     accepts_nested_attributes_for :access_grants, reject_if: :all_blank
 
+    # A bit of an analogue for a `belongs_to :admin_set` as it crosses from Fedora to the DB
+    # @return [AdminSet]
+    # @raise [ActiveFedora::ObjectNotFoundError] when the we cannot find the AdminSet
+    def admin_set
+      AdminSet.find(admin_set_id)
+    end
+
     # Valid Release Period values
     RELEASE_TEXT_VALUE_FIXED = 'fixed'.freeze
     RELEASE_TEXT_VALUE_NO_DELAY = 'now'.freeze

--- a/app/services/hyrax/admin_set_service.rb
+++ b/app/services/hyrax/admin_set_service.rb
@@ -56,18 +56,12 @@ module Hyrax
       # later utilized by Javascript to limit new Work options based on AdminSet selected
       def data_attributes(admin_set)
         attrs = {}
-        # Get permission template associated with this AdminSet (if any)
-        # TODO: Should this be a `find_by!` as per https://github.com/projecthydra-labs/hyrax/issues/256
-        permission_template = PermissionTemplate.find_by(admin_set_id: admin_set.id)
 
-        # Only add data attributes if permission template exists
-        if permission_template
-          # Save all PermissionTemplate release & visibility data attributes (if not blank or false)
-          attrs['data-release-date'] = permission_template.release_date unless permission_template.release_date.blank?
-          attrs['data-release-before-date'] = true if permission_template.release_before_date?
-          attrs['data-visibility'] = permission_template.visibility unless permission_template.visibility.blank?
-        end
-
+        permission_template = PermissionTemplate.find_by!(admin_set_id: admin_set.id)
+        # Leverage all PermissionTemplate release & visibility data attributes (if not blank or false)
+        attrs['data-release-date'] = permission_template.release_date unless permission_template.release_date.blank?
+        attrs['data-release-before-date'] = true if permission_template.release_before_date?
+        attrs['data-visibility'] = permission_template.visibility unless permission_template.visibility.blank?
         attrs
       end
   end

--- a/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
+++ b/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
@@ -111,6 +111,7 @@ describe Hyrax::Actors::InterpretVisibilityActor do
         end
 
         it "returns false and logs error on date field" do
+          permission_template # Ensuring permission_template is loaded
           expect(subject.create(attributes)).to be false
           expect(subject.curation_concern.errors[:embargo_release_date].first).to eq 'Must be a future date.'
         end
@@ -126,8 +127,8 @@ describe Hyrax::Actors::InterpretVisibilityActor do
 
       context "embargo with missing embargo date" do
         let(:attributes) { { title: ['New embargo'], admin_set_id: admin_set.id, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO } }
-
         it "returns false and logs error on visibility field" do
+          permission_template # Ensuring permission_template is loaded
           expect(subject.create(attributes)).to be false
           expect(subject.curation_concern.errors[:visibility].first).to eq 'When setting visibility to "embargo" you must also specify embargo release date.'
         end

--- a/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
@@ -13,7 +13,11 @@ RSpec.describe Hyrax::Admin::PermissionTemplatesController do
       let(:admin_set) { create(:admin_set) }
       let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id) }
       it "is unauthorized" do
-        put :update, params: { id: '888', admin_set_id: admin_set }
+        # This spec was not firing as expected. It was getting a nil permission template. This mock expectation is a bit
+        # odd, but it needs to go rather deep into CanCan to behave accordingly.
+        allow(controller.current_ability).to receive(:can?).with(:update, permission_template).and_return(false)
+        put :update, params: { id: permission_template, admin_set_id: permission_template.admin_set_id }
+        expect(assigns(:permission_template)).to eq(permission_template)
         expect(response).to be_unauthorized
       end
     end

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe AdminSet, type: :model do
     subject.title = ['Some title']
   end
 
+  describe '#permission_template' do
+    it 'queries for a Hyrax::PermissionTemplate with a matching admin_set_id' do
+      admin_set = build(:admin_set, id: '123')
+      permission_template = build(:permission_template)
+      expect(Hyrax::PermissionTemplate).to receive(:find_by!).with(admin_set_id: '123').and_return(permission_template)
+      expect(admin_set.permission_template).to eq(permission_template)
+    end
+  end
+
   describe "#to_solr" do
     let(:admin_set) do
       build(:admin_set, title: ['A good title'],

--- a/spec/models/hyrax/permission_template_spec.rb
+++ b/spec/models/hyrax/permission_template_spec.rb
@@ -1,7 +1,14 @@
 describe Hyrax::PermissionTemplate do
   let(:admin_set) { create(:admin_set) }
   let(:permission_template) { described_class.new(attributes) }
-  let(:attibutes) { { admin_set_id: admin_set.id } }
+  let(:attributes) { { admin_set_id: admin_set.id } }
+
+  describe "#admin_set" do
+    it 'leverages AdminSet.find for the given permission_template' do
+      expect(AdminSet).to receive(:find).with(permission_template.admin_set_id).and_return(admin_set)
+      expect(permission_template.admin_set).to eq(admin_set)
+    end
+  end
 
   describe "#release_fixed_date?" do
     subject { permission_template.release_fixed_date? }

--- a/spec/services/hyrax/admin_set_service_spec.rb
+++ b/spec/services/hyrax/admin_set_service_spec.rb
@@ -125,46 +125,22 @@ RSpec.describe Hyrax::AdminSetService do
 
     context "with empty permission_template" do
       let(:solr_doc1) { instance_double(SolrDocument, id: '123', to_s: 'Empty Template Set') }
-      let!(:permission_template1) { create(:permission_template, admin_set_id: '567') }
+      let!(:permission_template1) { create(:permission_template, admin_set_id: solr_doc1.id) }
 
       before do
-        allow(service).to receive(:search_results)
-          .with(:read)
-          .and_return([solr_doc1])
+        allow(service).to receive(:search_results).with(:read).and_return([solr_doc1])
       end
 
       it { is_expected.to eq [['Empty Template Set', '123', {}]] }
     end
 
     context "with no permission_template" do
-      context "with default (read) access" do
-        subject { service.select_options }
-        let(:solr_doc1) { instance_double(SolrDocument, id: '123', to_s: 'foo') }
-        let(:solr_doc2) { instance_double(SolrDocument, id: '234', to_s: 'bar') }
-        let(:solr_doc3) { instance_double(SolrDocument, id: '345', to_s: 'baz') }
-
-        before do
-          allow(service).to receive(:search_results)
-            .with(:read)
-            .and_return([solr_doc1, solr_doc2, solr_doc3])
-        end
-
-        it do
-          is_expected.to eq [['foo', '123', {}],
-                             ['bar', '234', {}],
-                             ['baz', '345', {}]]
-        end
+      let(:solr_doc1) { instance_double(SolrDocument, id: '123', to_s: 'foo') }
+      before do
+        allow(service).to receive(:search_results).with(:read).and_return([solr_doc1])
       end
-
-      context "with explicit edit access" do
-        subject { service.select_options(:edit) }
-        let(:solr_doc) { instance_double(SolrDocument, id: '123', to_s: 'baz') }
-
-        before do
-          allow(service).to receive(:search_results).with(:edit).and_return([solr_doc])
-        end
-
-        it { is_expected.to eq [['baz', '123', {}]] }
+      it 'will an raise exception' do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end


### PR DESCRIPTION
## Adding methods to reflect relationship

@d4e265115fbc5548999e6daf4ca4f0a7ffa0bcd9

There is a one-to-one relationship between Hyrax::PermissionTemplate
and AdminSet. However, in our modeling, we don't have an easy macro to
designate this relationship.

Related to #256

## Cleaning up a spec that happened to behave

@073e232cb11b1e51197a92b5a1713b01b5b37fe7

Prior to this commit, the `#find_by` was returning nil. And according
to CanCan `can?(:update, nil)` will always be `false`. Thus it behaved
as though the person didn't have permission.

This change does two things:

1) Enforces that an AdminSet has a PermissionTemplate (via `find_by!`)
2) Updates the test to reflect that the permission_set must be found
  for the given admin_set
  * Asserting that the permission_set is assigned in the controller
  * Also assigning the admin_set_id to the created permission set.

If I had added the `expect(assigns(:permission_set))` assertion, prior
to changing to `find_by!` the test would have failed.

Related to #256

## Ensuring that AdminSet has PermissionTemplate

@7ff74090652157affe20e689d16deb921f7bc845

The before blocks ensure that the permission_template is created before
we begin the request. Without those blocks, the specs fail as the lazy
load of `permission_template` does not fire during setup

Related to #256

## Enforcing AdminSet has_one PermissionTemplate

@cd7188a5b0acf57cf514942ed2ff23d6649ba718

This cleans up a bit of the extra scenarios, embracing the conceptual
idea that each AdminSet has one and only one PermissionTemplate and
that each PermissionTemplate must belong to one AdminSet.

Related to #256
