### PR TITLE
Adding support for magic workflow roles

### DIFF
--- a/app/models/sipity/role.rb
+++ b/app/models/sipity/role.rb
@@ -20,6 +20,7 @@ module Sipity
   #   work that is being deposited (i.e. co-author on a paper).
   #
   # @see Sipity::Agent
+  # @see Hyrax::Configuration
   class Role < ActiveRecord::Base
     self.table_name = 'sipity_roles'
 
@@ -32,6 +33,8 @@ module Sipity
              foreign_key: :role_id,
              class_name: 'Sipity::NotificationRecipient'
 
+    before_destroy :prevent_registered_roles_from_being_destroyed
+
     def self.[](name)
       find_or_create_by!(name: name.to_s)
     end
@@ -39,5 +42,11 @@ module Sipity
     def to_s
       name
     end
+
+    private
+
+      def prevent_registered_roles_from_being_destroyed
+        throw :abort if Hyrax.config.registered_role?(name: name)
+      end
   end
 end

--- a/lib/generators/hyrax/templates/config/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/hyrax.rb
@@ -1,4 +1,11 @@
 Hyrax.config do |config|
+  # Register roles that are expected by your implementation.
+  # @see Hyrax::RoleRegistry for additional details.
+  # @note there are magical roles as defined in Hyrax::RoleRegistry::MAGIC_ROLES
+  # config.register_roles do |registry|
+  #   registry.add(name: 'captaining', description: 'For those that really like the front lines')
+  # end
+
   # Email recipient of messages sent via the contact form
   # config.contact_email = "repo-admin@example.org"
 

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -31,6 +31,13 @@ module Hyrax
     autoload :Collections
   end
 
+  # @api public
+  #
+  # Exposes the Hyrax configuration
+  #
+  # @yield [Hyrax::Configuration] if a block is passed
+  # @return [Hyrax::Configuration]
+  # @see Hyrax::Configuration for configuration options
   def self.config(&block)
     @config ||= Hyrax::Configuration.new
 

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -1,4 +1,5 @@
 require 'hyrax/callbacks'
+require 'hyrax/role_registry'
 
 module Hyrax
   class Configuration
@@ -6,6 +7,28 @@ module Hyrax
 
     def initialize
       @registered_concerns = []
+      @role_registry = Hyrax::RoleRegistry.new
+    end
+
+    # @return [Hyrax::RoleRegistry]
+    attr_reader :role_registry
+    private :role_registry
+    delegate :registered_role?, :persist_registered_roles!, to: :role_registry
+
+    # @api public
+    #
+    # Exposes a means to register application critical roles
+    #
+    # @example
+    #   Hyrax.config.register_roles do |registry|
+    #     registry.add(name: 'captaining', description: 'Grants captain duties')
+    #   end
+    #
+    # @yield [Hyrax::RoleRegistry]
+    # @return [TrueClass]
+    def register_roles
+      yield(@role_registry)
+      true
     end
 
     # Path on the local file system where derivatives will be stored

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -20,6 +20,18 @@ module Hyrax
       #{config.root}/app/models/hyrax/pageview.rb
     )
 
+    config.after_initialize do
+      begin
+        Hyrax.config.persist_registered_roles!
+        Rails.logger.info("Hyrax::Engine.after_initialize - persisting registered roles!")
+      rescue
+        message = "Hyrax::Engine.after_initialize - unable to persist registered roles.\n"
+        message += "It is expected during the application installation - during integration tests, rails install.\n"
+        message += "It is UNEXPECTED if you are booting up a Hyrax powered application via `rails server'"
+        Rails.logger.info(message)
+      end
+    end
+
     initializer 'requires' do
       require 'hydra/derivatives'
       require 'hyrax/name'

