### PR TITLE
Fix admin set visibility radio buttons

### DIFF
--- a/app/controllers/hyrax/admin/permission_templates_controller.rb
+++ b/app/controllers/hyrax/admin/permission_templates_controller.rb
@@ -5,11 +5,23 @@ module Hyrax
                                   id_param: 'admin_set_id',
                                   class: 'Hyrax::PermissionTemplate'
 
+      # Override the default prefixes so that we use the collection partals.
+      def self.local_prefixes
+        ["hyrax/admin/admin_sets"]
+      end
+
       def update
-        form.update(update_params)
-        # Ensure we redirect to currently active tab with the appropriate notice
-        redirect_to edit_admin_admin_set_path(params[:admin_set_id], anchor: current_tab),
-                    notice: translate(current_tab, scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
+        update_info = form.update(update_params)
+        if update_info[:updated] == true # Ensure we redirect to currently active tab with the appropriate notice
+          redirect_to(edit_admin_admin_set_path(params[:admin_set_id], anchor: current_tab),
+                      notice: translate(update_info[:content_tab], scope: 'hyrax.admin.admin_sets.form.permission_update_notices'))
+        else
+          # When we have invalid data, we are redirecting because to render, we need to set an AdminSetForm
+          # (because we are rendering admin set forms)
+          # TODO: [Jeremy Friesen says: We need to better consolidate the form logic of admin sets and permission templates
+          redirect_to(edit_admin_admin_set_path(params[:admin_set_id], anchor: current_tab),
+                      alert: translate(update_info[:error_code], scope: 'hyrax.admin.admin_sets.form.permission_update_errors'))
+        end
       end
 
       private
@@ -29,7 +41,7 @@ module Hyrax
           pt = params[:permission_template]
           @current_tab ||= if pt[:access_grants_attributes].present?
                              'participants'
-                           elsif pt[:workflow_name].present?
+                           elsif pt[:workflow_id].present?
                              'workflow'
                            else
                              'visibility'

--- a/app/views/hyrax/admin/admin_sets/_form_visibility.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_visibility.html.erb
@@ -27,7 +27,7 @@
                       </li>
                       <li class="radio form-inline">
                         <label>
-                          <%= f.radio_button :release_varies, Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_EMBARGO %>
+                          <%= f.radio_button :release_varies, Hyrax::PermissionTemplate::RELEASE_TEXT_VALUE_EMBARGO  %>
                           <%= t('.release.varies.between') %>
                           <%= f.collection_select :release_embargo, f.object.embargo_options, :first, :last, prompt: t('.release.varies.embargo.select') %>
                         </label>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -52,8 +52,14 @@ en:
           permission_update_notices:
             new_admin_set:      "The administrative set '%{name}' has been created. Use the additional tabs to define other aspects of the administrative set."
             participants:       "The administrative set's participant rights have been updated"
-            visibility:         "The administrative set's visibility settings have been updated."
+            visibility:         "The administrative set's release & visibility settings have been updated."
             workflow:           "The administrative set's workflow has been updated."
+          permission_update_errors:
+            varies:             "Release option 'Varies' requires a date or embargo period."
+            no_date:            "A date is required for the selected release option."
+            no_embargo:         "An embargo period is required for the selected option."
+            nothing:            "Select release options before pressing save."
+            error:              "Invalid update option for permission template."
           tabs:
             description:        "Description"
             participants:       "Participants"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -54,6 +54,12 @@ es:
             participants:       "Se han actualizado los derechos de participante del conjunto administrativo"
             visibility:         "La configuración de visibilidad del conjunto administrativo se ha actualizado."
             workflow:           "El flujo de trabajo del conjunto administrativo se ha actualizado."
+          permission_update_errors:
+            varies:             "La opción de lanzamiento 'Varía' requiere una fecha o período de embargo."
+            no_date:            "Se requiere una fecha para la opción de lanzamiento seleccionada."
+            no_embargo:         "Se requiere un período de embargo para la opción seleccionada."
+            nothing:            "Seleccionar opciones de lanzamiento antes de guardar."
+            error:              "Opción de actualización no válida para la plantilla de permiso."
           tabs:
             description:        "Descripción"
             participants:       "Participantes"

--- a/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe Hyrax::Admin::PermissionTemplatesController do
 
       it "is successful" do
         expect(controller).to receive(:authorize!).with(:update, permission_template)
-        expect(form).to receive(:update).with(ActionController::Parameters.new(form_attributes).permit!)
+        expect(form).to receive(:update).with(ActionController::Parameters.new(form_attributes).permit!).and_return(updated: true, content_tab: 'participants')
         put :update, params: input_params
         expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(permission_template.admin_set_id, locale: 'en', anchor: 'participants'))
-        expect(flash[:notice]).to eq "The administrative set's participant rights have been updated"
+        expect(flash[:notice]).to eq(I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices'))
       end
     end
   end


### PR DESCRIPTION
- Resolves  https://github.com/projecthydra-labs/hyku/issues/744
- Resolves https://github.com/projecthydra-labs/hyrax/issues/463
- Specs now test for valid release option combinations, and return appropriate notifications if the selections aren't correct. 
- Radio buttons are now checked based on currently saved options.

Related issue https://github.com/projecthydra-labs/hyrax/pull/476 allowed the Visibility options to be correctly checked, but the Release Varies option needed an explicit statement to correctly know when to show the radio button as checked. 
`<%= f.radio_button :release_period, '', checked: !f.object.release_varies.blank? %>`

This is required because the button is based on simply a value of blank (because release period can contain either "before" or "embargo"), so the determining factor as to whether to check it relies on the existence of one of the underlying release_varies sub-options being selected. This can be removed if https://github.com/projecthydra-labs/hyrax/issues/489 is completed to persist all of the permission template data. 

I was unable to create a failing test for this radio button issue. Future clean-up of the admin set & permission templates should hopefully allow a simpler structure that can be validated. 

I have documented the current logic regarding the content of each of the visibility release attributes,  as well as which combinations throw which errors in the following table. (One correction to the table is that for "no delay", the date gets set to today's date after update).

![screen shot 2017-02-24 at 5 10 26 pm](https://cloud.githubusercontent.com/assets/17851674/23322999/8ab5a1ae-fab4-11e6-8b65-e94b5da0d0eb.png)

@jeremyf 
@projecthydra-labs/hyrax-code-reviewers
