### PR TITLE
Allow admin set deletion if empty and NOT default set

### DIFF
--- a/app/actors/hyrax/default_admin_set_actor.rb
+++ b/app/actors/hyrax/default_admin_set_actor.rb
@@ -21,22 +21,20 @@ module Hyrax
         attributes[:admin_set_id] = default_admin_set_id
       end
 
-      DEFAULT_ID = 'admin_set/default'.freeze
-
       def default_admin_set_id
         create_default_admin_set unless default_exists?
-        DEFAULT_ID
+        AdminSet::DEFAULT_ID
       end
 
       def default_exists?
-        AdminSet.exists?(DEFAULT_ID)
+        AdminSet.exists?(AdminSet::DEFAULT_ID)
       end
 
       # Creates the default AdminSet and an associated PermissionTemplate with workflow
       # rubocop:disable Lint/HandleExceptions
       def create_default_admin_set
-        AdminSet.create!(id: DEFAULT_ID, title: ['Default Admin Set']).tap do |_as|
-          PermissionTemplate.create!(admin_set_id: DEFAULT_ID)
+        AdminSet.create!(id: AdminSet::DEFAULT_ID, title: ['Default Admin Set']).tap do |_as|
+          PermissionTemplate.create!(admin_set_id: AdminSet::DEFAULT_ID)
         end
       rescue ActiveFedora::IllegalOperation
         # It is possible that another thread created the AdminSet just before this method

--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -66,8 +66,11 @@ module Hyrax
     end
 
     def destroy
-      @admin_set.destroy
-      redirect_to hyrax.admin_admin_sets_path, notice: t(:'hyrax.admin.admin_sets.delete.notification')
+      if @admin_set.destroy
+        redirect_to hyrax.admin_admin_sets_path, notice: t(:'hyrax.admin.admin_sets.delete.notification')
+      else
+        redirect_to hyrax.admin_admin_set_path(@admin_set), alert: @admin_set.errors.full_messages.to_sentence
+      end
     end
 
     # for the AdminSetService

--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -3,5 +3,16 @@ module Hyrax
     def total_items
       ActiveFedora::SolrService.count("{!field f=isPartOf_ssim}#{id}")
     end
+
+    # AdminSet cannot be deleted if default set or non-empty
+    def disable_delete?
+      AdminSet.default_set?(id) || total_items > 0
+    end
+
+    # Message to display if deletion is disabled
+    def disabled_message
+      return I18n.t('hyrax.admin.admin_sets.delete.error_default_set') if AdminSet.default_set?(id)
+      return I18n.t('hyrax.admin.admin_sets.delete.error_not_empty') if total_items > 0
+    end
   end
 end

--- a/app/views/hyrax/admin/admin_sets/show.html.erb
+++ b/app/views/hyrax/admin/admin_sets/show.html.erb
@@ -11,8 +11,16 @@
           <%= link_to edit_admin_admin_set_path(@presenter), class: 'btn btn-primary' do %>
             <span class="fa fa-edit"></span> <%= t(:'helpers.action.edit') %>
           <% end %>
-          <%= link_to admin_admin_set_path(@presenter), class: 'btn btn-danger', data: { confirm: t('.confirm_delete'), method: :delete } do %>
-            <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
+          <% if @presenter.disable_delete? %>
+            <span title="<%= @presenter.disabled_message %>">
+              <%= link_to admin_admin_set_path(@presenter), class: 'btn btn-danger disabled' do %>
+                <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
+              <% end %>
+            </span>
+          <% else %>
+            <%= link_to admin_admin_set_path(@presenter), class: 'btn btn-danger', data: { confirm: t('.confirm_delete'), method: :delete } do %>
+              <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -43,7 +43,9 @@ en:
     admin:
       admin_sets:
         delete:
-          notification:   "Administrative set successfully deleted"
+          error_default_set: "Administrative set cannot be deleted as it is the default set"
+          error_not_empty:   "Administrative set cannot be deleted as it is not empty"
+          notification:      "Administrative set successfully deleted"
         edit:
           header:         "Edit Administrative Set"
         form:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -43,7 +43,9 @@ es:
     admin:
       admin_sets:
         delete:
-          notification:   "Conjunto administrativo eliminado correctamente"
+          error_default_set: "El conjunto administrativo no se puede eliminar ya que es el conjunto predeterminado"
+          error_not_empty:   "El conjunto administrativo no se puede eliminar ya que no está vacío"
+          notification:      "Conjunto administrativo eliminado correctamente"
         edit:
           header:         "Editar Conjunto Administrativo"
         form:

