### PR TITLE
Add a rationale to the github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,6 +2,10 @@
 
 Include what version of Hyrax relates to this issue (7.x, 6.x, HEAD, etc.) if appropriate, and any relevant tracebacks if you're reporting a bug.
 
+### Rationale
+
+Provide the rationale or user story that describes "why" this issue should be addressed. Especially if this is a new feature or significant change to the existing implementation.
+
 ### Expected behavior
 
 ### Actual behavior


### PR DESCRIPTION
A quick change to add a prompt for rational when submitting an issue so we can hopefully get a better understanding of the issue.