### PR TITLE
Sorting translation keys

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -13,11 +13,11 @@ en:
           keyword: Keyword
   errors:
     messages:
-      carrierwave_processing_error: "Cannot resize image."
-      carrierwave_integrity_error: "Not an image."
       carrierwave_download_error: "Couldn't download image."
-      extension_whitelist_error: "You are not allowed to upload %{extension} files, allowed types: %{allowed_types}"
+      carrierwave_integrity_error: "Not an image."
+      carrierwave_processing_error: "Cannot resize image."
       extension_blacklist_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
+      extension_whitelist_error: "You are not allowed to upload %{extension} files, allowed types: %{allowed_types}"
   helpers:
     action:
       admin_set:
@@ -122,24 +122,24 @@ en:
           item_list_header: "Works in This Set"
       collections:
         collection:         "Collection"
+        files:              "Files"
         subtitle:           "Recent collection activity"
         title:              "Collections"
         works:              "Works"
-        files:              "Files"
       show:
         new_visitors:       "New Visitors"
         registered_users:   "Registered users"
         repository_growth:
-          title:            Repository Growth
           subtitle:         Past 90 days
+          title:            Repository Growth
         repository_objects:
-          title:            Repository Objects
           subtitle:         Current Status
+          title:            Repository Objects
         returning_visitors: "Returning Visitors"
         total_visitors:     "Total Visitors"
         user_activity:
-          title:            User Activity
           subtitle:         New user signups
+          title:            User Activity
       sidebar:
         admin_sets:      "Administrative Sets"
         settings:        "Settings"
@@ -157,18 +157,12 @@ en:
         repository_objects:
           series:
             published:   'Published'
-            unpublished: 'Unpublished'
             unknown:     'Unknown'
+            unpublished: 'Unpublished'
         user_deposits:
           end_label: "Ending [defaults to now]"
           heading: "Display files deposited by users"
           start_label: "Starting"
-      workflows:
-        index:
-          header: "Review Submissions"
-          tabs:
-            under_review: "Under Review"
-            published: "Published"
       workflow_roles:
         header:     "Workflow Roles"
         index:
@@ -179,6 +173,12 @@ en:
             user:   User
           new_role: "Grant a role to a user:"
           no_roles: No roles
+      workflows:
+        index:
+          header: "Review Submissions"
+          tabs:
+            published: "Published"
+            under_review: "Under Review"
     admin_sets:
       index:
         header:         "Administrative Collections"
@@ -683,8 +683,8 @@ en:
   simple_form:
     hints:
       admin_set:
-        title: "A name to aid in identifying the Administrative Set and to distinguish it from other Administrative Sets in the repository."
         description: 'A brief overarching description that applies to all works collected in this set. For example, "Theses and supplementary files created by the School of Earth Sciences graduate students."'
+        title: "A name to aid in identifying the Administrative Set and to distinguish it from other Administrative Sets in the repository."
       collection:
         based_near: "A place name related to the collection, such as its site of publication, or the city, state, or country the collection contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>."
         contributor: "A person or group you want to recognize for playing a role in the creation of the collection, but not the primary role."

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -13,11 +13,11 @@ es:
           keyword: "Palabra Clave"
   errors:
     messages:
-      carrierwave_processing_error: "No se puede cambiar el tamaño de la imagen."
-      carrierwave_integrity_error: "No una imagen."
       carrierwave_download_error: "No se pudo descargar la imagen."
-      extension_whitelist_error: "No puedes subir %{extension} archivos, tipos permitidos: %{allowed_types}"
+      carrierwave_integrity_error: "No una imagen."
+      carrierwave_processing_error: "No se puede cambiar el tamaño de la imagen."
       extension_blacklist_error: "No puedes subir %{extension} archivos, tipos prohibidos: %{prohibited_types}"
+      extension_whitelist_error: "No puedes subir %{extension} archivos, tipos permitidos: %{allowed_types}"
   helpers:
     action:
       admin_set:
@@ -122,24 +122,24 @@ es:
           item_list_header: "Trabajos en este conjunto"
       collections:
         collection:         "Collección"
+        files:              "Archivos"
         subtitle:           "Actividad reciente de la colección"
         title:              "Colleccións"
         works:              "Trabajos"
-        files:              "Archivos"
       show:
         new_visitors:       "Nuevos visitantes"
         registered_users:   "Usuarios registrados"
         repository_growth:
-          title:            Crecimiento del Repositorio
           subtitle:         Pasados 90 días
+          title:            Crecimiento del Repositorio
         repository_objects:
-          title:            Objetos del Repositorio
           subtitle:         Estado Actual
