### PR TITLE
Adds file count to admin sets on admin dash.

### DIFF
--- a/app/views/hyrax/admin/_collections.html.erb
+++ b/app/views/hyrax/admin/_collections.html.erb
@@ -13,6 +13,7 @@
             <tr>
               <th><%= t('.collection') %></th>
               <th><%= t('.works') %></th>
+              <th><%= t('.files') %></th>
             </tr>
           </thead>
           <tbody>
@@ -20,6 +21,7 @@
               <tr>
                 <td><%= row.first %></td>
                 <td><%= row.second %></td>
+                <td><%= row.third %></td>
               </tr>
             <% end %>
           </tbody>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -109,6 +109,7 @@ en:
         subtitle:           "Recent collection activity"
         title:              "Collections"
         works:              "Works"
+        files:              "Files"
       show:
         new_visitors:       "New Visitors"
         registered_users:   "Registered users"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -109,6 +109,7 @@ es:
         subtitle:           "Actividad reciente de la colección"
         title:              "Colleccións"
         works:              "Trabajos"
+        files:              "Archivos"
       show:
         new_visitors:       "Nuevos visitantes"
         registered_users:   "Usuarios registrados"

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe "The admin dashboard" do
+  let(:user) { create :admin }
+  let(:admin_set_1) do
+    create(:admin_set, title: ["First Admin Set"],
+                       description: ["A description"],
+                       edit_users: [user.user_key])
+  end
+  let(:admin_set_2) do
+    create(:admin_set, title: ["Second Admin Set"],
+                       description: ["A description"],
+                       edit_users: [user.user_key])
+  end
+
+  before do
+    create(:work_with_two_children, title: ["Work A"], admin_set_id: admin_set_1.id, edit_users: [user])
+    create(:work_with_one_child, title: ["Work B"], admin_set_id: admin_set_2.id, edit_users: [user])
+    create(:work_with_two_children, title: ["Work C"], admin_set_id: admin_set_2.id, edit_users: [user])
+  end
+
+  scenario do
+    login_as(user, scope: :user)
+    visit '/admin'
+
+    expect(find('tr', text: 'First Admin Set').find('td:eq(2)')).to have_content(1)
+    expect(find('tr', text: 'First Admin Set').find('td:eq(3)')).to have_content(2)
+
+    expect(find('tr', text: 'Second Admin Set').find('td:eq(2)')).to have_content(2)
+    expect(find('tr', text: 'Second Admin Set').find('td:eq(3)')).to have_content(3)
+  end
+end

--- a/spec/services/hyrax/admin_set_service_spec.rb
+++ b/spec/services/hyrax/admin_set_service_spec.rb
@@ -56,13 +56,29 @@ RSpec.describe Hyrax::AdminSetService do
     let(:doc3) { SolrDocument.new(id: 'zxy123') }
     let(:connection) { instance_double(RSolr::Client) }
     let(:results) do
-      { 'facet_counts' =>
-        {
-          'facet_fields' =>
-            {
-              'isPartOf_ssim' => [doc1.id, 8, doc2.id, 2]
-            }
-        } }
+      {
+        'response' =>
+          {
+            'docs' =>
+              [
+                {
+                  'isPartOf_ssim' => ['xyz123'],
+                  'file_set_ids_ssim' => ['aaa']
+                },
+                {
+                  'isPartOf_ssim' => ['xyz123', 'yyx123'],
+                  'file_set_ids_ssim' => ['bbb', 'ccc']
+                }
+              ]
+          },
+        'facet_counts' =>
+          {
+            'facet_fields' =>
+              {
+                'isPartOf_ssim' => [doc1.id, 8, doc2.id, 2]
+              }
+          }
+      }
     end
 
     before do
@@ -72,8 +88,8 @@ RSpec.describe Hyrax::AdminSetService do
                                                                   "facet.field" => "isPartOf_ssim" }).and_return(results)
     end
 
-    it "returns rows with document in the first column and integer count value in the second column" do
-      expect(subject).to eq [[doc1, 8], [doc2, 2], [doc3, 0]]
+    it "returns rows with document in the first column and integer count value in the second and third column" do
+      expect(subject).to eq [[doc1, 8, 3], [doc2, 2, 2], [doc3, 0, 0]]
     end
   end
 


### PR DESCRIPTION
Fixes #241 

Adds files count to administration dashboard under collections.

Accomplished by counting the file sets from the Solr query that identities the number of works in a admin set. Includes English and Spanish locales for column label.

@projecthydra-labs/hyrax-code-reviewers
