### PR TITLE
Add an editable help page

### DIFF
--- a/app/assets/javascripts/hyrax/app.js
+++ b/app/assets/javascripts/hyrax/app.js
@@ -15,7 +15,15 @@ Hyrax = {
         this.datatable();
         this.admin();
         this.adminStatisticsGraphs();
+        this.tinyMCE();
+    },
 
+    tinyMCE: function() {
+        if (typeof tinyMCE === "undefined")
+            return;
+        tinyMCE.init({
+            selector: 'textarea.tinymce'
+        });
     },
 
     admin: function() {

--- a/app/controllers/hyrax/pages_controller.rb
+++ b/app/controllers/hyrax/pages_controller.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  # Shows the about page
+  # Shows the about and help page
   class PagesController < ApplicationController
     helper Hyrax::ContentBlockHelper
 

--- a/app/helpers/hyrax/content_block_helper_behavior.rb
+++ b/app/helpers/hyrax/content_block_helper_behavior.rb
@@ -44,12 +44,5 @@ module Hyrax
       content_block = ContentBlock.new(name: name)
       edit_form(content_block, "new_#{name}_text_area")
     end
-
-    def tiny_mce_stuff
-      capture do
-        concat tinymce_assets
-        concat tinymce
-      end
-    end
   end
 end

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -3,10 +3,10 @@
     <div class="row">
       <ul class="nav navbar-nav col-sm-5 col-md-6">
         <li <%= 'class=active' if current_page?(hyrax.root_path) %>>
-          <%= link_to t(:'hyrax.controls.home'), hyrax.root_path, :'data-no-turbolink'=>"true" %></li>
+          <%= link_to t(:'hyrax.controls.home'), hyrax.root_path %></li>
         <li <%= 'class=active' if current_page?(hyrax.about_path) %>>
-          <%= link_to t(:'hyrax.controls.about'), hyrax.about_path, :'data-no-turbolink'=>"true" %></li>
-        <li <%= 'class=active' if action_name == "help" %>>
+          <%= link_to t(:'hyrax.controls.about'), hyrax.about_path %></li>
+        <li <%= 'class=active' if current_page?(hyrax.help_path) %>>
           <%= link_to t(:'hyrax.controls.help'), hyrax.help_path %></li>
         <li <%= 'class=active' if current_page?(hyrax.contact_path) %>>
           <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path %></li>

--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -23,4 +23,3 @@
 <div class="row home-content">
   <%= render 'home_content' %>
 </div>
-<%= tiny_mce_stuff if can? :update, ContentBlock%>

--- a/app/views/hyrax/pages/show.html.erb
+++ b/app/views/hyrax/pages/show.html.erb
@@ -1,3 +1,1 @@
 <%= editable_content_block @page %>
-<%= tiny_mce_stuff if can? :update, ContentBlock%>
-

--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -17,6 +17,8 @@
 
 <!-- application js -->
 <%= javascript_include_tag 'application' %>
+<%= tinymce_assets if can? :update, ContentBlock %>
+
 
 <!-- Google Analytics -->
 <%= render partial: '/ga', formats: [:html] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -197,9 +197,10 @@ Hyrax::Engine.routes.draw do
   post '/tinymce_assets' => 'tinymce_assets#create'
 
   get 'about' => 'pages#show', id: 'about_page'
+  get 'help' => 'pages#show', id: 'help_page'
 
   # Static page routes
-  %w(help terms zotero mendeley agreement versions).each do |action|
+  %w(terms zotero mendeley agreement versions).each do |action|
     get action, controller: 'static', action: action, as: action
   end
 end

--- a/spec/routing/route_spec.rb
+++ b/spec/routing/route_spec.rb
@@ -143,13 +143,12 @@ describe 'Routes', :no_clean, type: :routing do
     it "routes to about" do
       expect(get: '/about').to route_to(controller: 'hyrax/pages', action: 'show', id: 'about_page')
     end
+    it "routes to help" do
+      expect(get: '/help').to route_to(controller: 'hyrax/pages', action: 'show', id: 'help_page')
+    end
   end
 
   describe "Static Pages" do
-    it "routes to help" do
-      expect(get: '/help').to route_to(controller: 'hyrax/static', action: 'help')
-    end
-
     it "routes to terms" do
       expect(get: '/terms').to route_to(controller: 'hyrax/static', action: 'terms')
     end


### PR DESCRIPTION
Previously help was a static page, but about was something you could
edit with tinymce.  Now you can edit the help page just like you can
with the about page.

Also fixes tinymce + turbolinks compatibility.