+          title:            Objetos del Repositorio
         returning_visitors: "Regresos de visitantes"
         total_visitors:     "Total de visitantes"
         user_activity:
-          title:            Actividad del usuario
           subtitle:         Nuevas inscripciones de usuarios
+          title:            Actividad del usuario
       sidebar:
         admin_sets:      "Conjuntos Administrativos"
         settings:        "Ajustes"
@@ -157,18 +157,12 @@ es:
         repository_objects:
           series:
             published:   'Publicado'
-            unpublished: 'Inédito'
             unknown:     'Desconocido'
+            unpublished: 'Inédito'
         user_deposits:
           end_label: "Finalizando [por defecto a ahora]"
           heading: "Ver archivos depositados por los usuarios"
           start_label: "Comenzando"
-      workflows:
-        index:
-          header: "Revise Ofertas"
-        tabs:
-          under_review: "En Revisión"
-          published: "Publica"
       workflow_roles:
         header:     "Funciones del Flujo de Trabajo"
         index:
@@ -179,6 +173,12 @@ es:
             user: "Usuario"
           new_role: "Asignar un papel a un usuario:"
           no_roles: "Ningunos roles"
+      workflows:
+        index:
+          header: "Revise Ofertas"
+        tabs:
+          published: "Publica"
+          under_review: "En Revisión"
     admin_sets:
       index:
         header: "Colecciones Administrativas"
@@ -683,8 +683,8 @@ es:
   simple_form:
     hints:
       admin_set:
-        title: "Un nombre para ayudar a identificar el conjunto administrativo y distinguirlo de otros conjuntos administrativos en el repositorio."
         description: 'Una breve descripción general que se aplica a todas las obras recogidas en este conjunto. Por ejemplo, "Tesis y archivos suplementarios creados por los estudiantes graduados de la Escuela de Ciencias de la Tierra".'
+        title: "Un nombre para ayudar a identificar el conjunto administrativo y distinguirlo de otros conjuntos administrativos en el repositorio."
       collection:
         based_near: "Nombre de un lugar relacionado con la colección, tal como el sitio de publicación, o ciudad, estado, o país, que esté relacionado con los contenidos de la colección. Llamados a través del servicio de <a href='http://www.geonames.org'>GeoNames</a>."
         contributor: "Una persona o grupo que se quiera reconocer por tener un rol en la creación de la colección, pero no el rol principal."

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,13 +1,5 @@
 en:
   simple_form:
-    "yes": 'Yes'
-    "no": 'No'
-    required:
-      text: 'required'
-      mark: '*'
-      # You can uncomment the line below if you need to overwrite the whole required html.
-      # When using html, text and mark won't be used.
-      # html: '<abbr title="required">*</abbr>'
     error_notification:
       default_message: "Please review the problems below:"
     # Examples
@@ -29,3 +21,11 @@ en:
     # prompts:
     #   defaults:
     #     age: 'Select your age'
+    "no": 'No'
+    required:
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+      text: 'required'
+    "yes": 'Yes'

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -81,4 +81,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rails-controller-testing', '~> 0'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'i18n-debug' unless ENV['TRAVIS']
+  spec.add_development_dependency 'i18n_yaml_sorter' unless ENV['TRAVIS']
 end

--- a/tasks/hyrax-dev.rake
+++ b/tasks/hyrax-dev.rake
@@ -19,6 +19,17 @@ task :spec_with_app_load  do
   end
 end
 
+desc "Sort locales keys in alphabetic order."
+task :i18n_sorter do
+  require 'i18n_yaml_sorter'
+  locales = Dir.glob(File.expand_path('../../config/locales/**/*.yml', __FILE__))
+  locales.each do |locale_path|
+    sorted_contents = File.open(locale_path) { |f| I18nYamlSorter::Sorter.new(f).sort }
+    File.open(locale_path, 'w') { |f|  f << sorted_contents}
+    abort("Bad I18n conversion!") unless Psych.load_file(locale_path).is_a?(Hash)
+  end
+end
+
 desc 'Generate the engine_cart and spin up test servers and run specs'
 task ci: ['rubocop', 'engine_cart:generate'] do
   puts 'running continuous integration'


### PR DESCRIPTION
## Adding i18n_yaml_sorter gem and associated task

@dfe0c350bb1f5db9a6c01e186ecb852b5ab8c994

It's helpful to have a sorted set of YAML files.

## Sorting translation files

@45b000976904bc4b0c7edcb2fa7152c3763034a6

```console
$ rake i18n_sorter
```

@projecthydra-labs/hyrax-code-reviewers
