### PR TITLE
Ensuring User groups can be built as expected

### DIFF
--- a/lib/hyrax/collections/search_service.rb
+++ b/lib/hyrax/collections/search_service.rb
@@ -33,7 +33,7 @@ module Hyrax
         # Grant access based on user id & role
         unless @user_key.blank?
           # for roles
-          ::RoleMapper.roles(@user_key).each do |role|
+          ::User.group_service.roles(@user_key).each do |role|
             user_access_filters << "#{solr_access_control_suffix(:group)}:#{escape_slashes(role)}"
           end
           # for individual person access

--- a/spec/abilities/ability_spec.rb
+++ b/spec/abilities/ability_spec.rb
@@ -63,7 +63,7 @@ describe 'Hyrax::Ability', type: :model do
     end
 
     describe 'as admin' do
-      before { expect(RoleMapper).to receive(:byname).and_return(user.user_key => ['admin']).at_least(1).times }
+      let(:user) { create(:user, groups: ['admin']) }
       it '#admin? is true' do
         expect(ability).to be_admin
       end

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -124,7 +124,7 @@ describe Hyrax::GenericWorksController do
     end
 
     context 'when I am a repository manager' do
-      before { allow(RoleMapper).to receive(:byname).and_return(user.user_key => ['admin']) }
+      before { allow(::User.group_service).to receive(:byname).and_return(user.user_key => ['admin']) }
       let(:work) { create(:private_generic_work) }
       it 'someone elses private work should show me the page' do
         get :show, params: { id: work }
@@ -370,7 +370,7 @@ describe Hyrax::GenericWorksController do
     end
 
     context 'when I am a repository manager' do
-      before { allow(RoleMapper).to receive(:byname).and_return(user.user_key => ['admin']) }
+      before { allow(::User.group_service).to receive(:byname).and_return(user.user_key => ['admin']) }
       let(:work) { create(:private_generic_work) }
       it 'someone elses private work should show me the page' do
         get :edit, params: { id: work }
@@ -441,7 +441,7 @@ describe Hyrax::GenericWorksController do
     end
 
     context 'when I am a repository manager' do
-      before { allow(RoleMapper).to receive(:byname).and_return(user.user_key => ['admin']) }
+      before { allow(::User.group_service).to receive(:byname).and_return(user.user_key => ['admin']) }
 
       let(:work) { create(:private_generic_work) }
       it 'someone elses private work should update the work' do
@@ -491,7 +491,7 @@ describe Hyrax::GenericWorksController do
 
     context 'when I am a repository manager' do
       let(:work_to_be_deleted) { create(:private_generic_work) }
-      before { allow(RoleMapper).to receive(:byname).and_return(user.user_key => ['admin']) }
+      before { allow(::User.group_service).to receive(:byname).and_return(user.user_key => ['admin']) }
       it 'someone elses private work should delete the work' do
         delete :destroy, params: { id: work_to_be_deleted }
         expect(GenericWork).not_to exist(work_to_be_deleted.id)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,28 @@ FactoryGirl.define do
     sequence(:email) { |n| "user#{n}@example.com" }
     password 'password'
 
+    transient do
+      # Allow for custom groups when a user is instantiated.
+      # @example FactoryGirl.create(:user, groups: 'avacado')
+      groups []
+    end
+
+    # TODO: Register the groups for the given user key such that we can remove the following from other specs:
+    #   `allow(::User.group_service).to receive(:byname).and_return(user.user_key => ['admin'])``
+    after(:build) do |user, evaluator|
+      # In case we have the instance but it has not been persisted
+      ::RSpec::Mocks.allow_message(user, :groups).and_return(Array.wrap(evaluator.groups))
+      # Given that we are stubbing the class, we need to allow for the original to be called
+      ::RSpec::Mocks.allow_message(user.class.group_service, :fetch_groups).and_call_original
+      # We need to ensure that each instantiation of the admin user behaves as expected.
+      # This resolves the issue of both the created object being used as well as re-finding the created object.
+      ::RSpec::Mocks.allow_message(user.class.group_service, :fetch_groups).with(user: user).and_return(Array.wrap(evaluator.groups))
+    end
+
+    factory :admin do
+      groups ['admin']
+    end
+
     factory :user_with_mail do
       after(:create) do |user|
         # Create examples of single file successes and failures
@@ -19,14 +41,6 @@ FactoryGirl.define do
         end
         User.batch_user.send_message(user, 'These files could not be updated. You do not have sufficient privileges to edit them.', 'Batch upload permission denied', false)
         User.batch_user.send_message(user, 'These files have been saved', 'Batch upload complete', false)
-      end
-    end
-
-    factory :admin do
-      after(:build) do |user|
-        def user.groups
-          ['admin']
-        end
       end
     end
   end

