### PR TITLE
Add sharing to collections

### DIFF
--- a/app/assets/javascripts/hyrax/app.js
+++ b/app/assets/javascripts/hyrax/app.js
@@ -84,6 +84,8 @@ Hyrax = {
         new PermissionsControl($("#permission"), 'tmpl-file-set-grant');
         // On the batch edit page
         new PermissionsControl($("#form_permissions"), 'tmpl-work-grant');
+        // On the edit collection page
+        new PermissionsControl($("#collection_permissions"), 'tmpl-collection-grant');
     },
 
     notifications: function () {

--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -2,8 +2,9 @@ module Hyrax
   module Forms
     class CollectionForm
       include HydraEditor::Form
+      include HydraEditor::Form::Permissions
 
-      delegate :id, to: :model
+      delegate :id, :depositor, :permissions, to: :model
 
       # TODO: remove this when https://github.com/projecthydra/hydra-editor/pull/115
       # is merged and hydra-editor 3.0.0 is released
@@ -16,7 +17,7 @@ module Hyrax
       self.terms = [:resource_type, :title, :creator, :contributor, :description,
                     :keyword, :rights, :publisher, :date_created, :subject, :language,
                     :representative_id, :thumbnail_id, :identifier, :based_near,
-                    :related_url, :visibility]
+                    :related_url, :visibility, :depositor]
 
       self.required_fields = [:title]
 

--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -17,7 +17,7 @@ module Hyrax
       self.terms = [:resource_type, :title, :creator, :contributor, :description,
                     :keyword, :rights, :publisher, :date_created, :subject, :language,
                     :representative_id, :thumbnail_id, :identifier, :based_near,
-                    :related_url, :visibility, :depositor]
+                    :related_url, :visibility]
 
       self.required_fields = [:title]
 

--- a/app/views/hyrax/collections/_form.html.erb
+++ b/app/views/hyrax/collections/_form.html.erb
@@ -30,6 +30,10 @@
     <%= render 'form_permission', f: f %>
   </div>
 
+  <div class="collection_form_share" id="collection_permissions" data-param-key="<%= f.object.model_name.param_key %>">
+    <%= render 'form_share', f: f %>
+  </div>
+
   <div class="primary-actions">
     <% if params[:action] == "new" %>
       <%= f.submit 'Create Collection', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "create_submit", name: "create_collection" %>

--- a/app/views/hyrax/collections/_form_share.html.erb
+++ b/app/views/hyrax/collections/_form_share.html.erb
@@ -1,0 +1,90 @@
+<% depositor = f.object.depositor %>
+
+<fieldset>
+  <legend>
+    Share With <small>(optional)</small>
+  </legend>
+
+  <div class="alert alert-info hidden" id="save_perm_note">Permissions are
+  <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.</div>
+
+  <div class="alert alert-warning hidden" role="alert" id="permissions_error">
+    <span id="permissions_error_text"></span>
+  </div>
+
+  <table class="table">
+    <tr id="file_permissions">
+      <td width="20%">
+        <%= Hyrax.config.owner_permission_levels.keys[0] %>
+      </td>
+      <td width="60%">
+        <%= label_tag :owner_access, class: "control-label" do %>
+          Depositor (<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>)
+        <% end %>
+      </td>
+    </tr>
+    <%= f.fields_for :permissions do |permission_fields| %>
+      <%# skip the public, registered, and depositor perms as they are displayed first at the top %>
+      <% next if ['public', 'registered', depositor].include? permission_fields.object.agent_name.downcase %>
+      <tr>
+        <td>
+          <%= permission_fields.select :access, Hyrax.config.permission_levels, {}, class: 'form-control select_perm' %>
+        </td>
+        <td>
+          <%= permission_fields.label :agent_name, class: "control-label" do %>
+            <%= user_display_name_and_key(permission_fields.object.agent_name) %>
+          <% end %>
+          <button class="btn close remove_perm" data-index="<%= permission_fields.index %>">&times;</button>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+
+  <h4>Share work with other users</h4>
+  <p class="sr-only">Use the add button to give access to one <%=t('hyrax.account_label') %> at a time (it will be added to the list below).
+    Select the user, by name or <%= t('hyrax.account_label') %>. Then select the access level you wish to grant and click on Add this
+    <%= t('hyrax.account_label') %> to complete adding the permission.
+  </p>
+  <div class="form-group row">
+    <div class="col-sm-5">
+      <label for="new_user_name_skel" class="sr-only"><%= t('hyrax.account_label') %> (without the <%= t('hyrax.directory.suffix') %> part)</label>
+      <%= text_field_tag 'new_user_name_skel', nil %>
+    </div>
+    <div class="col-sm-4">
+      <label for="new_user_permission_skel" class="sr-only">Access type to grant</label>
+      <%= select_tag 'new_user_permission_skel', options_for_select(Hyrax.config.permission_levels), class: 'form-control' %>
+    </div>
+    <div class="col-sm-3">
+      <button class="btn btn-default" id="add_new_user_skel">
+        <span class="sr-only">Add this <%= t('hyrax.account_label') %></span>
+        <span aria-hidden="true"><i class="glyphicon glyphicon-plus"></i></span>
+      </button>
+      <br /> <span id="directory_user_result"></span>
+    </div>
+  </div>
+
+  <h4>Share work with groups of users</h4>
+  <p class="sr-only">Use the add button to give access to one group at a time (it will be added to the list below).</p>
+  <div class="form-group row">
+    <div class="col-sm-5">
+      <label for="new_group_name_skel" class="sr-only">Group</label>
+      <%= select_tag 'new_group_name_skel', options_for_select(["Select a group"] + current_user.groups), class: 'form-control' %>
+    </div>
+    <div class="col-sm-4">
+      <label for="new_group_permission_skel" class="sr-only">Access type to grant</label>
+      <%= select_tag 'new_group_permission_skel', options_for_select(Hyrax.config.permission_levels), class: 'form-control' %>
+    </div>
+    <div class="col-sm-3">
+      <span class="sr-only">Add this group</span>
+      <button class="btn btn-default" id="add_new_group_skel"><i class="glyphicon glyphicon-plus"></i></button>
+      <br /><span id="directory_group_result"></span>
+    </div>
+  </div>
+
+  <script type="text/x-tmpl" id="tmpl-collection-grant">
+  <tr>
+    <td>{%= o.accessLabel %}</td>
+    <td><label class="control-label">{%= o.name %}</label> <button class="btn close">&times;</button></td>
+  </tr>
+  </script>
+</fieldset>

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -35,10 +35,16 @@ describe Hyrax::CollectionsController do
     it "creates a Collection" do
       expect do
         post :create, params: {
-          collection: collection_attrs.merge(visibility: 'open')
+          collection: collection_attrs.merge(
+            visibility: 'open',
+            permissions_attributes: [{ type: 'person',
+                                       name: 'archivist1',
+                                       access: 'edit' }]
+          )
         }
       end.to change { Collection.count }.by(1)
       expect(assigns[:collection].visibility).to eq 'open'
