### PR TITLE
Remove the misleading INSTITUTION_NAME pointer

### DIFF
--- a/app/helpers/hyrax/ability_helper.rb
+++ b/app/helpers/hyrax/ability_helper.rb
@@ -24,6 +24,7 @@ module Hyrax
     private
 
       def visibility_text(value)
+        return institution_name if value == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
         t("hyrax.visibility.#{value}.text", default: value)
       end
   end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -38,7 +38,6 @@ en:
       update: 'Save'
   hyrax:
     account_label:      "User"
-    account_name:       "My Institution Account Id"
     active_consent_to_agreement:  "I have read and agree to the"
     admin:
       admin_sets:
@@ -410,9 +409,6 @@ en:
           The list of groups in the drop-down marked "Select a group" is a list of User Managed Groups that
           you are a member of.  You may select a specific group and assign an access level for a file
           within %{application_name}, similarly to adding user access levels.
-    footer:
-      copyright_html: "<strong>Copyright &copy; 2017 Project Hydra</strong> Licensed under the Apache License, Version 2.0"
-      service_html: A service of <a href="http://projecthydra.org/" class="navbar-link" target="_blank">Project Hydra</a>.
     help:
       header: "User Support"
       override_text: "Use app/views/static/help.html.erb to override this file."
@@ -439,8 +435,6 @@ en:
     icons:
       collection:       'fa fa-cubes'
       default:          'fa fa-cube'
-    institution_name: &INSTITUTION_NAME "Institution Name"
-    institution_name_full: "The Institution Name"
     mailbox:
       date:     'Date'
       delete:   'Delete Message'
@@ -463,8 +457,6 @@ en:
         subject: "Batch upload complete"
         title:  "Files uploaded successfully"
     passive_consent_to_agreement: "By saving this work I agree to the"
-    product_name:       "Hyrax"
-    product_twitter_handle: "@HydraSphere"
     schema_org:
       based_near:
         property: contentLocation
@@ -630,7 +622,6 @@ en:
         class: "label-info"
         label_html: <span class="label label-info">%{institution}</span>
         note_html: Restrict access to only users and/or groups from %{institution}
-        text: *INSTITUTION_NAME
       embargo:
         class: "label-warning"
         label_html: <span class="label label-warning">Embargo</span>

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -38,7 +38,6 @@ es:
       update: 'Guardar'
   hyrax:
     account_label:      "Usuario"
-    account_name:       "Mi identificador de cuenta institucional"
     active_consent_to_agreement:  "He leído y estoy de acuerdo con"
     admin:
       admin_sets:
@@ -410,9 +409,6 @@ es:
           La lista de grupos en el listado marcados como "Seleccionar un grupo" es una lista de Grupos de Usuarios Administrados de la cual
           Tu eres un miembro de. Puedes seleccionar un grupo específico y asignar un nivel de acceso por archivo
           dentro de %{application_name}, y del mismo modo también para agregar niveles de acceso de usuarios.
-    footer:
-      copyright_html: "<strong>Copyright &copy; 2017 Proyecto Hydra</strong> bajo licencia de Apache, Version 2.0"
-      service_html: Un servicio de <a href="http://projecthydra.org/" class="navbar-link" target="_blank">Proyecto Hydra</a>.
     help:
       header: "Soporte al Usuario"
       override_text: "Utilice app/views/static/help.html.erb para anular este archivo"
@@ -439,8 +435,6 @@ es:
     icons:
       collection:       'fa fa-cubes'
       default:          'fa fa-cube'
-    institution_name: &INSTITUTION_NAME "Nombre de la institución"
-    institution_name_full: "El nombre de la institución"
     mailbox:
       date:     'Fecha'
       delete:   'Borrar Mensaje'
@@ -463,8 +457,6 @@ es:
         subject: "Carga en lote completa"
         title:  "Archivos cargados satisfactoriamente"
     passive_consent_to_agreement: "Al salvar este trabajo yo acepto a"