--- a/spec/features/admin_admin_set_spec.rb
+++ b/spec/features/admin_admin_set_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe "The admin sets, through the admin dashboard" do
-  let(:user) { create :user }
+  let(:user) { create :admin }
   let(:admin_set) do
     create(:admin_set, title: ["A completely unique name"],
                        description: ["A substantial description"],
@@ -9,7 +9,6 @@ RSpec.describe "The admin sets, through the admin dashboard" do
   end
   before do
     Hyrax::PermissionTemplate.create!(admin_set_id: admin_set.id)
-    allow(RoleMapper).to receive(:byname).and_return(user.user_key => ['admin'])
   end
 
   scenario do

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -14,9 +14,8 @@ RSpec.feature "The homepage" do
   end
 
   context "as an admin" do
-    let(:user) { create(:user) }
+    let(:user) { create(:admin) }
     before do
-      allow(RoleMapper).to receive(:byname).and_return(user.user_key => ['admin'])
       sign_in user
       visit root_path
     end

--- a/spec/features/workflow_roles_spec.rb
+++ b/spec/features/workflow_roles_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe "Manage workflow roles", type: :feature do
-  let(:user) { create(:user) }
+  let(:user) { create(:admin) }
   let(:one_step_workflow) do
     {
       workflows: [
@@ -34,7 +34,6 @@ RSpec.describe "Manage workflow roles", type: :feature do
     }
   end
   before do
-    allow(RoleMapper).to receive(:byname).and_return(user.user_key => ['admin'])
     Hyrax::Workflow::WorkflowImporter.new(data: one_step_workflow.as_json).call
     Hyrax::Workflow::PermissionGenerator.call(roles: Sipity::Role.all,
                                               workflow: Sipity::Workflow.last,

--- a/spec/features/workflow_state_changes_spec.rb
+++ b/spec/features/workflow_state_changes_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 RSpec.describe "Workflow state changes", type: :feature do
   let(:workflow_name) { 'with_comment' }
-  let(:approving_user) { create(:user) }
-  let(:depositing_user) { create(:user) }
+  let(:approving_user) { create(:admin) }
+  let(:depositing_user) { create(:admin) }
   let(:admin_set) { create(:admin_set, edit_users: [depositing_user.user_key]) }
   let(:one_step_workflow) do
     {
@@ -32,7 +32,7 @@ RSpec.describe "Workflow state changes", type: :feature do
   let(:work) { create(:work, user: depositing_user, admin_set: admin_set) }
   let(:workflow_strategy) { double(workflow_name: workflow.name) }
   before do
-    allow(RoleMapper).to receive(:byname).and_return(depositing_user.user_key => ['admin'], approving_user.user_key => ['admin'])
+    allow(::User.group_service).to receive(:byname).and_return(depositing_user.user_key => ['admin'], approving_user.user_key => ['admin'])
     Hyrax::Workflow::WorkflowImporter.new(data: one_step_workflow.as_json).call
     Hyrax::Workflow::PermissionGenerator.call(roles: 'approving', workflow: workflow, agents: approving_user)
     # Need to instantiate the Sipity::Entity for the given work. This is necessary as I'm not creating the work via the UI.

--- a/spec/lib/hyrax/collections/search_service_spec.rb
+++ b/spec/lib/hyrax/collections/search_service_spec.rb
@@ -13,7 +13,7 @@ describe Hyrax::Collections::SearchService do
 
   describe 'apply_gated_search' do
     before do
-      allow(RoleMapper).to receive(:roles).with(login).and_return(['umg/test.group.1'])
+      allow(::User.group_service).to receive(:roles).with(login).and_return(['umg/test.group.1'])
     end
 
     let(:params) { service.apply_gated_search({}, {}) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,6 +2,37 @@ describe User, type: :model do
   let(:user) { FactoryGirl.build(:user) }
   let(:another_user) { FactoryGirl.build(:user) }
 
+  describe 'verifying factories' do
+    describe ':user' do
+      let(:user) { FactoryGirl.build(:user) }
+      it 'will, by default, have no groups' do
+        expect(user.groups).to eq([])
+        user.save!
+        # Ensuring that we can refind it and have the correct groups
+        expect(user.class.find(user.id).groups).to eq([])
+      end
+      it 'will allow for override of groups' do
+        user = FactoryGirl.build(:user, groups: 'chicken')
+        expect(user.groups).to eq(['chicken'])
+        user.save!
+        # Ensuring that we can refind it and have the correct groups
+        expect(user.class.find(user.id).groups).to eq(['chicken'])
+      end
+    end
+    describe ':admin' do
+      let(:admin_user) { FactoryGirl.create(:admin) }
+      it 'will have an "admin" group' do
+        expect(admin_user.groups).to eq(['admin'])
+      end
+      context 'when found from the database' do
+        it 'will have the expected "admin" group' do
+          refound_admin_user = described_class.find(admin_user.id)
+          expect(refound_admin_user.groups).to eq(['admin'])
+        end
+      end
+    end
+  end
+
   it "has an email" do
     expect(user.user_key).to be_kind_of String
   end


### PR DESCRIPTION
## Ensuring User groups can be built as expected

@4a52156a849ac8be5208df8672cedf6de86cc4f5

Prior to this commit the following was happening:

```ruby
admin_set = FactoryGirl.create(:admin)
admin_set.groups == ['admin']
=> true
found_admin_set = User.find(admin_set.id)
found_admin_set.groups == ['admin']
=> false
```

This is because the method redefinition was applying only to the in
memory version of the user that was being created. If we were to run
`User.find` and get back a new in-memory version, the user's `groups`
override would not be applied.

This change leverages:

* [ActiveRecord's identity][1]
* [RSpec::Mocks.allow_message][2]
* [FactoryGirl's transient attributes][3]

And with this change, we can now specify what each user's groups should
be as part of the `FactoryGirl.create` or `.build` method.

In addition this commit replaces direct reference to `::RoleMapper`
instead preferring [`::User.group_service`][4]. The change also removes
some of the now needless spec stubbing of ::RoleMapper by leveraging
the FactoryGirl stubbing that now automatically occurs.

[1]:http://api.rubyonrails.org/classes/ActiveRecord/Core.html#method-i-3D-3D
[2]:https://github.com/rspec/rspec-mocks/blob/2d67315c09e8d21a470f25d511bbdea287d89c4c/lib/rspec/mocks.rb#L57-L71
[3]:https://github.com/thoughtbot/factory_girl/blob/d42595f4696a986d626a6b84e2592e85c5bb4c4f/GETTING_STARTED.md#transient-attributes
[4]:https://github.com/projecthydra/hydra-head/blob/v10.4.0/hydra-access-controls/lib/hydra/user.rb#L8-L11
