### PR TITLE
CSS change to align work metadata fields.

### DIFF
--- a/app/assets/stylesheets/hyrax/_work-show.scss
+++ b/app/assets/stylesheets/hyrax/_work-show.scss
@@ -27,6 +27,9 @@ header > h1 .label {
   tbody th {
     width: 20%;
   }
+  ul.tabular {
+    padding-left: 0px;
+  }
 }
 
 ul.tabular {


### PR DESCRIPTION
Fixes #277

Aligns links with text fields in works metadata display.

@projecthydra-labs/hyrax-code-reviewers