+      expect(assigns[:collection].edit_users).to contain_exactly "archivist1", user.email
     end
 
     it "removes blank strings from params before creating Collection" do

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -19,8 +19,7 @@ describe Hyrax::Forms::CollectionForm do
                          :identifier,
                          :based_near,
                          :related_url,
-                         :visibility,
-                         :depositor]
+                         :visibility]
     end
   end
 
@@ -97,7 +96,6 @@ describe Hyrax::Forms::CollectionForm do
                          { based_near: [] },
                          { related_url: [] },
                          :visibility,
-                         :depositor,
                          { permissions_attributes: [:type, :name, :access, :id, :_destroy] }]
     end
   end

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -19,7 +19,8 @@ describe Hyrax::Forms::CollectionForm do
                          :identifier,
                          :based_near,
                          :related_url,
-                         :visibility]
+                         :visibility,
+                         :depositor]
     end
   end
 
@@ -95,7 +96,9 @@ describe Hyrax::Forms::CollectionForm do
                          { identifier: [] },
                          { based_near: [] },
                          { related_url: [] },
-                         :visibility]
+                         :visibility,
+                         :depositor,
+                         { permissions_attributes: [:type, :name, :access, :id, :_destroy] }]
     end
   end
 

--- a/spec/views/hyrax/collections/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_form.html.erb_spec.rb
@@ -8,6 +8,7 @@ describe 'hyrax/collections/_form.html.erb', type: :view do
     assign(:collection, collection)
     # Stub route because view specs don't handle engine routes
     allow(view).to receive(:collections_path).and_return("/collections")
+    allow(controller).to receive(:current_user).and_return(stub_model(User))
     render
   end
 

--- a/spec/views/hyrax/collections/_form_share.erb_spec.rb
+++ b/spec/views/hyrax/collections/_form_share.erb_spec.rb
@@ -1,0 +1,42 @@
+describe 'hyrax/collections/_form_share.html.erb', type: :view do
+  let(:collection) do
+    stub_model(Collection, id: '123', depositor: 'bob')
+  end
+
+  let(:form) do
+    view.simple_form_for(collection, url: '/update') do |fs_form|
+      return fs_form
+    end
+  end
+
+  before do
+    allow(controller).to receive(:current_user).and_return(stub_model(User))
+    allow(collection).to receive(:permissions).and_return(permissions)
+    allow(view).to receive(:f).and_return(form)
+    view.lookup_context.prefixes.push 'hyrax/base'
+    view.extend Hyrax::PermissionsHelper
+    render
+  end
+
+  context "without additional users" do
+    let(:permissions) { [] }
+
+    it "draws the permissions form without error" do
+      expect(rendered).to have_css("input#new_user_name_skel")
+      expect(rendered).not_to have_css("button.remove_perm")
+    end
+  end
+
+  context "with additional users" do
+    let(:depositor_permission) { Hydra::AccessControls::Permission.new(id: '123', name: 'bob', type: 'person', access: 'edit') }
+    let(:public_permission) { Hydra::AccessControls::Permission.new(id: '124', name: 'public', type: 'group', access: 'read') }
+    let(:other_permission) { Hydra::AccessControls::Permission.new(id: '125', name: 'joe@example.com', type: 'person', access: 'edit') }
+    let(:permissions) { [depositor_permission, public_permission, other_permission] }
+
+    it "draws the permissions form without error" do
+      expect(rendered).to have_css("input#new_user_name_skel")
+      expect(rendered).to have_css("button.remove_perm", count: 1) # depositor and public should be filtered out
+      expect(rendered).to have_css("button.remove_perm[data-index='2']")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #128 

Adds ability to share collections (read/view privileges) with other users and groups.

This is mostly just adding the UI for the share permissions form. This PR includes a workaround that bypasses the Cancan `load_and_authorize` function for the `create` action in `Hyrax::CollectionsControllerBehavior`. Allowing Cancan to load and authorize the collection causes the collection to be saved without the `has_model` attribute. This, in turn, leads to collections not being accessible or discoverable.

*Special Note: This should be blocked until CLAs come through.*

@projecthydra-labs/hyrax-code-reviewers
