### PR TITLE
Have a single way to draw permission badges

### DIFF
--- a/app/helpers/hyrax/ability_helper.rb
+++ b/app/helpers/hyrax/ability_helper.rb
@@ -17,15 +17,30 @@ module Hyrax
     end
 
     def visibility_badge(value)
-      klass = t("hyrax.visibility.#{value}.class", default: 'label-info')
-      content_tag :span, visibility_text(value), class: "label #{klass}"
+      PermissionBadge.new(value).render
+    end
+
+    def render_visibility_link(document)
+      # Anchor must match with a tab in
+      # https://github.com/projecthydra/hyrax/blob/master/app/views/hyrax/base/_guts4form.html.erb#L2
+      path = if document.collection?
+               hyrax.edit_collection_path(document, anchor: 'share')
+             else
+               edit_polymorphic_path([main_app, document], anchor: 'share')
+             end
+      link_to(
+        visibility_badge(document.visibility),
+        path,
+        id: "permission_#{document.id}",
+        class: 'visibility-link'
+      )
     end
 
     private
 
       def visibility_text(value)
         return institution_name if value == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-        t("hyrax.visibility.#{value}.text", default: value)
+        t("hyrax.visibility.#{value}.text")
       end
   end
 end

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -220,18 +220,6 @@ module Hyrax
       end
     end
 
-    def render_visibility_link(document)
-      # Anchor must match with a tab in
-      # https://github.com/projecthydra/hyrax/blob/master/app/views/hyrax/base/_guts4form.html.erb#L2
-      path = document.collection? ? hyrax.edit_collection_path(document, anchor: 'share') : edit_polymorphic_path([main_app, document], anchor: 'share')
-      link_to(
-        render_visibility_label(document),
-        path,
-        id: "permission_#{document.id}",
-        class: 'visibility-link'
-      )
-    end
-
     def user_display_name_and_key(user_key)
       user = ::User.find_by_user_key(user_key)
       return user_key if user.nil?
@@ -244,16 +232,6 @@ module Hyrax
     end
 
     private
-
-      def render_visibility_label(document)
-        if document.registered?
-          content_tag(:span, institution_name, class: 'label label-info', title: institution_name)
-        elsif document.public?
-          content_tag(:span, t('hyrax.visibility.open.text'), class: 'label label-success', title: t('hyrax.visibility.open_title_attr'))
-        else
-          content_tag(:span, t('hyrax.visibility.private.text'), class: 'label label-danger', title: t('hyrax.visibility.private_title_attr'))
-        end
-      end
 
       def user_agent
         request.user_agent || ''

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -164,9 +164,13 @@ module Hyrax
     end
 
     def visibility
-      @visibility ||= if read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
+      @visibility ||= if embargo_release_date.present?
+                        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
+                      elsif lease_expiration_date.present?
+                        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE
+                      elsif public?
                         Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-                      elsif read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
+                      elsif registered?
                         Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
                       else
                         Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE

--- a/app/presenters/hyrax/presents_attributes.rb
+++ b/app/presenters/hyrax/presents_attributes.rb
@@ -21,7 +21,7 @@ module Hyrax
     end
 
     def permission_badge
-      permission_badge_class.new(solr_document).render
+      permission_badge_class.new(solr_document.visibility).render
     end
 
     def permission_badge_class

--- a/app/views/hyrax/base/_form_permission.html.erb
+++ b/app/views/hyrax/base/_form_permission.html.erb
@@ -13,11 +13,11 @@
     <div class="form-group">
       <label class="radio">
         <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>
-        <%= t('hyrax.visibility.open.label_html', type: 'work') %>
+        <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) %>
       </label>
       <label class="radio">
         <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
-        <%= t('hyrax.visibility.authenticated.label_html', institution: institution_name) %>
+        <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) %>
       </label>
       <label class="radio">
         <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>
@@ -29,7 +29,7 @@
       </label>
       <label class="radio">
         <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
-        <%= t('hyrax.visibility.private.label_html') %>
+        <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
       </label>
     </div>
   </fieldset>

--- a/app/views/hyrax/base/_form_permission_embargo.html.erb
+++ b/app/views/hyrax/base/_form_permission_embargo.html.erb
@@ -1,5 +1,5 @@
 <div class="form-inline">
