### PR TITLE
Wrap the actor stack in a transaction

### DIFF
--- a/app/actors/hyrax/actors/transactional_request.rb
+++ b/app/actors/hyrax/actors/transactional_request.rb
@@ -1,0 +1,20 @@
+module Hyrax
+  module Actors
+    # Wrap the stack in a database transaction.
+    # This will roll back any database actions (particularly workflow) if there
+    # is an error elsewhere in the actor stack.
+    class TransactionalRequest < Actors::AbstractActor
+      def create(attributes)
+        ActiveRecord::Base.transaction do
+          next_actor.create(attributes)
+        end
+      end
+
+      def update(attributes)
+        ActiveRecord::Base.transaction do
+          next_actor.update(attributes)
+        end
+      end
+    end
+  end
+end

--- a/app/services/hyrax/actor_factory.rb
+++ b/app/services/hyrax/actor_factory.rb
@@ -1,7 +1,8 @@
 module Hyrax
   class ActorFactory
     def self.stack_actors(curation_concern)
-      [Hyrax::Actors::OptimisticLockValidator,
+      [Hyrax::Actors::TransactionalRequest,
+       Hyrax::Actors::OptimisticLockValidator,
        CreateWithRemoteFilesActor,
        CreateWithFilesActor,
        Hyrax::Actors::AddAsMemberOfCollectionsActor,

--- a/spec/actors/hyrax/actors/transactional_request_spec.rb
+++ b/spec/actors/hyrax/actors/transactional_request_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe Hyrax::Actors::TransactionalRequest do
+  let(:bad_actor) do
+    Class.new(Hyrax::Actors::AbstractActor) do
+      def create(attributes)
+        next_actor.create(attributes) && raise('boom')
+      end
+    end
+  end
+
+  let(:actor_stack) do
+    Hyrax::Actors::ActorStack.new(work, depositor, [described_class,
+                                                    bad_actor,
+                                                    Hyrax::Actors::InitializeWorkflowActor])
+  end
+
+  let(:depositor) { create(:user) }
+  let(:work) { create(:work) }
+
+  describe "create" do
+    subject { actor_stack.create({}) }
+
+    it "rolls back any database changes" do
+      expect do
+        expect { subject }.to raise_error 'boom'
+      end.not_to change { Sipity::Entity.count }
+    end
+  end
+end

--- a/spec/services/hyrax/actor_factory_spec.rb
+++ b/spec/services/hyrax/actor_factory_spec.rb
@@ -5,7 +5,8 @@ describe Hyrax::ActorFactory, :no_clean do
   describe '.stack_actors' do
     subject { described_class.stack_actors(work) }
     it do
-      is_expected.to eq [Hyrax::Actors::OptimisticLockValidator,
+      is_expected.to eq [Hyrax::Actors::TransactionalRequest,
+                         Hyrax::Actors::OptimisticLockValidator,
                          Hyrax::CreateWithRemoteFilesActor,
                          Hyrax::CreateWithFilesActor,
                          Hyrax::Actors::AddAsMemberOfCollectionsActor,
@@ -25,6 +26,7 @@ describe Hyrax::ActorFactory, :no_clean do
     subject { described_class.build(work, user) }
     it "has the correct stack frames" do
       expect(subject.more_actors).to eq [
+        Hyrax::Actors::OptimisticLockValidator,
         Hyrax::CreateWithRemoteFilesActor,
         Hyrax::CreateWithFilesActor,
         Hyrax::Actors::AddAsMemberOfCollectionsActor,
@@ -38,7 +40,7 @@ describe Hyrax::ActorFactory, :no_clean do
         Hyrax::Actors::GenericWorkActor,
         Hyrax::Actors::InitializeWorkflowActor
       ]
-      expect(subject.first_actor_class).to eq Hyrax::Actors::OptimisticLockValidator
+      expect(subject.first_actor_class).to eq Hyrax::Actors::TransactionalRequest
     end
   end
 


### PR DESCRIPTION
This should roll back any workflow or other database changes if
there is an exception somewhere in the actor stack (e.g. can't write to
solr).  This will allow us to repeat the action without encountering
RecordNotUnique exceptions when getting to the InitializeWorkflowActor
when attempting an action a second time.

Fixes https://github.com/projecthydra-labs/hyku/issues/746
