### PR TITLE
Refactor for clarity

### DIFF
--- a/app/services/hyrax/admin_set_service.rb
+++ b/app/services/hyrax/admin_set_service.rb
@@ -18,15 +18,15 @@ module Hyrax
       response.documents
     end
 
-    SearchResultForWorkCount = Struct.new(:document, :work_count, :file_count)
+    SearchResultForWorkCount = Struct.new(:admin_set, :work_count, :file_count)
 
     # This performs a two pass query, first getting the AdminSets
     # and then getting the work and file counts
     # @param [Symbol] access :read or :edit
     # @return [Array<Hyrax::AdminSetService::SearchResultForWorkCount>] a list with document, then work and file count
     def search_results_with_work_count(access)
-      documents = search_results(access)
-      ids = documents.map(&:id).join(',')
+      admin_sets = search_results(access)
+      ids = admin_sets.map(&:id).join(',')
       join_field = "isPartOf_ssim"
       query = "{!terms f=#{join_field}}#{ids}"
       results = ActiveFedora::SolrService.instance.conn.get(
@@ -36,8 +36,8 @@ module Hyrax
       )
       counts = results['facet_counts']['facet_fields'][join_field].each_slice(2).to_h
       file_counts = count_files(results)
-      documents.map do |doc|
-        SearchResultForWorkCount.new(doc, counts[doc.id].to_i, file_counts[doc.id].to_i)
+      admin_sets.map do |admin_set|
+        SearchResultForWorkCount.new(admin_set, counts[admin_set.id].to_i, file_counts[admin_set.id].to_i)
       end
     end
 

--- a/app/services/hyrax/admin_set_service.rb
+++ b/app/services/hyrax/admin_set_service.rb
@@ -23,11 +23,11 @@ module Hyrax
     # This performs a two pass query, first getting the AdminSets
     # and then getting the work and file counts
     # @param [Symbol] access :read or :edit
+    # @param join_field [String] how are we joining the admin_set ids (by default "isPartOf_ssim")
     # @return [Array<Hyrax::AdminSetService::SearchResultForWorkCount>] a list with document, then work and file count
-    def search_results_with_work_count(access)
+    def search_results_with_work_count(access, join_field: "isPartOf_ssim")
       admin_sets = search_results(access)
       ids = admin_sets.map(&:id).join(',')
-      join_field = "isPartOf_ssim"
       query = "{!terms f=#{join_field}}#{ids}"
       results = ActiveFedora::SolrService.instance.conn.get(
         ActiveFedora::SolrService.select_path,

--- a/app/services/hyrax/admin_set_service.rb
+++ b/app/services/hyrax/admin_set_service.rb
@@ -18,10 +18,12 @@ module Hyrax
       response.documents
     end
 
+    SearchResultForWorkCount = Struct.new(:document, :work_count, :file_count)
+
     # This performs a two pass query, first getting the AdminSets
     # and then getting the work and file counts
     # @param [Symbol] access :read or :edit
-    # @return [Array<Array>] a list with document, then work and file count
+    # @return [Array<Hyrax::AdminSetService::SearchResultForWorkCount>] a list with document, then work and file count
     def search_results_with_work_count(access)
       documents = search_results(access)
       ids = documents.map(&:id).join(',')
@@ -35,7 +37,7 @@ module Hyrax
       counts = results['facet_counts']['facet_fields'][join_field].each_slice(2).to_h
       file_counts = count_files(results)
       documents.map do |doc|
-        [doc, counts[doc.id].to_i, file_counts[doc.id]]
+        SearchResultForWorkCount.new(doc, counts[doc.id].to_i, file_counts[doc.id].to_i)
       end
     end
 

--- a/app/views/hyrax/admin/_collections.html.erb
+++ b/app/views/hyrax/admin/_collections.html.erb
@@ -19,9 +19,9 @@
           <tbody>
             <% @admin_set_rows.each do |row| %>
               <tr>
-                <td><%= row.first %></td>
-                <td><%= row.second %></td>
-                <td><%= row.third %></td>
+                <td><%= row.document %></td>
+                <td><%= row.work_count %></td>
+                <td><%= row.file_count %></td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/hyrax/admin/_collections.html.erb
+++ b/app/views/hyrax/admin/_collections.html.erb
@@ -19,7 +19,7 @@
           <tbody>
             <% @admin_set_rows.each do |row| %>
               <tr>
-                <td><%= row.document %></td>
+                <td><%= row.admin_set %></td>
                 <td><%= row.work_count %></td>
                 <td><%= row.file_count %></td>
               </tr>

--- a/spec/services/hyrax/admin_set_service_spec.rb
+++ b/spec/services/hyrax/admin_set_service_spec.rb
@@ -89,9 +89,11 @@ RSpec.describe Hyrax::AdminSetService do
                                                                   "facet.field" => "isPartOf_ssim" }).and_return(results)
     end
 
+    let(:struct) { described_class::SearchResultForWorkCount }
+
     context "when there are works in the admin set" do
       it "returns rows with document in the first column and integer count value in the second and third column" do
-        expect(subject).to eq [[doc1, 8, 3], [doc2, 2, 2], [doc3, 0, 0]]
+        expect(subject).to eq [struct.new(doc1, 8, 3), struct.new(doc2, 2, 2), struct.new(doc3, 0, 0)]
       end
     end
 
@@ -107,7 +109,7 @@ RSpec.describe Hyrax::AdminSetService do
         ]
       end
       it "returns rows with document in the first column and integer count value in the second and third column" do
-        expect(subject).to eq [[doc1, 8, 0], [doc2, 2, 0], [doc3, 0, 0]]
+        expect(subject).to eq [struct.new(doc1, 8, 0), struct.new(doc2, 2, 0), struct.new(doc3, 0, 0)]
       end
     end
   end


### PR DESCRIPTION
## Replacing ordinal access with structure

@1daceb621deefcfbcee60d714b5549648ceb6cc6

Instead of relying on order from an array to indicate what is what,
prefer instead a struct that provides method names and equality.

## Updating variable name to reflect documentation

@1985b2fb74c3d1a88b5d93504b2acabb31af58aa

Document is a hold over from SOLR, instead prefer the more meaningful
admin_set

## Allowing for parameterization of join_field

@5cf2f839575862ff4742b903bd1c6df3b06bd81d

Related to #446

@projecthydra-labs/hyrax-code-reviewers
