### PR TITLE
Grant required workflow roles to AdminSet managers

### DIFF
--- a/app/forms/hyrax/forms/widgets/admin_set_embargo_period.rb
+++ b/app/forms/hyrax/forms/widgets/admin_set_embargo_period.rb
@@ -1,0 +1,16 @@
+module Hyrax
+  module Forms
+    module Widgets
+      class AdminSetEmbargoPeriod
+        # Visibility options for permission templates
+        def options
+          i18n_prefix = "hyrax.admin.admin_sets.form_visibility.release.varies.embargo"
+          [[Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_6_MONTHS, I18n.t('.6mos', scope: i18n_prefix)],
+           [Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_1_YEAR, I18n.t('.1yr', scope: i18n_prefix)],
+           [Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_2_YEARS, I18n.t('.2yrs', scope: i18n_prefix)],
+           [Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_3_YEARS, I18n.t('.3yrs', scope: i18n_prefix)]]
+        end
+      end
+    end
+  end
+end

--- a/app/forms/hyrax/forms/widgets/admin_set_visibility.rb
+++ b/app/forms/hyrax/forms/widgets/admin_set_visibility.rb
@@ -1,0 +1,17 @@
+module Hyrax
+  module Forms
+    module Widgets
+      class AdminSetVisibility
+        # Visibility options for permission templates
+        def options
+          i18n_prefix = "hyrax.admin.admin_sets.form_visibility.visibility"
+          # Note: Visibility 'varies' = '' implies no constraints
+          [[Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, I18n.t('.everyone', scope: i18n_prefix)],
+           ['', I18n.t('.varies', scope: i18n_prefix)],
+           [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, I18n.t('.institution', scope: i18n_prefix)],
+           [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, I18n.t('.restricted', scope: i18n_prefix)]]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When changing a workflow for an AdminSet, the managers of the
AdminSet should be granted all roles for the new workflow.

Fixes #336
