### PR TITLE
Update default admin set creation call in rake job

### DIFF
--- a/lib/tasks/default_admin_set.rake
+++ b/lib/tasks/default_admin_set.rake
@@ -2,7 +2,7 @@ namespace :hyrax do
   namespace :default_admin_set do
     desc "Create the Default Admin Set"
     task create: :environment do
-      AdminSet.create_default!
+      AdminSet.find_or_create_default_admin_set_id
     end
   end
 end


### PR DESCRIPTION
Fixes #516 

Most recent changes to the default admin set behavior invalidated the rake task used. This replaces `create_default!` with the proper call to `find_or_create_default_admin_set_id`