### PR TITLE
470 default admin set does not have active workflow

### DIFF
--- a/app/actors/hyrax/default_admin_set_actor.rb
+++ b/app/actors/hyrax/default_admin_set_actor.rb
@@ -3,6 +3,8 @@ module Hyrax
   # an admin_set_id provided. This should come before the
   # Hyrax::Actors::InitializeWorkflowActor, so that the correct
   # workflow can be kicked off.
+  #
+  # @note Creates AdminSet, Hyrax::PermissionTemplate, Sipity::Workflow (with activation)
   class DefaultAdminSetActor < Hyrax::Actors::AbstractActor
     def create(attributes)
       ensure_admin_set_attribute!(attributes)
@@ -30,11 +32,20 @@ module Hyrax
         AdminSet.exists?(AdminSet::DEFAULT_ID)
       end
 
-      # Creates the default AdminSet and an associated PermissionTemplate with workflow
+      # Creates the default AdminSet and an associated PermissionTemplate with workflow and activates the default.
+      #
       # rubocop:disable Lint/HandleExceptions
       def create_default_admin_set
-        AdminSet.create!(id: AdminSet::DEFAULT_ID, title: ['Default Admin Set']).tap do |_as|
-          PermissionTemplate.create!(admin_set_id: AdminSet::DEFAULT_ID)
+        # Wrapping in a transaction, leveraging the fact that database entries can be transactional.
+        # If we first create the admin set then step through the Hyrax::PermissionTemplate
+        Hyrax::PermissionTemplate.transaction do
+          Sipity::Workflow.transaction do
+            Hyrax::PermissionTemplate.create!(admin_set_id: AdminSet::DEFAULT_ID) do |permission_template|
+              Hyrax::Workflow::WorkflowImporter.load_workflow_for(permission_template: permission_template)
+              Sipity::Workflow.activate!(permission_template: permission_template, workflow_name: Hyrax.config.default_active_workflow_name)
+            end
+            AdminSet.create!(id: AdminSet::DEFAULT_ID, title: ['Default Admin Set'])
+          end
         end
       rescue ActiveFedora::IllegalOperation
         # It is possible that another thread created the AdminSet just before this method

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -21,7 +21,7 @@ module Hyrax
       attr_writer :workflow_id
 
       def workflow_id
-        @workflow_id || active_workflow.id
+        @workflow_id || active_workflow.try(:id)
       end
 
       def visibility

--- a/app/models/sipity/workflow.rb
+++ b/app/models/sipity/workflow.rb
@@ -42,10 +42,14 @@ module Sipity
     #
     # @param permission_template [Hyrax::PermissionTemplate] The scope for activation of the workflow id
     # @param workflow_id [Integer] The workflow_id within the given permission_template that should be activated
+    # @param workflow_name [String] The name of the workflow within the given permission template that should be activated
     # @return [TrueClass]
     # @raise [ActiveRecord::RecordNotFound] When we have a mismatch on permission template and workflow id
-    def self.activate!(permission_template:, workflow_id:)
-      Sipity::Workflow.find_by!(permission_template: permission_template, id: workflow_id).tap do |workflow|
+    # @raise [RuntimeError] When you don't specify a workflow_id or workflow_name
+    def self.activate!(permission_template:, workflow_id: nil, workflow_name: nil)
+      raise "You must specify a workflow_id or workflow_name to activate!" if workflow_id.blank? && workflow_name.blank?
+      finder_attributes = { permission_template: permission_template, id: workflow_id, name: workflow_name }.compact
+      Sipity::Workflow.find_by!(finder_attributes).tap do |workflow|
         Sipity::Workflow.where(permission_template: permission_template, active: true).update(active: nil)
         workflow.update!(active: true)
       end

--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -44,6 +44,7 @@ module Hyrax
 
       def create_workflows_for(permission_template:)
         workflow_importer.call(permission_template: permission_template)
+        Sipity::Workflow.activate!(permission_template: permission_template, workflow_name: Hyrax.config.default_active_workflow_name)
       end
 
       def default_workflow_importer

--- a/lib/generators/hyrax/templates/config/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/hyrax.rb
@@ -6,6 +6,11 @@ Hyrax.config do |config|
   #   registry.add(name: 'captaining', description: 'For those that really like the front lines')
   # end
 
+  # When an admin set is created, we need to activate a workflow.
+  # The :default_active_workflow_name is the name of the workflow we will activate.
+  # @see Hyrax::Configuration for additional details and defaults.
+  # config.default_active_workflow_name = 'default'
+
   # Email recipient of messages sent via the contact form
   # config.contact_email = "repo-admin@example.org"
 

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -8,7 +8,22 @@ module Hyrax
     def initialize
       @registered_concerns = []
       @role_registry = Hyrax::RoleRegistry.new
+      @default_active_workflow_name = DEFAULT_ACTIVE_WORKFLOW_NAME
     end
+
+    DEFAULT_ACTIVE_WORKFLOW_NAME = 'default'.freeze
+    private_constant :DEFAULT_ACTIVE_WORKFLOW_NAME
+
+    # @api public
+    # When an admin set is created, we need to activate a workflow.
+    # The :default_active_workflow_name is the name of the workflow we will activate.
+    #
+    # @return [String]
+    # @see Sipity::Workflow
+    # @see AdminSet
+    # @note The active workflow for an admin set can be changed at a later point.
+    # @note Changing this value after other AdminSet(s) are created does not alter the already created AdminSet(s)
+    attr_accessor :default_active_workflow_name
 
     # @return [Hyrax::RoleRegistry]
     attr_reader :role_registry

