### PR TITLE
Derivative service shared examples & Configurable Derivatives

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - 'script/**/*'
     - 'spec/test_app_templates/**/*'
     - 'vendor/**/*'
+    - 'lib/hyrax/specs/**/*'
 
 Lint/ImplicitStringConcatenation:
   Exclude:
@@ -114,6 +115,10 @@ RSpec/MessageSpies:
     - 'spec/controllers/hyrax/api/zotero_controller_spec.rb'
     - 'spec/controllers/hyrax/generic_works_controller_spec.rb'
     - 'spec/services/hyrax/workflow/workflow_importer_spec.rb'
+
+RSpec/InstanceVariable:
+  Exclude:
+    - 'spec/services/hyrax/derivative_service_spec.rb'
 
 RSpec/ExpectActual:
   Enabled: false

--- a/app/models/concerns/hyrax/file_set/characterization.rb
+++ b/app/models/concerns/hyrax/file_set/characterization.rb
@@ -19,7 +19,7 @@ module Hyrax
         class_attribute :characterization_terms, :characterization_proxy
         self.characterization_terms = [
           :format_label, :file_size, :height, :width, :filename, :well_formed,
-          :page_count, :file_title, :last_modified, :original_checksum, :mime_type,
+          :page_count, :file_title, :last_modified, :original_checksum,
           :duration, :sample_rate
         ]
         self.characterization_proxy = :original_file
@@ -32,6 +32,10 @@ module Hyrax
 
         def characterization_proxy?
           !characterization_proxy.is_a?(NullCharacterizationProxy)
+        end
+
+        def mime_type
+          @mime_type ||= characterization_proxy.mime_type
         end
       end
 

--- a/app/models/concerns/hyrax/file_set/derivatives.rb
+++ b/app/models/concerns/hyrax/file_set/derivatives.rb
@@ -54,7 +54,7 @@ module Hyrax
       private
 
         def file_set_derivatives_service
-          @file_set_derivatives_service ||= Hyrax::FileSetDerivativesService.new(self)
+          Hyrax::DerivativeService.for(self)
         end
     end
   end

--- a/app/services/hyrax/derivative_service.rb
+++ b/app/services/hyrax/derivative_service.rb
@@ -1,0 +1,26 @@
+class Hyrax::DerivativeService
+  class_attribute :services
+  self.services = [Hyrax::FileSetDerivativesService]
+  def self.for(file_set)
+    services.map { |service| service.new(file_set) }.find(&:valid?) ||
+      new(file_set)
+  end
+  attr_reader :file_set
+  delegate :mime_type, :uri, to: :file_set
+  def initialize(file_set)
+    @file_set = file_set
+  end
+
+  def cleanup_derivatives; end
+
+  def create_derivatives(_file_path); end
+
+  # What should this return?
+  def derivative_url(_destination_name)
+    ""
+  end
+
+  def valid?
+    true
+  end
+end

--- a/app/services/hyrax/file_set_derivatives_service.rb
+++ b/app/services/hyrax/file_set_derivatives_service.rb
@@ -25,6 +25,13 @@ module Hyrax
       end
     end
 
+    # The destination_name parameter has to match up with the file parameter
+    # passed to the DownloadsController
+    def derivative_url(destination_name)
+      path = derivative_path_factory.derivative_path_for_reference(file_set, destination_name)
+      URI("file://#{path}").to_s
+    end
+
     private
 
       def create_pdf_derivatives(filename)
@@ -59,13 +66,6 @@ module Hyrax
       def create_image_derivatives(filename)
         Hydra::Derivatives::ImageDerivatives.create(filename,
                                                     outputs: [{ label: :thumbnail, format: 'jpg', size: '200x150>', url: derivative_url('thumbnail') }])
-      end
-
-      # The destination_name parameter has to match up with the file parameter
-      # passed to the DownloadsController
-      def derivative_url(destination_name)
-        path = derivative_path_factory.derivative_path_for_reference(file_set, destination_name)
-        URI("file://#{path}").to_s
       end
 
       def derivative_path_factory

--- a/app/services/hyrax/file_set_derivatives_service.rb
+++ b/app/services/hyrax/file_set_derivatives_service.rb
@@ -15,6 +15,10 @@ module Hyrax
       end
     end
 
+    def valid?
+      supported_mime_types.include?(mime_type)
+    end
+
     def create_derivatives(filename)
       case mime_type
       when *file_set.class.pdf_mime_types             then create_pdf_derivatives(filename)
@@ -33,6 +37,14 @@ module Hyrax
     end
 
     private
