### PR TITLE
Add YAMLStrategy for Flipflop

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,22 @@ The [Sufia Management Guide](https://github.com/projecthydra/sufia/wiki/Sufia-Ma
 * Setting up administrative users
 * Metadata customization
 
+## Toggling Features
+
+Some features in Hyrax can be flipped on and off from either the Administrative
+Dashboard or via a YAML configuration file at `config/features.yml`. An example
+of the YAML file is below:
+
+```yaml
+assign_admin_set:
+  enabled: "false"
+proxy_deposit:
+  enabled: "false"
+```
+
+If both options exist, whichever option is set from the Administrative Dashboard
+will take precedence.
+
 # License
 
 Hyrax is available under [the Apache 2.0 license](LICENSE.md).

--- a/app/strategies/hyrax/strategies/yaml_strategy.rb
+++ b/app/strategies/hyrax/strategies/yaml_strategy.rb
@@ -1,0 +1,45 @@
+module Hyrax::Strategies
+  class YamlStrategy < Flipflop::Strategies::AbstractStrategy
+    class << self
+      def default_description
+        "Features configured by a YAML configuration file."
+      end
+    end
+
+    def initialize(**options)
+      @config_file = options.delete(:config)
+      yaml_file
+      super(**options)
+    end
+
+    def switchable?
+      false
+    end
+
+    def enabled?(feature)
+      return unless key_exists?(feature)
+      yaml_file[feature.to_s]["enabled"]
+    end
+
+    def switch!(_feature, _enabled); end
+
+    def clear!(_feature); end
+
+    private
+
+      def key_exists?(feature)
+        yaml_file[feature.to_s] && yaml_file[feature.to_s].key?("enabled")
+      end
+
+      def yaml_file
+        @yaml_file ||=
+          begin
+            if File.exist?(@config_file)
+              YAML.load_file(@config_file)
+            else
+              {}
+            end
+          end
+      end
+  end
+end

--- a/config/features.rb
+++ b/config/features.rb
@@ -2,6 +2,7 @@ Flipflop.configure do
   # Strategies will be used in the order listed here.
   strategy :cookie
   strategy :active_record, class: Hyrax::Feature
+  strategy Hyrax::Strategies::YamlStrategy, config: Hyrax.config.feature_config_path
   strategy :default
 
   feature :proxy_deposit,

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -59,6 +59,11 @@ module Hyrax
       @fits_message_length ||= 5
     end
 
+    attr_writer :feature_config_path
+    def feature_config_path
+      @feature_config_path ||= Rails.root.join('config', 'features.yml')
+    end
+
     attr_accessor :temp_file_base, :enable_local_ingest,
                   :analytics, :analytic_start_date
 

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -35,4 +35,5 @@ describe Hyrax::Configuration do
   it { is_expected.to respond_to(:contact_email) }
   it { is_expected.to respond_to(:subject_prefix) }
   it { is_expected.to respond_to(:model_to_create) }
+  it { is_expected.to respond_to(:feature_config_path) }
 end

--- a/spec/strategies/hyrax/strategies/yaml_strategy_spec.rb
+++ b/spec/strategies/hyrax/strategies/yaml_strategy_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe Hyrax::Strategies::YamlStrategy do
+  subject { described_class.new(config: "test_file") }
+  context "when given a YAML file" do
+    let(:content) do
+      {
+        "assign_admin_set" => {
+          "enabled" => false
+        }
+      }
+    end
+    before do
+      allow(YAML).to receive(:load_file).with("test_file").and_return(content)
+      allow(File).to receive(:exist?).with("test_file").and_return(true)
+    end
+    it "tests for features based on an enabled key" do
+      expect(subject.enabled?(:assign_admin_set)).to eq false
+    end
+    it "returns nil for unknown features" do
+      expect(subject.enabled?(:unknown_Feature)).to be_nil
+    end
+  end
+
+  context "when given a non-existent file" do
+    it "returns nil for everything" do
+      expect(subject.enabled?(:assign_admin_set)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This allows users to configure their application without using the admin
panel, if they so wish.

Closes #372.