-  <%= t('hyrax.visibility.embargo.label_html') %>
+  <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) %>
   <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
   <%= f.input :embargo_release_date, wrapper: :inline, input_html: { value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker' } %>
   <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>

--- a/app/views/hyrax/base/_form_permission_lease.html.erb
+++ b/app/views/hyrax/base/_form_permission_lease.html.erb
@@ -1,5 +1,5 @@
 <div class="form-inline">
-  <%= t('hyrax.visibility.lease.label_html') %>
+  <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE) %>
   <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
   <%= f.input :lease_expiration_date, wrapper: :inline, input_html: { value: f.object.lease_expiration_date || Date.tomorrow, class: 'datepicker' } %>
   <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -9,24 +9,24 @@
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' }  %>
-            <%= t('hyrax.visibility.open.label_html') %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) %>
             <%= t('hyrax.visibility.open.note_html', type: f.object.human_readable_type) %>
             <div class="collapse" id="collapsePublic">
-              <%= t('hyrax.visibility.open.warning_html', label: t('hyrax.visibility.open.label_html')) %>
+              <%= t('hyrax.visibility.open.warning_html', label: visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)) %>
             </div>
           </label>
         </li>
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
-            <%= t('hyrax.visibility.authenticated.label_html', institution: institution_name) %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) %>
             <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
           </label>
         </li>
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
-            <%= t('hyrax.visibility.embargo.label_html') %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) %>
             <div class="collapse" id="collapseEmbargo">
               <div class="form-inline">
                 <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
@@ -39,7 +39,7 @@
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, data: { 'target': '#collapseLease' } %>
-            <%= t('hyrax.visibility.lease.label_html') %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE) %>
             <div class="collapse" id="collapseLease">
               <div class="form-inline">
                 <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
@@ -52,7 +52,7 @@
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
-            <%= t('hyrax.visibility.private.label_html') %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
             <%= t('hyrax.visibility.private.note_html') %>
           </label>
         </li>

--- a/app/views/hyrax/collections/_form_permission.html.erb
+++ b/app/views/hyrax/collections/_form_permission.html.erb
@@ -8,15 +8,15 @@
     <div class="form-group">
       <label class="radio">
         <input type="radio" id="visibility_open" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>" <% if @collection.open_access? %> checked="true"<% end %>/>
-        <%= t('hyrax.visibility.open.label_html', type: 'content') %>
+        <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) %>
       </label>
       <label class="radio">
         <input type="radio" id="visibility_registered" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>" <% if @collection.authenticated_only_access? %> checked="true"<% end %> />
-        <%= t('hyrax.visibility.authenticated.label_html', institution: institution_name) %>
+        <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) %>
       </label>
       <label class="radio">
         <input type="radio" id="visibility_restricted" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE%>" <% if @collection.private_access? %> checked="true"<% end %>/>
-        <%= t('hyrax.visibility.private.label_html') %>
+        <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
       </label>
     </div>
 

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -620,19 +620,15 @@ en:
     visibility:
       authenticated:
         class: "label-info"
-        label_html: <span class="label label-info">%{institution}</span>
         note_html: Restrict access to only users and/or groups from %{institution}
       embargo:
         class: "label-warning"
-        label_html: <span class="label label-warning">Embargo</span>
         text: "Embargo"
       lease:
         class: "label-warning"
-        label_html: <span class="label label-warning">Lease</span>
         text: "Lease"
       open:
         class: "label-success"
-        label_html: <span class="label label-success">Open Access</span>
         note_html:  Everyone. Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for specific publishers' copyright policies if you plan to patent and/or publish your %{type} in a journal.
         text: "Open Access"
         warning_html: "<p>
@@ -650,7 +646,6 @@ en:
                       </p>"
       open_title_attr: "Change the visibility of this resource"
       private:
-        label_html: <span class="label label-danger">Private</span>
         note_html: Only users and/or groups that have been given specific access in the "Share With" section.
         text: "Private"
       private_title_attr: "Change the visibility of this resource"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -620,19 +620,15 @@ es:
     visibility:
       authenticated:
         class: "label-info"
-        label_html: <span class="label label-info">%{institution}</span>
         note_html: Restringir el acceso sólo a usuarios y / o grupos de %{institution}
       embargo:
         class: "label-warning"
-        label_html: <span class="label label-warning">Embargo</span>
         text: "Embargo"
       lease:
         class: "label-warning"
-        label_html: <span class="label label-warning">Arrendamiento</span>
         text: "Arrendamiento"
       open:
         class: "label-success"