--- a/lib/hyrax/role_registry.rb
+++ b/lib/hyrax/role_registry.rb
@@ -1,0 +1,54 @@
+module Hyrax
+  # Responsible for registering roles critical for your application.
+  # Registering a role is effectively saying "my application logic will not work if this role goes away".
+  #
+  # @see Sipity::Role
+  class RoleRegistry
+    # @api public
+    # You may develop your application assuming that the 'managing' role will always be present and valid
+    MANAGING = 'managing'.freeze
+
+    # @api public
+    # You may develop your application assuming that the 'depositing' role will always be present and valid
+    DEPOSITING = 'depositing'.freeze
+
+    # @api public
+    #
+    # It is a safe assumption that Hyrax has these magic roles.
+    # While the descriptions may be mutable, the names are assumed to exist.
+    #
+    # @see Sipity::Role for data integrity enforcement
+    MAGIC_ROLES = {
+      MANAGING => 'Grants access to management tasks'.freeze,
+      DEPOSITING => 'Grants access to depositing tasks'.freeze
+    }.freeze
+
+    def initialize
+      @roles = MAGIC_ROLES.dup
+    end
+
+    def add(name:, description:)
+      @roles[name.to_s] = description
+    end
+
+    def role_names
+      @roles.keys.sort
+    end
+
+    def registered_role?(name:)
+      @roles.key?(name.to_s)
+    end
+
+    # @api public
+    #
+    # Load the registered roles into Sipity::Role
+    def persist_registered_roles!
+      @roles.each do |name, description|
+        Sipity::Role.find_or_create_by!(name: name).tap do |role|
+          role.description = description
+          role.save!
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -3,6 +3,14 @@ require 'spec_helper'
 describe Hyrax::Configuration do
   subject { described_class.new }
 
+  describe '#register_roles' do
+    it 'yields a RoleRegistry' do
+      expect { |b| subject.register_roles(&b) }.to yield_with_args(kind_of(Hyrax::RoleRegistry))
+    end
+  end
+  it { is_expected.to delegate_method(:registered_role?).to(:role_registry) }
+  it { is_expected.to delegate_method(:persist_registered_roles!).to(:role_registry) }
+
   it { is_expected.to respond_to(:persistent_hostpath) }
   it { is_expected.to respond_to(:redis_namespace) }
   it { is_expected.to respond_to(:libreoffice_path) }

--- a/spec/lib/hyrax/role_registry_spec.rb
+++ b/spec/lib/hyrax/role_registry_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::RoleRegistry do
+  let(:role_registry) { described_class.new }
+  describe '#role_names (without adding roles)' do
+    subject { role_registry.role_names }
+    it { is_expected.to eq(['depositing', 'managing']) }
+  end
+
+  describe '#registered_role?' do
+    subject { role_registry.registered_role?(name: name) }
+    describe 'for already registered name' do
+      let(:name) { described_class::MANAGING }
+      it { is_expected.to be_truthy }
+    end
+    describe 'for non-registered name' do
+      let(:name) { 'gong_farming' }
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe '#add' do
+    subject { role_registry.add(name: 'captaining', description: 'Grants captain duties') }
+    it 'includes those added via #add' do
+      expect { subject }.to change { role_registry.role_names }
+        .from(['depositing', 'managing']).to(['captaining', 'depositing', 'managing'])
+    end
+  end
+
+  describe '#persist_registered_roles!' do
+    subject { role_registry.persist_registered_roles! }
+    it 'creates Sipity::Role records for each role_name' do
+      expect { subject }.to change { Sipity::Role.count }.by(role_registry.role_names.count)
+    end
+  end
+end

--- a/spec/models/sipity/role_spec.rb
+++ b/spec/models/sipity/role_spec.rb
@@ -26,5 +26,16 @@ module Sipity
       subject.name = 'advising'
       expect(subject.to_s).to eq(subject.name)
     end
+
+    context '#destroy' do
+      it 'will not allow registered role names to be destroyed' do
+        role = Sipity::Role.create!(name: Hyrax::RoleRegistry::MANAGING)
+        expect { role.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+      end
+      it 'will allow unregistered role names to be destroyed' do
+        role = Sipity::Role.create!(name: 'gong_farming')
+        expect { role.destroy! }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
It is helpful to include magical role names for the workflow. In doing
so we can begin to describe more assumptions about how workflows are
configured and work.

It also provides a concrete concept to hang assumptions on.

Closes #458

@projecthydra-labs/hyrax-code-reviewers