+
+      def supported_mime_types
+        file_set.class.pdf_mime_types +
+          file_set.class.office_document_mime_types +
+          file_set.class.audio_mime_types +
+          file_set.class.video_mime_types +
+          file_set.class.image_mime_types
+      end
 
       def create_pdf_derivatives(filename)
         Hydra::Derivatives::PdfDerivatives.create(filename,

--- a/lib/hyrax/specs/shared_specs.rb
+++ b/lib/hyrax/specs/shared_specs.rb
@@ -1,0 +1,1 @@
+require 'hyrax/specs/shared_specs/derivative_service'

--- a/lib/hyrax/specs/shared_specs/derivative_service.rb
+++ b/lib/hyrax/specs/shared_specs/derivative_service.rb
@@ -1,0 +1,20 @@
+RSpec.shared_examples 'a Hyrax::DerivativeService' do
+  before do
+    raise 'file_set must be set with `let(:file_set)`' unless
+      defined? file_set
+  end
+  it { is_expected.to respond_to(:create_derivatives).with(1).arguments }
+
+  it { is_expected.to respond_to(:cleanup_derivatives).with(0).arguments }
+
+  it { is_expected.to respond_to(:file_set) }
+
+  it { is_expected.to respond_to(:mime_type) }
+
+  it { is_expected.to respond_to(:derivative_url).with(1).arguments }
+
+  it "takes a fileset as an argument" do
+    obj = described_class.new(file_set)
+    expect(obj.file_set).to eq file_set
+  end
+end

--- a/lib/hyrax/specs/shared_specs/derivative_service.rb
+++ b/lib/hyrax/specs/shared_specs/derivative_service.rb
@@ -1,8 +1,12 @@
 RSpec.shared_examples 'a Hyrax::DerivativeService' do
   before do
-    raise 'file_set must be set with `let(:file_set)`' unless
-      defined? file_set
+    raise 'valid_file_set must be set with `let(:valid_file_set)`' unless
+      defined? valid_file_set
   end
+
+  subject { described_class.new(file_set) }
+  let(:file_set) { valid_file_set }
+
   it { is_expected.to respond_to(:create_derivatives).with(1).arguments }
 
   it { is_expected.to respond_to(:cleanup_derivatives).with(0).arguments }
@@ -13,8 +17,15 @@ RSpec.shared_examples 'a Hyrax::DerivativeService' do
 
   it { is_expected.to respond_to(:derivative_url).with(1).arguments }
 
+  describe "#valid?" do
+    context "when given a file_set it handles" do
+      let(:file_set) { valid_file_set }
+      it { is_expected.to be_valid }
+    end
+  end
+
   it "takes a fileset as an argument" do
-    obj = described_class.new(file_set)
-    expect(obj.file_set).to eq file_set
+    obj = described_class.new(valid_file_set)
+    expect(obj.file_set).to eq valid_file_set
   end
 end

--- a/spec/services/hyrax/derivative_service_spec.rb
+++ b/spec/services/hyrax/derivative_service_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'hyrax/specs/shared_specs'
+
+RSpec.describe Hyrax::DerivativeService do
+  let(:valid_file_set) { FileSet.new }
+  subject { described_class.new(file_set) }
+  it_behaves_like "a Hyrax::DerivativeService"
+  before do
+    @cached_services = described_class.services
+  end
+  after do
+    described_class.services = @cached_services
+  end
+
+  describe ".services=" do
+    it "allows you to set the available services" do
+      described_class.services = [Hyrax::FileSetDerivativesService, Hyrax::FileSetDerivativesService]
+      expect(described_class.services).to eq [Hyrax::FileSetDerivativesService, Hyrax::FileSetDerivativesService]
+    end
+    it "defaults to an array" do
+      expect(described_class.services).to eq [Hyrax::FileSetDerivativesService]
+    end
+  end
+
+  describe ".for" do
+    before do
+      described_class.services = [Hyrax::FileSetDerivativesService]
+    end
+    context "when a FileSet matches the requirements of a service" do
+      let(:file_set) do
+        FileSet.new.tap do |f|
+          allow(f).to receive(:mime_type).and_return(FileSet.image_mime_types.first)
+        end
+      end
+      it "returns it" do
+        expect(described_class.for(file_set)).to be_instance_of Hyrax::FileSetDerivativesService
+      end
+    end
+    context "when a FileSet matches no services" do
+      let(:file_set) { FileSet.new }
+      it "returns a base DerivativeService" do
+        expect(described_class.for(file_set)).to be_instance_of described_class
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/file_set_derivatives_service_spec.rb
+++ b/spec/services/hyrax/file_set_derivatives_service_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'hyrax/specs/shared_specs'
+
+RSpec.describe Hyrax::FileSetDerivativesService do
+  let(:file_set) { ::FileSet.new }
+  subject { described_class.new(file_set) }
+  it_behaves_like "a Hyrax::DerivativeService"
+end

--- a/spec/services/hyrax/file_set_derivatives_service_spec.rb
+++ b/spec/services/hyrax/file_set_derivatives_service_spec.rb
@@ -2,7 +2,11 @@ require 'spec_helper'
 require 'hyrax/specs/shared_specs'
 
 RSpec.describe Hyrax::FileSetDerivativesService do
-  let(:file_set) { ::FileSet.new }
+  let(:valid_file_set) do
+    FileSet.new.tap do |f|
+      allow(f).to receive(:mime_type).and_return(FileSet.image_mime_types.first)
+    end
+  end
   subject { described_class.new(file_set) }
   it_behaves_like "a Hyrax::DerivativeService"
 end


### PR DESCRIPTION
This does a few things:

1. Creates a shared example for DerivativeServices that can be called in other apps, for cases where users want their own derivative logic.

2. Adds a `#valid?` method to DerivativeServices which checks to see if it can handle a given fileset.

3. Adds a factory method `Hyrax::DerivativeService.for` which will return the first appropriate DerivativeService given a configured set.

Some questions:

A. Do we like this pattern?
B. Is the shared spec correct? For example, is `#uri` and `#mime_type` a part of the interface, or just for that specific derivative service? Is `#file_set` part of the interface? SHOULD we be checking if `#valid?` works?
C. Should we blow up FileSetDerivativeService into one per mime type, now that it's easy? (Maybe another PR, but that's a benefit of this refactor.)