### PR TITLE
Use institution_name everywhere

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -20,13 +20,7 @@ module Hyrax
       { 'en' => 'English', 'es' => 'Español' }
     end
 
-    def institution_name
-      t('hyrax.institution_name')
-    end
-
-    def institution_name_full
-      t('hyrax.institution_name_full', default: institution_name)
-    end
+    delegate :name, :name_full, to: :institution, prefix: :institution
 
     def banner_image
       Hyrax.config.banner_image
@@ -288,6 +282,10 @@ module Hyrax
         return state.params if facet.none?
         state.add_facet_params(Solrizer.solr_name(facet.keys.first, :facetable),
                                facet.values.first)
+      end
+
+      def institution
+        Institution
       end
   end
 end

--- a/app/models/concerns/hyrax/solr_document/export.rb
+++ b/app/models/concerns/hyrax/solr_document/export.rb
@@ -50,7 +50,7 @@ module Hyrax
           '%[' => [:date_modified],
           '%9' => [:resource_type],
           '%~' => I18n.t('hyrax.product_name'),
-          '%W' => I18n.t('hyrax.institution_name')
+          '%W' => Institution.name
         }
       end
     end

--- a/app/presenters/hyrax/permission_badge.rb
+++ b/app/presenters/hyrax/permission_badge.rb
@@ -1,6 +1,7 @@
 module Hyrax
   class PermissionBadge
     include ActionView::Helpers::TagHelper
+    include HyraxHelper
 
     def initialize(solr_document)
       @solr_document = solr_document
@@ -31,7 +32,7 @@ module Hyrax
         elsif open_access?
           'Open Access'
         elsif registered?
-          I18n.translate('hyrax.institution_name')
+          Institution.name
         else
           'Private'
         end

--- a/app/services/hyrax/institution.rb
+++ b/app/services/hyrax/institution.rb
@@ -1,0 +1,11 @@
+module Hyrax
+  class Institution
+    def self.name
+      I18n.t('hyrax.institution_name')
+    end
+
+    def self.name_full
+      I18n.t('hyrax.institution_name_full', default: name)
+    end
+  end
+end

--- a/app/views/hyrax/base/_form_permission.html.erb
+++ b/app/views/hyrax/base/_form_permission.html.erb
@@ -17,7 +17,7 @@
       </label>
       <label class="radio">
         <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
-        <%= t('hyrax.visibility.authenticated.label_html', institution: t('hyrax.institution_name')) %>
+        <%= t('hyrax.visibility.authenticated.label_html', institution: institution_name) %>
       </label>
       <label class="radio">
         <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -31,8 +31,8 @@
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
-            <%= t('hyrax.visibility.authenticated.label_html', institution: t('hyrax.institution_name')) %>
-            <%= t('hyrax.visibility.authenticated.note_html', institution: t('hyrax.institution_name')) %>
+            <%= t('hyrax.visibility.authenticated.label_html', institution: institution_name) %>
+            <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
           </label>
         </li>
         <li class="radio">

--- a/app/views/hyrax/collections/_form_permission.html.erb
+++ b/app/views/hyrax/collections/_form_permission.html.erb
@@ -12,7 +12,7 @@
       </label>
       <label class="radio">
         <input type="radio" id="visibility_registered" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>" <% if @collection.authenticated_only_access? %> checked="true"<% end %> />
-        <%= t('hyrax.visibility.authenticated.label_html', institution: t('hyrax.institution_name')) %>
+        <%= t('hyrax.visibility.authenticated.label_html', institution: institution_name) %>
       </label>
       <label class="radio">
         <input type="radio" id="visibility_restricted" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE%>" <% if @collection.private_access? %> checked="true"<% end %>/>


### PR DESCRIPTION
This ensures that when this method is overridden, the overriden value
appears everwhere.  This is important for hyku as we want the
institution to be per tenant, so a simple translation won't do.

Fixes #403