### PR TITLE
Replace size() calls with .length

### DIFF
--- a/app/assets/javascripts/batch_edit.js.coffee
+++ b/app/assets/javascripts/batch_edit.js.coffee
@@ -39,7 +39,7 @@ $.fn.batchEdit = (args) ->
     unique_id = form.attr("data-doc-id") || Math.random()
     # if form is currently using method delete to change state, 
     # then checkbox is currently checked
-    checked = (form.find("input[name=_method][value=delete]").size() != 0)
+    checked = (form.find("input[name=_method][value=delete]").length != 0)
         
     checkbox = $('<input type="checkbox">')
       .addClass( options.css_class )

--- a/app/assets/javascripts/hyrax/app.js
+++ b/app/assets/javascripts/hyrax/app.js
@@ -24,7 +24,7 @@ Hyrax = {
     datatable: function () {
         // This keeps the datatable from being added to a table that already has it.
         // This is a problem when turbolinks is active.
-        if ($('.dataTables_wrapper').size() === 0) {
+        if ($('.dataTables_wrapper').length === 0) {
             $('.datatable').DataTable();
         }
     },

--- a/app/assets/javascripts/hyrax/permissions/control.es6
+++ b/app/assets/javascripts/hyrax/permissions/control.es6
@@ -9,7 +9,7 @@ export class PermissionsControl {
    * @param {String} template_id the identifier of the template for the added elements 
    */
   constructor(element, template_id) {
-    if (element.size() == 0) {
+    if (element.length == 0) {
       return
     }
     this.element = element

--- a/app/assets/javascripts/hyrax/permissions/registry.es6
+++ b/app/assets/javascripts/hyrax/permissions/registry.es6
@@ -43,7 +43,7 @@ export class Registry {
   }
 
   nextIndex() {
-      return $('#file_permissions').parent().children().size() - 1;
+      return $('#file_permissions').parent().children().length - 1;
   }
 
   showPermissionNote() {

--- a/app/assets/javascripts/hyrax/save_work/deposit_agreement.es6
+++ b/app/assets/javascripts/hyrax/save_work/deposit_agreement.es6
@@ -7,7 +7,7 @@ export class DepositAgreement {
     // Tracks whether the user needs to accept again to the depositor
     // agreement. Once the user has manually agreed once she does not
     // need to agree again regardless on how many files are being added.
-    this.isActiveAgreement = this.agreementCheckbox.size() > 0
+    this.isActiveAgreement = this.agreementCheckbox.length > 0
     if (this.isActiveAgreement) {
       this.setupActiveAgreement(callback)
       this.mustAgreeAgain = this.isAccepted

--- a/app/assets/javascripts/hyrax/save_work/save_work_control.es6
+++ b/app/assets/javascripts/hyrax/save_work/save_work_control.es6
@@ -20,7 +20,7 @@ export class SaveWorkControl {
    * @param {jQuery} element the jquery selector for the save panel
    */
   constructor(element) {
-    if (element.size() == 0) {
+    if (element.length == 0) {
       return
     }
     this.element = element

--- a/app/assets/javascripts/hyrax/save_work/uploaded_files.es6
+++ b/app/assets/javascripts/hyrax/save_work/uploaded_files.es6
@@ -8,7 +8,7 @@ export class UploadedFiles {
 
   get hasFileRequirement() {
     let fileRequirement = this.form.find('li#required-files')
-    return fileRequirement.size() > 0
+    return fileRequirement.length > 0
   }
 
   get inProgress() {
@@ -17,7 +17,7 @@ export class UploadedFiles {
 
   get hasFiles() {
     let fileField = this.form.find('input[name="uploaded_files[]"]')
-    return fileField.size() > 0
+    return fileField.length > 0
   }
 
   get hasNewFiles() {


### PR DESCRIPTION
Fixes jQuery 3 compatibility. .size() was deprecated in 1.x and removed
in 3.x.

Closes #374.