### PR TITLE
Catch ActiveFedora::IllegalOperation

### DIFF
--- a/app/actors/hyrax/default_admin_set_actor.rb
+++ b/app/actors/hyrax/default_admin_set_actor.rb
@@ -33,10 +33,16 @@ module Hyrax
       end
 
       # Creates the default AdminSet and an associated PermissionTemplate with workflow
+      # rubocop:disable Lint/HandleExceptions
       def create_default_admin_set
         AdminSet.create!(id: DEFAULT_ID, title: ['Default Admin Set']).tap do |_as|
           PermissionTemplate.create!(admin_set_id: DEFAULT_ID, workflow_name: 'default')
         end
+      rescue ActiveFedora::IllegalOperation
+        # It is possible that another thread created the AdminSet just before this method
+        # was called, so ActiveFedora will raise IllegalOperation. In this case we can safely
+        # ignore the error.
       end
+    # rubocop:enable Lint/HandleExceptions
   end
 end

--- a/spec/actors/hyrax/default_admin_set_actor_spec.rb
+++ b/spec/actors/hyrax/default_admin_set_actor_spec.rb
@@ -40,4 +40,16 @@ RSpec.describe Hyrax::DefaultAdminSetActor do
       end
     end
   end
+
+  describe "#create_default_admin_set" do
+    let(:actor) { described_class.new(double, double, double) }
+    context "when another thread has already created the admin set" do
+      before do
+        AdminSet.create!(id: described_class::DEFAULT_ID, title: ['Default Admin Set'])
+      end
+      it "doesn't raise an error" do
+        expect { actor.send(:create_default_admin_set) }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
This can occur when a different thread makes the default admin set in
between the time we check for it's existence and when we actually create
it.

Fixes https://github.com/projecthydra-labs/hyku/issues/756