### PR TITLE
Admin Set hint text

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -723,6 +723,7 @@ en:
         admin_set_id:              "Add as member of administrative set"
         based_near:                "Location"
         collection_ids:            "Add as member of collection"
+        creator:                   "Creator"
         date_created:              "Date Created"
         description:               "Abstract or Summary"
         embargo_release_date:      'until'
@@ -730,6 +731,8 @@ en:
         keyword:                   "Keyword"
         lease_expiration_date:     'until'
         related_url:               "Related URL"
+        rights:                    "Rights"
+        title:                     "Title"
         visibility_after_embargo:  'then open it up to'
         visibility_after_lease:    'then restrict it to'
         visibility_during_embargo: 'Restricted to'

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -682,6 +682,9 @@ en:
         header: Edit Work
   simple_form:
     hints:
+      admin_set:
+        title: "A name to aid in identifying the Administrative Set and to distinguish it from other Administrative Sets in the repository."
+        description: 'A brief overarching description that applies to all works collected in this set. For example, "Theses and supplementary files created by the School of Earth Sciences graduate students."'
       collection:
         based_near: "A place name related to the collection, such as its site of publication, or the city, state, or country the collection contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>."
         contributor: "A person or group you want to recognize for playing a role in the creation of the collection, but not the primary role."

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -682,6 +682,9 @@ es:
         header: Editar Trabajo
   simple_form:
     hints:
+      admin_set:
+        title: "Un nombre para ayudar a identificar el conjunto administrativo y distinguirlo de otros conjuntos administrativos en el repositorio."
+        description: 'Una breve descripción general que se aplica a todas las obras recogidas en este conjunto. Por ejemplo, "Tesis y archivos suplementarios creados por los estudiantes graduados de la Escuela de Ciencias de la Tierra".'
       collection:
         based_near: "Nombre de un lugar relacionado con la colección, tal como el sitio de publicación, o ciudad, estado, o país, que esté relacionado con los contenidos de la colección. Llamados a través del servicio de <a href='http://www.geonames.org'>GeoNames</a>."
         contributor: "Una persona o grupo que se quiera reconocer por tener un rol en la creación de la colección, pero no el rol principal."

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -723,6 +723,7 @@ es:
         admin_set_id:     "Agregar como miembro del conjunto administrativo"
         based_near:       "Ubicación"
         collection_ids:   "Agregar como miembro de la colección"
+        creator:          "Creador"
         date_created:     "Fecha de creación"
         description:      "Resumen or Sumario"
         embargo_release_date:      'hasta'
@@ -730,6 +731,8 @@ es:
         keyword:          "Palabra Clave"
         lease_expiration_date:     'hasta'
         related_url:      "URL relacionada"
+        rights:           "Derechos"
+        title:            "Título"
         visibility_after_embargo:  'luego abrirlo a'
         visibility_after_lease:    'luego restringirlo a'
         visibility_during_embargo: 'Restringido a'

--- a/spec/views/hyrax/admin/admin_sets/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/_form.html.erb_spec.rb
@@ -18,5 +18,8 @@ RSpec.describe 'hyrax/admin/admin_sets/_form.html.erb', type: :view do
     # metadata fields
     expect(rendered).to have_selector('input[type=text][name="admin_set[title]"]')
     expect(rendered).to have_selector('textarea[name="admin_set[description]"]')
+
+    # hint text
+    expect(rendered).to have_content("A name to aid in identifying the Administrative Set and to distinguish it from other Administrative Sets in the repository.")
   end
 end


### PR DESCRIPTION
Add hint text in both English and Spanish to display on the
add and edit pages for Admin Sets. Also add Title to the default labels
list in order to allow for Spanish translation.

Resolves issue https://github.com/projecthydra-labs/hyrax/issues/201

@projecthydra-labs/hyrax-code-reviewers
