### PR TITLE
Removing deprecation usage

### DIFF
--- a/app/models/concerns/hyrax/user.rb
+++ b/app/models/concerns/hyrax/user.rb
@@ -34,7 +34,7 @@ module Hyrax::User
     validates_with AvatarValidator
 
     # Add token to authenticate Arkivo API calls
-    after_initialize :set_arkivo_token, unless: :persisted? if Hyrax.config.arkivo_api
+    after_initialize :set_arkivo_token, unless: :persisted? if Hyrax.config.arkivo_api?
 
     has_many :trophies
     has_one :sipity_agent, as: :proxy_for, dependent: :destroy, class_name: 'Sipity::Agent'

--- a/app/presenters/hyrax/homepage_presenter.rb
+++ b/app/presenters/hyrax/homepage_presenter.rb
@@ -7,7 +7,7 @@ module Hyrax
     end
 
     def display_share_button?
-      Hyrax.config.always_display_share_button || current_ability.can_create_any_work?
+      Hyrax.config.always_display_share_button? || current_ability.can_create_any_work?
     end
   end
 end

--- a/app/presenters/hyrax/presents_attributes.rb
+++ b/app/presenters/hyrax/presents_attributes.rb
@@ -29,7 +29,7 @@ module Hyrax
     end
 
     def display_microdata?
-      Hyrax.config.display_microdata
+      Hyrax.config.display_microdata?
     end
 
     def microdata_type_to_html

--- a/app/renderers/hyrax/renderers/configured_microdata.rb
+++ b/app/renderers/hyrax/renderers/configured_microdata.rb
@@ -5,14 +5,12 @@ module Hyrax
 
       def microdata?(field)
         return false unless Hyrax.config.display_microdata?
-        key = "#{PREFIX}.#{field}.property"
-        t(key, default: false)
+        translate_microdata(field: field, field_context: 'property', default: false)
       end
 
       def microdata_object?(field)
         return false unless Hyrax.config.display_microdata?
-        key = "#{PREFIX}.#{field}.type"
-        t(key, default: false)
+        translate_microdata(field: field, field_context: 'type', default: false)
       end
 
       def microdata_object_attributes(field)
@@ -24,21 +22,27 @@ module Hyrax
       end
 
       def microdata_property(field)
-        t("#{PREFIX}.#{field}.property")
+        translate_microdata(field: field, field_context: 'property')
       end
 
       def microdata_type(field)
-        t("#{PREFIX}.#{field}.type")
+        translate_microdata(field: field, field_context: 'type')
       end
 
       def microdata_value_attributes(field)
         if microdata?(field)
-          key = microdata_object?(field) ? :value : :property
-          { itemprop: t("#{PREFIX}.#{field}.#{key}") }
+          field_context = microdata_object?(field) ? :value : :property
+          { itemprop: translate_microdata(field: field, field_context: field_context) }
         else
           {}
         end
       end
+
+      private
+
+        def translate_microdata(field:, field_context:, default: true)
+          t("#{PREFIX}.#{field}.#{field_context}", default: default)
+        end
     end
   end
 end

--- a/app/renderers/hyrax/renderers/configured_microdata.rb
+++ b/app/renderers/hyrax/renderers/configured_microdata.rb
@@ -4,13 +4,13 @@ module Hyrax
       PREFIX = 'hyrax.schema_org'.freeze
 
       def microdata?(field)
-        return false unless Hyrax.config.display_microdata
+        return false unless Hyrax.config.display_microdata?
         key = "#{PREFIX}.#{field}.property"
         t(key, default: false)
       end
 
       def microdata_object?(field)
-        return false unless Hyrax.config.display_microdata
+        return false unless Hyrax.config.display_microdata?
         key = "#{PREFIX}.#{field}.type"
         t(key, default: false)
       end

--- a/app/services/hyrax/noid.rb
+++ b/app/services/hyrax/noid.rb
@@ -7,9 +7,10 @@ module Hyrax
     ## This overrides the default behavior, which is to ask Fedora for an id
     # @see ActiveFedora::Persistence.assign_id
     def assign_id
-      service.mint if Hyrax.config.enable_noids
+      service.mint if Hyrax.config.enable_noids?
     end
 
+    # @todo Do we need this here? I'm a bit surprised to see it here [JNF]
     def to_param
       id
     end

--- a/app/views/_ga.html.erb
+++ b/app/views/_ga.html.erb
@@ -1,5 +1,5 @@
 <%
-if Hyrax.config.respond_to? :google_analytics_id
+if Hyrax.config.google_analytics_id?
 tracking_id = Hyrax.config.google_analytics_id
 %>
 <script type="text/javascript">

--- a/app/views/hyrax/base/_citations.html.erb
+++ b/app/views/hyrax/base/_citations.html.erb
@@ -1,5 +1,5 @@
 <div class="citations">
-    <% if Hyrax.config.citations %>
+    <% if Hyrax.config.citations? %>
       <%= link_to "Citations", hyrax.citations_work_path(presenter), id: 'citations', class: 'btn btn-default' %>
     <% end %>
     <div class='citations-heading'><%= t('.header') %></div>

