### PR TITLE
Call ingest_file synchronously (not in a job)

### DIFF
--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -19,13 +19,19 @@ module Hyrax
       # TODO: create a job to monitor this directory and prune old files that
       # have made it to the repo
       # @param [File, ActionDigest::HTTP::UploadedFile, Tempfile] file the file to save in the repository
-      def ingest_file(file)
-        IngestFileJob.perform_later(
-          file_set,
-          working_file(file),
-          user,
-          ingest_options(file)
-        )
+      # @param [Boolean] asynchronous set to true if you want to launch a new background job.
+      def ingest_file(file, asynchronous)
+        method = if asynchronous
+                   :perform_later
+                 else
+                   :perform_now
+                 end
+
+        IngestFileJob.send(method,
+                           file_set,
+                           working_file(file),
+                           user,
+                           ingest_options(file))
         true
       end
 

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -32,9 +32,11 @@ module Hyrax
         yield(file_set) if block_given?
       end
 
+      # Called from AttachFilesActor, FileSetsController, AttachFilesToWorkJob, ImportURLJob, IngestLocalFileJob
       # @param [File, ActionDigest::HTTP::UploadedFile, Tempfile] file the file uploaded by the user.
       # @param [String] relation ('original_file')
-      def create_content(file, relation = 'original_file')
+      # @param [Boolean] asynchronous (true) set to false if you don't want to launch a new background job.
+      def create_content(file, relation = 'original_file', asynchronous = true)
         # If the file set doesn't have a title or label assigned, set a default.
         file_set.label ||= file.respond_to?(:original_filename) ? file.original_filename : ::File.basename(file)
         file_set.title = [file_set.label] if file_set.title.blank?
@@ -42,7 +44,7 @@ module Hyrax
         # Need to save the file_set in order to get an id
         return false unless file_set.save
 
-        file_actor_class.new(file_set, relation, user).ingest_file(file)
+        file_actor_class.new(file_set, relation, user).ingest_file(file, asynchronous)
         true
       end
 

--- a/spec/actors/hyrax/actors/file_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_actor_spec.rb
@@ -17,16 +17,24 @@ describe Hyrax::Actors::FileActor do
       it 'calls ingest file job' do
         expect(IngestFileJob).to receive(:perform_later).with(file_set, uploaded_file.path, user, ingest_options)
         expect(Hyrax::WorkingDirectory).not_to receive(:copy_file_to_working_directory)
-        actor.ingest_file(uploaded_file)
+        actor.ingest_file(uploaded_file, true)
       end
     end
+
     context "when the file is not available locally" do
       before do
         allow(actor).to receive(:working_file).with(uploaded_file).and_return(working_file)
       end
       it 'calls ingest file job' do
         expect(IngestFileJob).to receive(:perform_later).with(file_set, /world\.png$/, user, ingest_options)
-        actor.ingest_file(uploaded_file)
+        actor.ingest_file(uploaded_file, true)
+      end
+    end
+
+    context "when performing the ingest synchronously" do
+      it 'calls ingest file job' do
+        expect(IngestFileJob).to receive(:perform_now).with(file_set, uploaded_file.path, user, ingest_options)
+        actor.ingest_file(uploaded_file, false)
       end
     end
   end


### PR DESCRIPTION
This enables the `ImportURLJob` to fetch the remote file and have it
ingested in one job (rather than 2).  If we do it in two jobs there is
the risk that the tempfile is not available to the second job if it runs
on a different machine.

Fixes https://github.com/projecthydra-labs/hyku/issues/745