-    product_name: "Hyrax"
-    product_twitter_handle: "@HydraSphere"
     schema_org:
       based_near:
         property: contentLocation
@@ -630,7 +622,6 @@ es:
         class: "label-info"
         label_html: <span class="label label-info">%{institution}</span>
         note_html: Restringir el acceso sólo a usuarios y / o grupos de %{institution}
-        text: *INSTITUTION_NAME
       embargo:
         class: "label-warning"
         label_html: <span class="label label-warning">Embargo</span>

--- a/lib/generators/hyrax/config_generator.rb
+++ b/lib/generators/hyrax/config_generator.rb
@@ -54,5 +54,6 @@ class Hyrax::ConfigGenerator < Rails::Generators::Base
 
   def inject_i18n
     copy_file "config/locales/hyrax.en.yml", "config/locales/hyrax.en.yml"
+    copy_file "config/locales/hyrax.es.yml", "config/locales/hyrax.es.yml"
   end
 end

--- a/lib/generators/hyrax/templates/config/locales/hyrax.en.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.en.yml
@@ -1,11 +1,12 @@
 en:
   hyrax:
-    product_name:       "Hyrax"
+    product_name:           "Hyrax"
     product_twitter_handle: "@HydraSphere"
-    institution_name:   "Institution Name"
-#    institution_name_full:   "The Institution Name"
-    account_name:       "My Institution Account Id"
+    institution_name:       "Institution"
+    institution_name_full:  "The Institution Name"
+    account_name:           "My Institution Account Id"
     directory:
-      suffix:           "@example.org"
+      suffix:               "@example.org"
     footer:
-      copyright_html: "<strong>Copyright &copy; 2016 Project Hydra</strong> Licensed under the Apache License, Version 2.0"
+      copyright_html: "<strong>Copyright &copy; 2017 Project Hydra</strong> Licensed under the Apache License, Version 2.0"
+      service_html: A service of <a href="http://projecthydra.org/" class="navbar-link" target="_blank">Project Hydra</a>.

--- a/lib/generators/hyrax/templates/config/locales/hyrax.es.yml
+++ b/lib/generators/hyrax/templates/config/locales/hyrax.es.yml
@@ -1,0 +1,12 @@
+es:
+  hyrax:
+    product_name:           "Hyrax"
+    product_twitter_handle: "@HydraSphere"
+    institution_name:       "institución"
+    institution_name_full:  "El nombre de la institución"
+    account_name:           "Mi identificador de cuenta institucional"
+    directory:
+      suffix:               "@example.org"
+    footer:
+      copyright_html: "<strong>Copyright &copy; 2017 Proyecto Hydra</strong> bajo licencia de Apache, Version 2.0"
+      service_html: Un servicio de <a href="http://projecthydra.org/" class="navbar-link" target="_blank">Proyecto Hydra</a>.

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -50,7 +50,7 @@ describe "display a work as its owner" do
       expect(page).to have_content '%T Magnificent splendor'
       expect(page).to have_content '%R http://localhost/files/'
       expect(page).to have_content '%~ Hyrax'
-      expect(page).to have_content '%W Institution Name'
+      expect(page).to have_content '%W Institution'
     end
   end
 end

--- a/spec/presenters/hyrax/permission_badge_spec.rb
+++ b/spec/presenters/hyrax/permission_badge_spec.rb
@@ -19,7 +19,7 @@ describe Hyrax::PermissionBadge do
 
     context "when registered" do
       let(:attributes) { { read_access_group_ssim: ['registered'] } }
-      it { is_expected.to eq "<span title=\"Institution Name\" class=\"label label-info\">Institution Name</span>" }
+      it { is_expected.to eq "<span title=\"Institution\" class=\"label label-info\">Institution</span>" }
     end
 
     context "when private" do


### PR DESCRIPTION
Moved translations that will certainly be overriden to the generator
so that they are easier to find.  Generate the spanish locale file.

Fixes #455