--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -8,7 +8,7 @@
         <legend class="legend-save-work"><%= t('.requirements') %></legend>
         <ul class="requirements">
           <li class="incomplete" id="required-metadata"><%= t('.required_descriptions') %></li>
-          <% if Hyrax.config.work_requires_files %>
+          <% if Hyrax.config.work_requires_files? %>
             <li class="incomplete" id="required-files"><%= t('.required_files') %></li>
           <% end %>
         </ul>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,5 +1,5 @@
 <div class="show-actions">
-  <% if Hyrax.config.analytics %>
+  <% if Hyrax.config.analytics? %>
     <%= link_to "Analytics", presenter.stats_path, id: 'stats', class: 'btn btn-default' %>
   <% end %>
   <% if presenter.editor? %>

--- a/app/views/hyrax/users/_edit_primary.html.erb
+++ b/app/views/hyrax/users/_edit_primary.html.erb
@@ -24,7 +24,7 @@
     </div>
   </div><!-- .form-group -->
 
-  <% if Hyrax.config.arkivo_api %>
+  <% if Hyrax.config.arkivo_api? %>
     <%= render partial: 'zotero', locals: { f: f, user: @user } %>
   <% end %>
 

--- a/app/views/hyrax/users/_user_info.html.erb
+++ b/app/views/hyrax/users/_user_info.html.erb
@@ -5,7 +5,7 @@
   <dd><%= link_to user.orcid, user.orcid, { target: '_blank' } %></dd>
 <% end %>
 
-<% if Hyrax.config.arkivo_api && user.zotero_userid.present? %>
+<% if Hyrax.config.arkivo_api? && user.zotero_userid.present? %>
   <dt><%= zotero_label(html_class: 'profile') %></dt>
   <dd><%= link_to zotero_profile_url(user.zotero_userid), zotero_profile_url(user.zotero_userid), { target: '_blank' } %></dd>
 <% end %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -24,6 +24,6 @@ Flipflop.configure do
           description: "Show a deposit agreement to users creating works"
 
   feature :active_deposit_agreement_acceptance,
-          default: Hyrax.config.active_deposit_agreement_acceptance,
+          default: Hyrax.config.active_deposit_agreement_acceptance?,
           description: "Require an active acceptance of the deposit agreement by checking a checkbox"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,7 +163,7 @@ Hyrax::Engine.routes.draw do
   end
 
   # API routes
-  if Hyrax.config.arkivo_api
+  if Hyrax.config.arkivo_api?
     namespace :api do
       if defined?(Hyrax::ArkivoConstraint)
         constraints Hyrax::ArkivoConstraint do

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -369,11 +369,10 @@ module Hyrax
     deprecation_deprecate always_display_share_button: "use always_display_share_button? instead"
 
     attr_writer :google_analytics_id
-    def google_analytics_id?
+    def google_analytics_id
       @google_analytics_id ||= nil
     end
-    alias google_analytics_id google_analytics_id?
-    deprecation_deprecate google_analytics_id: "use google_analytics_id? instead"
+    alias google_analytics_id? google_analytics_id
 
     # Defaulting analytic start date to whenever the file was uploaded by leaving it blank
     attr_writer :analytic_start_date

--- a/lib/tasks/hyrax_user.rake
+++ b/lib/tasks/hyrax_user.rake
@@ -12,7 +12,7 @@ namespace :hyrax do
 
     desc 'Populate user tokens'
     task tokens: :environment do
-      unless Hyrax.config.arkivo_api
+      unless Hyrax.config.arkivo_api?
         puts "Zotero integration is not enabled"
         next
       end

--- a/spec/presenters/hyrax/homepage_presenter_spec.rb
+++ b/spec/presenters/hyrax/homepage_presenter_spec.rb
@@ -6,11 +6,14 @@ describe Hyrax::HomepagePresenter do
   describe "#display_share_button?" do
     subject { presenter.display_share_button? }
     context "when config is set to always_display_share_button" do
+      before do
+        allow(Hyrax.config).to receive(:always_display_share_button?).and_return(true)
+      end
       it { is_expected.to be true }
     end
     context "when config is not set to always_display_share_button" do
       before do
-        allow(Hyrax.config).to receive(:always_display_share_button).and_return(false)
+        allow(Hyrax.config).to receive(:always_display_share_button?).and_return(false)
         allow(ability).to receive(:can_create_any_work?).and_return(false)
       end
       it { is_expected.to be false }

--- a/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
@@ -19,7 +19,7 @@ describe Hyrax::Renderers::AttributeRenderer do
 
     context 'without microdata enabled' do
       before do
-        allow(Hyrax.config).to receive(:display_microdata).and_return(false)
+        allow(Hyrax.config).to receive(:display_microdata?).and_return(false)
       end
       let(:tr_content) do
         "<tr><th>Name</th>\n" \

