### PR TITLE
Switch version 1.0.0.alpha

### DIFF
--- a/lib/hyrax/version.rb
+++ b/lib/hyrax/version.rb
@@ -1,3 +1,3 @@
 module Hyrax
-  VERSION = '0.0.1.alpha'.freeze
+  VERSION = '1.0.0.alpha'.freeze
 end


### PR DESCRIPTION
Now that we've decided that 1.0.0 will be the target release for sufia 7
parity/migration