-        label_html: <span class="label label-success">Público</span>
         note_html: Todo el mundo. Consulte <a href="">SHERPA / RoMEO</a> para las políticas de derechos de autor de editores específicos si planea patentar y / o publicar su %{type} en un diario
         text: "Acceso abierto"
         warning_html: "<p>
@@ -650,7 +646,6 @@ es:
                       </p>"
       open_title_attr: "Cambiar la visibilidad de este recurso"
       private:
-        label_html: <span class="label label-danger">Privado</span>
         note_html:  Sólo los usuarios y / o grupos a los que se les ha dado acceso específico en la sección "Compartir con".
         text: Privado
       private_title_attr: "Cambiar la visibilidad de este recurso"

--- a/spec/presenters/hyrax/permission_badge_spec.rb
+++ b/spec/presenters/hyrax/permission_badge_spec.rb
@@ -1,29 +1,72 @@
 require 'spec_helper'
 
 describe Hyrax::PermissionBadge do
-  let(:badge) { described_class.new(solr_doc) }
-  let(:solr_doc) { SolrDocument.new(attributes) }
-  let(:attributes) { {} }
+  context "with a SolrDocument" do
+    let(:badge) { described_class.new(solr_doc) }
+    let(:solr_doc) { SolrDocument.new(attributes) }
+    let(:attributes) { {} }
 
-  describe "#render" do
-    subject { badge.render }
-    context "when open-access with embargo" do
-      let(:attributes) { { read_access_group_ssim: ['public'], embargo_release_date_dtsi: '2016-05-04' } }
-      it { is_expected.to eq "<span title=\"Open Access with Embargo\" class=\"label label-warning\">Open Access with Embargo</span>" }
+    describe "#render" do
+      subject { badge.render }
+      before do
+        expect(Deprecation).to receive(:warn)
+      end
+
+      context "when under embargo" do
+        let(:attributes) { { read_access_group_ssim: ['public'], embargo_release_date_dtsi: '2016-05-04' } }
+        it { is_expected.to eq "<span class=\"label label-warning\">Embargo</span>" }
+      end
+
+      context "when under lease" do
+        let(:attributes) { { read_access_group_ssim: ['public'], lease_expiration_date_dtsi: '2016-05-04' } }
+        it { is_expected.to eq "<span class=\"label label-warning\">Lease</span>" }
+      end
+
+      context "when open-access" do
+        let(:attributes) { { read_access_group_ssim: ['public'] } }
+        it { is_expected.to eq "<span class=\"label label-success\">Open Access</span>" }
+      end
+
+      context "when registered" do
+        let(:attributes) { { read_access_group_ssim: ['registered'] } }
+        it { is_expected.to eq "<span class=\"label label-info\">Institution</span>" }
+      end
+
+      context "when private" do
+        it { is_expected.to eq "<span class=\"label label-danger\">Private</span>" }
+      end
     end
+  end
 
-    context "when open-access" do
-      let(:attributes) { { read_access_group_ssim: ['public'] } }
-      it { is_expected.to eq "<span title=\"Open Access\" class=\"label label-success\">Open Access</span>" }
-    end
+  context "with a string" do
+    let(:badge) { described_class.new(value) }
 
-    context "when registered" do
-      let(:attributes) { { read_access_group_ssim: ['registered'] } }
-      it { is_expected.to eq "<span title=\"Institution\" class=\"label label-info\">Institution</span>" }
-    end
+    describe "#render" do
+      subject { badge.render }
+      context "when under embargo" do
+        let(:value) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO }
+        it { is_expected.to eq "<span class=\"label label-warning\">Embargo</span>" }
+      end
 
-    context "when private" do
-      it { is_expected.to eq "<span title=\"Private\" class=\"label label-danger\">Private</span>" }
+      context "when under lease" do
+        let(:value) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE }
+        it { is_expected.to eq "<span class=\"label label-warning\">Lease</span>" }
+      end
+
+      context "when open-access" do
+        let(:value) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+        it { is_expected.to eq "<span class=\"label label-success\">Open Access</span>" }
+      end
+
+      context "when registered" do
+        let(:value) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+        it { is_expected.to eq "<span class=\"label label-info\">Institution</span>" }
+      end
+
+      context "when private" do
+        let(:value) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+        it { is_expected.to eq "<span class=\"label label-danger\">Private</span>" }
+      end
     end
   end
 end


### PR DESCRIPTION
Prior to this there was still the Sufia way and the CurationConcerns
way.

Fixes #137