--- a/spec/services/hyrax/noid_spec.rb
+++ b/spec/services/hyrax/noid_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe Hyrax::Noid do
+  let(:class_with_noids) do
+    Class.new do
+      include Hyrax::Noid
+      attr_reader :id
+      def initialize(id:)
+        @id = id
+      end
+    end
+  end
+  let(:object) { class_with_noids.new(id: 1234) }
+
+  describe '#to_param' do
+    it "will be the object's id" do
+      expect(object.to_param).to eq(object.id)
+    end
+  end
+
+  describe 'when noids are not enabled' do
+    before { expect(Hyrax.config).to receive(:enable_noids?).and_return(false) }
+    subject { object.assign_id }
+    it { is_expected.to be_nil }
+    it 'will not update the id (as the name might imply)' do
+      expect { object.assign_id }.not_to change { object.id }
+    end
+  end
+
+  describe 'when noids is enabled' do
+    let(:service) { double(mint: 5678) }
+    before do
+      expect(Hyrax.config).to receive(:enable_noids?).and_return(true)
+      expect(object).to receive(:service).and_return(service)
+    end
+    subject { object.assign_id }
+    it { is_expected.to eq(service.mint) }
+    it 'will not update the id (as the name might imply)' do
+      expect { object.assign_id }.not_to change { object.id }
+    end
+  end
+end

--- a/spec/views/hyrax/users/_user_info.html.erb_spec.rb
+++ b/spec/views/hyrax/users/_user_info.html.erb_spec.rb
@@ -3,7 +3,7 @@ describe 'hyrax/users/_user_info.html.erb', type: :view do
 
   context 'with Zotero disabled' do
     before do
-      allow(Hyrax.config).to receive(:arkivo_api) { false }
+      allow(Hyrax.config).to receive(:arkivo_api?) { false }
       allow(user).to receive(:zotero_userid).and_raise(NoMethodError)
       render "hyrax/users/user_info", user: user
     end
@@ -15,7 +15,7 @@ describe 'hyrax/users/_user_info.html.erb', type: :view do
 
   context 'with Zotero enabled' do
     before do
-      allow(Hyrax.config).to receive(:arkivo_api) { true }
+      allow(Hyrax.config).to receive(:arkivo_api?) { true }
       allow(user).to receive(:zotero_userid) { 'jdoe42zotero' }
       render "hyrax/users/user_info", user: user
     end

--- a/spec/views/hyrax/users/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/users/edit.html.erb_spec.rb
@@ -28,7 +28,7 @@ describe 'hyrax/users/edit.html.erb', type: :view do
 
   context 'with Zotero integration enabled' do
     before do
-      allow(Hyrax.config).to receive(:arkivo_api) { true }
+      allow(Hyrax.config).to receive(:arkivo_api?) { true }
     end
 
     it 'shows a Zotero label' do
@@ -69,7 +69,7 @@ describe 'hyrax/users/edit.html.erb', type: :view do
 
   context 'with Zotero integration disabled' do
     before do
-      allow(Hyrax.config).to receive(:arkivo_api) { false }
+      allow(Hyrax.config).to receive(:arkivo_api?) { false }
     end
 
     it 'hides a Zotero OAuth button' do


### PR DESCRIPTION
## Correcting deprecation warning

@c9403bb57b05f3f7d678021031ffbea79594d651


## Adding specs for Hyrax::Noid

@b7c4139ba64537665bff45bfac4f85a25ae70208

As part of removing the deprecation notice, I wanted to test the
behavior of the Hyrax::Noid module.

## Replacing deprecated display_microdata

@c579e9fe5740d46c681eaab2bb27a737ba7e5e66


## Consolidating duplicate knowledge for microdata

@3fef081fff3f40c8acfa1c646142281f7573e3bb

Instead of several different paths for translation, opt for a single
path. Also renamed the 'key' to 'context' as it provides a bit of
disambiguation (we lookup translations by a full key, and by using key
it implies that might be the only part of translation we use).

## Replacing deprecated work_requires_files

@61320ef1a6aa502bd63725b6deece0634646bf6e

Instead prefer work_requires_files?

## Restore Hyrax.config.google_analytics_id

@9e833509266580fc76d2847c1428c3504f4e6591

In reviewing usage, google_analytics_id needs both boolean and "getter"
method.

## Removing Hyrax.config.always_display_share_button

@4f691844963d9fad97cb1558b6a2f08d1da64d87

Instead favor Hyrax.config.always_display_share_button?

## Removing Hyrax.config.arkivo_api usage

@6aa56cb569e8c51279c9513b0d36528863a9e7dd

Instead favor Hyrax.config.arkivo_api?

## Removing Hyrax.config.citations usage

@5ba3d1f83b1fafc7c51ff29e0b7b96d8c40f99b2

Prefer Hyrax.config.citations?

## Removing Hyrax.config.analytics usage

@1dab456444e7f981e22ae901a1fe21236b46a354

Prefer Hyrax.config.analytics?

@projecthydra-labs/hyrax-code-reviewers
