### PR TITLE
Link to generic_type field

### DIFF
--- a/app/views/hyrax/users/_vitals.html.erb
+++ b/app/views/hyrax/users/_vitals.html.erb
@@ -4,12 +4,12 @@
 
 <div class="list-group-item">
   <span class="badge"><%= number_of_collections(user) %></span>
-  <span class="glyphicon glyphicon-folder-open"></span> <%= link_to_field('depositor', user.to_s, t("hyrax.dashboard.stats.collections"), human_readable_type: "Collection") %>
+  <span class="glyphicon glyphicon-folder-open"></span> <%= link_to_field('depositor', user.to_s, t("hyrax.dashboard.stats.collections"), generic_type: "Collection") %>
 </div>
 
 <div class="list-group-item">
   <span class="badge"><%= number_of_works(user) %></span>
-  <span class="glyphicon glyphicon-upload"></span> <%= link_to_field('depositor', user.to_s, t("hyrax.dashboard.stats.works"),  human_readable_type: "Work") %>
+  <span class="glyphicon glyphicon-upload"></span> <%= link_to_field('depositor', user.to_s, t("hyrax.dashboard.stats.works"), generic_type: "Work") %>
 
   <ul class="views-downloads-dashboard list-unstyled">
       <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t("hyrax.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>

--- a/lib/generators/hyrax/templates/catalog_controller.rb
+++ b/lib/generators/hyrax/templates/catalog_controller.rb
@@ -46,6 +46,10 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("file_format", :facetable), label: "File Format", limit: 5
     config.add_facet_field solr_name('member_of_collections', :symbol), limit: 5, label: 'Collections'
 
+    # The generic_type isn't displayed on the facet list
+    # It's used to give a label to the filter that comes from the user profile
+    config.add_facet_field solr_name("generic_type", :facetable), label: "Type", if: false
+
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
     # handler defaults, or have no facets.


### PR DESCRIPTION
Previously we were linking to human_readable_type, which only was
matching on the GenericWork objects. We want this link to filter all
work types.

Fixes #396