--- a/spec/actors/hyrax/default_admin_set_actor_spec.rb
+++ b/spec/actors/hyrax/default_admin_set_actor_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Hyrax::DefaultAdminSetActor do
 
     context "when admin_set_id is blank" do
       let(:attributes) { { admin_set_id: '' } }
-      let(:default_id) { described_class::DEFAULT_ID }
+      let(:default_id) { AdminSet::DEFAULT_ID }
 
       it "creates the default AdminSet with a PermissionTemplate and calls the next actor with the default admin set id" do
         expect(next_actor).to receive(:create).with(admin_set_id: default_id).and_return(true)
@@ -46,7 +46,7 @@ RSpec.describe Hyrax::DefaultAdminSetActor do
     let(:actor) { described_class.new(double, double, double) }
     context "when another thread has already created the admin set" do
       before do
-        AdminSet.create!(id: described_class::DEFAULT_ID, title: ['Default Admin Set'])
+        AdminSet.create!(id: AdminSet::DEFAULT_ID, title: ['Default Admin Set'])
       end
       it "doesn't raise an error" do
         expect { actor.send(:create_default_admin_set) }.not_to raise_error

--- a/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
@@ -123,26 +123,41 @@ describe Hyrax::Admin::AdminSetsController do
 
     describe "#destroy" do
       let(:admin_set) { create(:admin_set, edit_users: [user]) }
+
       context "with empty admin set" do
         it "deletes the admin set" do
           delete :destroy, params: { id: admin_set }
           expect(response).to have_http_status(:found)
           expect(response).to redirect_to(admin_admin_sets_path)
           expect(flash[:notice]).to eq "Administrative set successfully deleted"
+          expect(AdminSet.exists?(admin_set.id)).to be false
         end
       end
+
       context "with a non-empty admin set" do
         let(:work) { create(:generic_work, user: user) }
         before do
           admin_set.members << work
           admin_set.reload
         end
-        it "detaches the works and deletes the admin set" do
+        it "doesn't delete the admin set (or work)" do
           delete :destroy, params: { id: admin_set }
           expect(response).to have_http_status(:found)
-          expect(response).to redirect_to(admin_admin_sets_path)
-          expect(flash[:notice]).to eq "Administrative set successfully deleted"
+          expect(response).to redirect_to(admin_admin_set_path(admin_set))
+          expect(flash[:alert]).to eq "Administrative set cannot be deleted as it is not empty"
+          expect(AdminSet.exists?(admin_set.id)).to be true
           expect(GenericWork.exists?(work.id)).to be true
+        end
+      end
+
+      context "with the default admin set" do
+        let(:admin_set) { create(:admin_set, edit_users: [user], id: AdminSet::DEFAULT_ID) }
+        it "doesn't delete the admin set" do
+          delete :destroy, params: { id: admin_set }
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(admin_admin_set_path(admin_set))
+          expect(flash[:alert]).to eq "Administrative set cannot be deleted as it is the default set"
+          expect(AdminSet.exists?(admin_set.id)).to be true
         end
       end
     end

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -76,16 +76,60 @@ RSpec.describe AdminSet, type: :model do
     expect(subject.reload.description).to eq ["description"]
   end
 
-  describe "#destroy" do
-    before do
-      subject.members = [gf1, gf2]
-      subject.save
-      subject.destroy
+  describe "#default_set?" do
+    context "with default AdminSet ID" do
+      it "returns true" do
+        expect(AdminSet.default_set?(described_class::DEFAULT_ID)).to be true
+      end
     end
 
-    it "does not delete member files when deleted" do
-      expect(GenericWork.exists?(gf1.id)).to be true
-      expect(GenericWork.exists?(gf2.id)).to be true
+    context "with a non-default  ID" do
+      it "returns false" do
+        expect(AdminSet.default_set?('different-id')).to be false
+      end
+    end
+  end
+
+  describe "#destroy" do
+    context "with member works" do
+      before do
+        subject.members = [gf1, gf2]
+        subject.save!
+        subject.destroy
+      end
+
+      it "does not delete adminset or member works" do
+        expect(subject.errors.full_messages).to eq ["Administrative set cannot be deleted as it is not empty"]
+        expect(AdminSet.exists?(subject.id)).to be true
+        expect(GenericWork.exists?(gf1.id)).to be true
+        expect(GenericWork.exists?(gf2.id)).to be true
+      end
+    end
+
+    context "with no member works" do
+      before do
+        subject.members = []
+        subject.save!
+        subject.destroy
+      end
+
+      it "deletes the adminset" do
+        expect(AdminSet.exists?(subject.id)).to be false
+      end
+    end
+
+    context "is default adminset" do
+      before do
+        subject.members = []
+        subject.id = described_class::DEFAULT_ID
+        subject.save!
+        subject.destroy
+      end
+
+      it "does not delete the adminset" do
+        expect(subject.errors.full_messages).to eq ["Administrative set cannot be deleted as it is the default set"]
+        expect(AdminSet.exists?(described_class::DEFAULT_ID)).to be true
+      end
     end
   end
 end

