### PR TITLE
My works page should show all my deposits

### DIFF
--- a/app/search_builders/hyrax/my_works_search_builder.rb
+++ b/app/search_builders/hyrax/my_works_search_builder.rb
@@ -1,9 +1,13 @@
 # Added to allow for the My controller to show only things I have edit access to
 class Hyrax::MyWorksSearchBuilder < Hyrax::SearchBuilder
-  include Hyrax::MySearchBuilderBehavior
   include Hyrax::FilterByType
 
   self.default_processor_chain += [:show_only_resources_deposited_by_current_user]
+
+  # We remove the access controls filter, because some of the works a user has
+  # deposited may have gone through a workflow which has removed their ability
+  # to edit the work.
+  self.default_processor_chain -= [:add_access_controls_to_solr_params]
 
   def only_works?
     true

--- a/spec/search_builder/hyrax/my_shares_search_builder_spec.rb
+++ b/spec/search_builder/hyrax/my_shares_search_builder_spec.rb
@@ -10,8 +10,6 @@ describe Hyrax::MySharesSearchBuilder do
   end
   let(:builder) { described_class.new(scope) }
 
-  let(:solr_params) { { q: user_query } }
-
   before do
     allow(builder).to receive(:gated_discovery_filters).and_return(["access_filter1", "access_filter2"])
 

--- a/spec/search_builder/hyrax/my_works_search_builder_spec.rb
+++ b/spec/search_builder/hyrax/my_works_search_builder_spec.rb
@@ -1,0 +1,52 @@
+describe Hyrax::MyWorksSearchBuilder do
+  let(:me) { create(:user) }
+  let(:config) { CatalogController.blacklight_config }
+  let(:scope) do
+    double('The scope',
+           blacklight_config: config,
+           params: {},
+           current_ability: Ability.new(me),
+           current_user: me)
+  end
+  let(:builder) { described_class.new(scope) }
+
+  describe "#to_hash" do
+    before do
+      # This prevents any generated classes from interfering with this test:
+      allow(builder).to receive(:work_classes).and_return([GenericWork])
+
+      allow(ActiveFedora::SolrQueryBuilder).to receive(:construct_query_for_rel)
+        .with(depositor: me.user_key)
+        .and_return("depositor")
+    end
+
+    subject { builder.to_hash['fq'] }
+
+    it "filters works that we are the depositor of" do
+      expect(subject).to eq ["{!terms f=has_model_ssim}GenericWork",
+                             "-suppressed_bsi:true",
+                             "depositor"]
+    end
+  end
+
+  describe ".default_processor_chain" do
+    subject { described_class.default_processor_chain }
+    let(:expected_filters) do
+      [
+        :default_solr_parameters,
+        :add_query_to_solr,
+        :add_facet_fq_to_solr,
+        :add_facetting_to_solr,
+        :add_solr_fields_to_query,
+        :add_paging_to_solr,
+        :add_sorting_to_solr,
+        :add_group_config_to_solr,
+        :add_facet_paging_to_solr,
+        :filter_models,
+        :only_active_works,
+        :show_only_resources_deposited_by_current_user
+      ]
+    end
+    it { is_expected.to eq expected_filters }
+  end
+end


### PR DESCRIPTION
Even those I lack edit access to.  Some workflows may remove a
depositors ability to edit their submissions once they are deposited. We
still want these works to be displayed on the "My Works" page.

Fixes #448