--- a/spec/actors/hyrax/default_admin_set_actor_spec.rb
+++ b/spec/actors/hyrax/default_admin_set_actor_spec.rb
@@ -25,10 +25,11 @@ RSpec.describe Hyrax::DefaultAdminSetActor do
       let(:attributes) { { admin_set_id: '' } }
       let(:default_id) { AdminSet::DEFAULT_ID }
 
-      it "creates the default AdminSet with a PermissionTemplate and calls the next actor with the default admin set id" do
+      it "creates the default AdminSet with a PermissionTemplate and an ActiveWorkflow then calls the next actor with the default admin set id" do
         expect(next_actor).to receive(:create).with(admin_set_id: default_id).and_return(true)
         expect { actor.create(attributes) }.to change { AdminSet.count }.by(1)
           .and change { Hyrax::PermissionTemplate.count }.by(1)
+          .and change { Sipity::Workflow.where(active: true).count }.by(1)
       end
     end
 

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -11,6 +11,11 @@ describe Hyrax::Configuration do
   it { is_expected.to delegate_method(:registered_role?).to(:role_registry) }
   it { is_expected.to delegate_method(:persist_registered_roles!).to(:role_registry) }
 
+  describe '#default_active_workflow_name' do
+    subject { described_class.new.default_active_workflow_name }
+    it { is_expected.to eq('default') }
+  end
+
   it { is_expected.to respond_to(:persistent_hostpath) }
   it { is_expected.to respond_to(:redis_namespace) }
   it { is_expected.to respond_to(:libreoffice_path) }

--- a/spec/models/sipity/workflow_spec.rb
+++ b/spec/models/sipity/workflow_spec.rb
@@ -19,19 +19,37 @@ module Sipity
       let!(:permission_template) { create(:permission_template) }
       let!(:other_permission_template) { create(:permission_template) }
       let!(:active_workflow) { create(:workflow, active: true, permission_template_id: permission_template.id) }
+      it 'raises an exception if you do not pass a workflow_id nor workflow_name' do
+        expect do
+          described_class.activate!(permission_template: other_permission_template)
+        end.to raise_error(RuntimeError)
+      end
       it 'raises an exception on a mismatch' do
         expect do
           described_class.activate!(permission_template: other_permission_template, workflow_id: active_workflow.id)
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
-      it 'toggles current active workflows for the permission_template' do
-        active_workflow_wrong_template = create(:workflow, active: true, permission_template_id: other_permission_template.id)
-        inactive_workflow = create(:workflow, permission_template_id: permission_template.id)
+      context 'with :workflow_id keyword' do
+        it 'toggles current active workflows for the permission_template' do
+          active_workflow_wrong_template = create(:workflow, active: true, permission_template_id: other_permission_template.id)
+          inactive_workflow = create(:workflow, permission_template_id: permission_template.id)
 
-        described_class.activate!(permission_template: permission_template, workflow_id: inactive_workflow)
-        expect(inactive_workflow.reload).to be_active
-        expect(active_workflow.reload).not_to be_active
-        expect(active_workflow_wrong_template.reload).to be_active
+          described_class.activate!(permission_template: permission_template, workflow_id: inactive_workflow)
+          expect(inactive_workflow.reload).to be_active
+          expect(active_workflow.reload).not_to be_active
+          expect(active_workflow_wrong_template.reload).to be_active
+        end
+      end
+      context 'with :workflow_name keyword' do
+        it 'toggles current active workflows for the permission_template' do
+          active_workflow_wrong_template = create(:workflow, active: true, permission_template_id: other_permission_template.id)
+          inactive_workflow = create(:workflow, permission_template_id: permission_template.id)
+
+          described_class.activate!(permission_template: permission_template, workflow_name: inactive_workflow.name)
+          expect(inactive_workflow.reload).to be_active
+          expect(active_workflow.reload).not_to be_active
+          expect(active_workflow_wrong_template.reload).to be_active
+        end
       end
     end
 

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Hyrax::AdminSetCreateService do
     context "when the admin_set is valid" do
       let(:permission_template) { Hyrax::PermissionTemplate.find_by(admin_set_id: admin_set.id) }
       let(:grant) { permission_template.access_grants.first }
-      it "is creates an AdminSet, PermissionTemplate, Workflows and sets access" do
+      it "is creates an AdminSet, PermissionTemplate, Workflows, activates the default workflow, and sets access" do
+        expect(Sipity::Workflow).to receive(:activate!).with(permission_template: kind_of(Hyrax::PermissionTemplate), workflow_name: Hyrax.config.default_active_workflow_name)
         expect do
           expect(subject).to be true
         end.to change { admin_set.persisted? }.from(false).to(true)


### PR DESCRIPTION
**NOTE: This introduces a change in behavior for the default admin set by
changing the grants applied to the AdminSet.**

## Activating workflow for DefaultAdminSetActor

@15ddc1eb5ce28e54614dad88b7545371fc939bbc

* Allow configuration of default active workflow
* Incorporating transaction to wrap creation of:
  * AdminSet
  * Hyrax::PermissionTemplate
  * Sipity::Workflow
* Allow activation of Sipity::Workflow by workflow name

Related to #470

## Consolidating AdminSet creation logic

@a6f3ad740a3565a7772ffea1448825a6532784e0

The DefaultAdminSetActor logic was going through a different path than
the AdminSetCreateService. In consolidating these, I hope to improve
the consistence of the logic.

NOTE: This introduces a change in behavior for the default admin set by
changing the grants applied to the AdminSet.

Closes #470

@projecthydra-labs/hyrax-code-reviewers
