### PR TITLE
Visibility method should not shadow exisiting method

### DIFF
--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -24,17 +24,13 @@ module Hyrax
         @workflow_id || active_workflow.id
       end
 
-      def visibility
-        Widgets::AdminSetVisibility.new
+      def visibility_options
+        Widgets::AdminSetVisibility.new.options
       end
 
-      delegate :options, to: :visibility, prefix: :visibility
-
-      def embargo
-        Widgets::AdminSetEmbargoPeriod.new
+      def embargo_options
+        Widgets::AdminSetEmbargoPeriod.new.options
       end
-
-      delegate :options, to: :embargo, prefix: :embargo
 
       def initialize(model)
         super(model)

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
   it { is_expected.to delegate_method(:available_workflows).to(:model) }
   it { is_expected.to delegate_method(:active_workflow).to(:model) }
   it { is_expected.to delegate_method(:admin_set).to(:model) }
+  it { is_expected.to delegate_method(:visibility).to(:model) }
 
   it 'is expected to delegate method #active_workflow_id to #active_workflow#id' do
     workflow = double(:workflow, id: 1234, active: true)


### PR DESCRIPTION
Reverting part of 91729ff3bf48e1d7be1084bbe418d0c393ce46a2 which
shadowed the existing visibility method defined here:
https://github.com/projecthydra-labs/hyrax/blob/91729ff3bf48e1d7be1084bbe418d0c393ce46a2/app/forms/hyrax/forms/permission_template_form.rb#L8