--- a/spec/presenters/hyrax/admin_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_presenter_spec.rb
@@ -7,22 +7,52 @@ describe Hyrax::AdminSetPresenter do
           description: ['An example admin set.'],
           title: ['Example Admin Set Title'])
   end
-  let(:work) { build(:work, title: ['Example Work Title'], admin_set_id: '123') }
+
+  let(:work) { build(:work, title: ['Example Work Title']) }
   let(:solr_document) { SolrDocument.new(admin_set.to_solr) }
   let(:ability) { double }
   let(:presenter) { described_class.new(solr_document, ability) }
 
   describe "total_items" do
     subject { presenter.total_items }
+
     context "empty admin set" do
       it { is_expected.to eq 0 }
     end
+
     context "admin set with work" do
       before do
+        admin_set.members = [work]
         admin_set.save!
-        work.save!
       end
       it { is_expected.to eq 1 }
+    end
+  end
+
+  describe "disable_delete?" do
+    subject { presenter.disable_delete? }
+
+    context "empty admin set" do
+      before do
+        admin_set.members = []
+        admin_set.save!
+      end
+      it { is_expected.to be false }
+    end
+
+    context "non-empty admin set" do
+      before do
+        admin_set.members = [work]
+        admin_set.save!
+      end
+      it { is_expected.to be true }
+    end
+
+    context "default admin set" do
+      let(:admin_set) do
+        build(:admin_set, id: AdminSet::DEFAULT_ID)
+      end
+      it { is_expected.to be true }
     end
   end
 end

--- a/spec/views/hyrax/admin/admin_sets/show.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/show.html.erb_spec.rb
@@ -1,0 +1,52 @@
+describe "hyrax/admin/admin_sets/show.html.erb", type: :view do
+  let(:solr_document) { SolrDocument.new(admin_set.to_solr) }
+  let(:ability) { double }
+  let(:presenter) { Hyrax::AdminSetPresenter.new(solr_document, ability) }
+  before do
+    # Stub route because view specs don't handle engine routes
+    allow(view).to receive(:edit_admin_admin_set_path).and_return("/admin/admin_sets/123/edit")
+    allow(view).to receive(:admin_admin_set_path).and_return("/admin/admin_sets/123")
+
+    stub_template '_collection_description.html.erb' => ''
+    stub_template '_show_descriptions.erb' => ''
+    stub_template '_sort_and_per_page.html.erb' => 'sort and per page'
+    stub_template '_document_list.html.erb' => 'document list'
+    stub_template '_paginate.html.erb' => 'paginate'
+
+    assign(:presenter, presenter)
+  end
+
+  context "with non-empty admin set" do
+    let(:admin_set) { build(:admin_set, id: '123') }
+    let(:work) { build(:work, title: ['Example Work Title']) }
+    before do
+      admin_set.members = [work]
+      admin_set.save!
+      render
+    end
+    it "displays a disabled delete button" do
+      expect(rendered).to have_selector(:css, "a.btn-danger.disabled")
+    end
+  end
+
+  context "with empty admin set" do
+    let(:admin_set) { build(:admin_set, id: '345') }
+    before do
+      render
+    end
+    it "displays an enabled delete button" do
+      expect(rendered).to have_selector(:css, "a.btn-danger")
+      expect(rendered).not_to have_selector(:css, "a.btn-danger.disabled")
+    end
+  end
+
+  context "with default admin set" do
+    let(:admin_set) { build(:admin_set, id: AdminSet::DEFAULT_ID) }
+    before do
+      render
+    end
+    it "displays a disabled delete button" do
+      expect(rendered).to have_selector(:css, "a.btn-danger.disabled")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #217 

Updates Admin Set deletion logic (from projecthydra/sufia#3041) to only allow deletion if an Admin Set has no member Works. Also ensures default admin set cannot be deleted.

- [x] Serverside validation (and specs)
- [x] Disable delete button when not allowed (and provide hover over explanation)
- [x] Default admin set cannot be deleted (id hardcoded to `admin_set/default`)
- [x] Spanish translations (using Google Translate) in `hyrax.es.yml`

@projecthydra-labs/hyrax-code-reviewers
