### PR TITLE
247 admin users page

### DIFF
--- a/app/controllers/concerns/hyrax/admin/users_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/admin/users_controller_behavior.rb
@@ -1,0 +1,16 @@
+module Hyrax
+  module Admin
+    module UsersControllerBehavior
+      extend ActiveSupport::Concern
+      include Blacklight::SearchContext
+
+      # Display admin menu list of users
+      def index
+        add_breadcrumb t(:'hyrax.controls.home'), root_path
+        add_breadcrumb t(:'hyrax.toolbar.admin.menu'), hyrax.admin_path
+        add_breadcrumb t(:'hyrax.admin.users.index.title'), hyrax.admin_users_path
+        @presenter = Hyrax::Admin::UsersPresenter.new
+      end
+    end
+  end
+end

--- a/app/controllers/hyrax/admin/users_controller.rb
+++ b/app/controllers/hyrax/admin/users_controller.rb
@@ -1,0 +1,5 @@
+module Hyrax
+  class Admin::UsersController < AdminController
+    include Hyrax::Admin::UsersControllerBehavior
+  end
+end

--- a/app/models/concerns/hyrax/user.rb
+++ b/app/models/concerns/hyrax/user.rb
@@ -24,6 +24,7 @@ module Hyrax::User
 
     scope :guests, ->() { where(guest: true) }
     scope :registered, ->() { where(guest: false) }
+    scope :without_system_accounts, -> { where("#{Devise.authentication_keys.first} not in (?)", [::User.batch_user_key, ::User.audit_user_key]) }
 
     # Validate and normalize ORCIDs
     validates_with OrcidValidator

--- a/app/presenters/hyrax/admin/users_presenter.rb
+++ b/app/presenters/hyrax/admin/users_presenter.rb
@@ -1,0 +1,31 @@
+module Hyrax
+  module Admin
+    class UsersPresenter
+      # @return [Array] an array of Users
+      def users
+        @users ||= search
+      end
+
+      # @return [Number] quantity of users excluding the system users and guest_users
+      def user_count
+        users.count
+      end
+
+      # @return [Array] an array of user roles
+      def user_roles(user)
+        user.groups
+      end
+
+      def last_accessed(user)
+        user.last_sign_in_at || user.created_at
+      end
+
+      protected
+
+        # Returns a list of users excluding the system users and guest_users
+        def search
+          ::User.registered.without_system_accounts
+        end
+    end
+  end
+end

--- a/app/views/hyrax/admin/_sidebar.html.erb
+++ b/app/views/hyrax/admin/_sidebar.html.erb
@@ -26,4 +26,8 @@
       <% end %>
     <% end %>
   </li>
+
+  <%= menu.nav_link(hyrax.admin_users_path) do %>
+    <span class="fa fa-user"></span> <%= t('hyrax.admin.sidebar.users') %>
+  <% end %>
 </ul>

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -1,0 +1,48 @@
+<% content_for :page_header do %>
+  <h1><span class="fa fa-user"></span> <%= t('hyrax.admin.users.index.title') %></h1>
+<% end %>
+
+<div class="panel panel-default users-listing">
+  <div class="panel-heading">
+      <%= t('hyrax.admin.users.index.describe_users_html', count: @presenter.user_count) %>
+  </div>
+
+  <div class="panel-body">
+    <div class="table-responsive">
+      <table class="table table-striped datatable">
+        <thead>
+          <tr>
+            <th></th>
+            <th><%= t('.id_label') %></th>
+            <th><%= t('.role_label') %></th>
+            <th><%= t('.access_label') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @presenter.users.each do |user| %>
+            <tr>
+              <td><%= link_to hyrax.profile_path(user) do %>
+                    <%= image_tag(user.avatar.url(:thumb), width: 30) if user.avatar.file %>
+                  <% end %>
+              </td>
+              <br>
+              <td><%= link_to user.email, hyrax.profile_path(user) %></td>
+              <td><% roles = @presenter.user_roles(user) %>
+                  <ul><% roles.each do |role| %>
+                    <li><%= role %></li>
+                    <% end %>
+                  </ul>
+              </td>
+              <td>
+                <%# in the case that a user is created who never signs in, this is necessary %>
+                <relative-time datetime="<%= @presenter.last_accessed(user).getutc.iso8601 %>" title="<%= @presenter.last_accessed(user).to_formatted_s(:standard) %>">
+                  <%= @presenter.last_accessed(user).to_formatted_s(:long_ordinal) %>
+                </relative-time>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -151,6 +151,7 @@ en:
         settings:        "Settings"
         statistics:      "Statistics"
         tasks:           "Tasks"
+        users:           "Manage Users"
         workflow:        "Workflows"
         workflow_review: "Review Submissions"
         workflow_roles:  "Roles"
@@ -169,6 +170,15 @@ en:
           end_label: "Ending [defaults to now]"
           heading: "Display files deposited by users"
           start_label: "Starting"
+      users:
+        index:
+          access_label: "Last access"
+          describe_users_html:
+            one: "There is <b>%{count} user</b> in this repository."
+            other: "There are <b>%{count} users</b> in this repository."
+          id_label:   "Username"
+          role_label: "Roles"
+          title: "Manage Users"
       workflow_roles:
         header:     "Workflow Roles"
         index:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -151,6 +151,7 @@ es:
         settings:        "Ajustes"
         statistics:      "Estadísticas"
         tasks:           'Tareas'
+        users:           "Usarios"
         workflow:        "Flujos de Trabajo"
         workflow_review: "Revise Ofertas"
         workflow_roles:  "Roles"
@@ -169,6 +170,15 @@ es:
           end_label: "Finalizando [por defecto a ahora]"
           heading: "Ver archivos depositados por los usuarios"
           start_label: "Comenzando"
+      users:
+        index:
+          access_label: "Ultimo acceso"
+          describe_users_html:
+            one: "Es <b>%{count} usario</b> en este repositorio."
+            other: "Hay <b>%{count} usarios</b> en este repositorio."
+          id_label:   "Nombre de usuario"
+          role_label: "Roles"
+          title: "Administrar usuarios"
       workflow_roles:
         header:     "Funciones del Flujo de Trabajo"
         index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,6 +183,7 @@ Hyrax::Engine.routes.draw do
     resources :admin_sets do
       resource :permission_template
     end
+    resources :users, only: [:index]
     resources :permission_template_accesses, only: :destroy
     resource 'stats', only: [:show]
     resources :features, only: [:index] do

--- a/spec/controllers/hyrax/admin/users_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/users_controller_spec.rb
@@ -1,0 +1,27 @@
+describe Hyrax::Admin::UsersController, type: :controller do
+  let!(:user) { FactoryGirl.create(:user) }
+  before do
+    expect(controller).to receive(:authorize!).with(:read, :admin_dashboard).and_return(true)
+  end
+  let!(:admin_user) { FactoryGirl.create(:user, groups: 'admin') }
+  let!(:audit_user) { User.audit_user }
+  let!(:batch_user) { User.batch_user }
+  let!(:guest_user) { FactoryGirl.create(:user, :guest) }
+
+  describe "#index" do
+    it "is successful" do
+      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.controls.home'), root_path)
+      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.toolbar.admin.menu'), admin_path)
+      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.admin.users.index.title'), admin_users_path)
+
+      get :index
+      expect(response).to be_successful
+    end
+
+    it "excludes audit_user, batch_user, and guest user" do
+      get :index
+      expect(assigns[:presenter].users.to_a).to match_array [user, admin_user]
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -200,4 +200,32 @@ describe User, type: :model do
       end
     end
   end
+  describe "scope Users" do
+    let!(:basic_user) { FactoryGirl.create(:user) }
+    let!(:guest_user) { FactoryGirl.create(:user, :guest) }
+    let!(:audit_user) { User.audit_user }
+    let!(:batch_user) { User.batch_user }
+
+    context "without_system_accounts" do
+      subject { described_class.without_system_accounts }
+      it "omits audit_user and batch_user" do
+        is_expected.to include(basic_user, guest_user)
+        is_expected.not_to include(audit_user, batch_user)
+      end
+    end
+    context "registered" do
+      subject { described_class.registered }
+      it "omits guest_user" do
+        is_expected.to include(basic_user, audit_user, batch_user)
+        is_expected.not_to include(guest_user)
+      end
+    end
+    context "guests" do
+      subject { described_class.guests }
+      it "includes only guest_user" do
+        is_expected.not_to include(basic_user, audit_user, batch_user)
+        is_expected.to include(guest_user)
+      end
+    end
+  end
 end

--- a/spec/presenters/hyrax/admin/users_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin/users_presenter_spec.rb
@@ -1,0 +1,32 @@
+describe Hyrax::Admin::UsersPresenter do
+  let(:instance) { described_class.new }
+  let!(:user) { FactoryGirl.create(:user) }
+  let!(:admin_user) { FactoryGirl.create(:user, groups: 'admin') }
+  let!(:audit_user) { User.audit_user }
+  let!(:batch_user) { User.batch_user }
+
+  describe "#users" do
+    it "includes all users except batch and audit users" do
+      expect(instance.users).to match_array [admin_user, user]
+    end
+  end
+
+  describe "#user_count" do
+    it "counts users excluding batch_user and audit_user" do
+      expect(instance.user_count).to eq 2
+    end
+  end
+
+  describe "#user_roles" do
+    describe "for an admin user" do
+      it "finds the admin role" do
+        expect(instance.user_roles(admin_user)).to eq(['admin'])
+      end
+    end
+    describe "for a generic user with no user roles" do
+      it "returns blank" do
+        expect(instance.user_roles(user)).to eq([])
+      end
+    end
+  end
+end

--- a/spec/views/hyrax/admin/users/index.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/users/index.html.erb_spec.rb
@@ -1,0 +1,21 @@
+describe 'hyrax/admin/users/index.html.erb', type: :view do
+  let(:presenter) { Hyrax::Admin::UsersPresenter.new }
+  let(:users) { [] }
+
+  before do
+    (1..4).each { |i| users << FactoryGirl.build(:user, display_name: "user#{i}", email: "email#{i}@example.com", last_sign_in_at: Time.zone.now - 15.minutes, created_at: Time.zone.now - 3.days) }
+    allow(presenter).to receive(:users).and_return(users)
+    assign(:presenter, presenter)
+  end
+
+  it "draws user list with all users" do
+    render
+    page = Capybara::Node::Simple.new(rendered)
+    expect(page).to have_content("Username")
+    expect(page).to have_content("Roles")
+    expect(page).to have_content("Last access")
+    (1..4).each do |i|
+      expect(page).to have_content("email#{i}@example.com")
+    end
+  end
+end


### PR DESCRIPTION
**Resolves:** 
- https://github.com/projecthydra-labs/hyrax/issues/247
- https://github.com/projecthydra-labs/hyrax/issues/248
- https://github.com/projecthydra-labs/hyrax/issues/249

**Creates a paginated list of users**
- make a UserPresenter class and make it functional
- add breadcrumbs for page
- add User scope :not_batch_or_audit_user for user count
- modify specs accordingly
- incorporate Spanish translation (other than for datatables)

**Note:** By using datatables, this PR also incorporates the sorting and searching capabilities as specified in issues 248 and 249. However datatables currently does not support Spanish translation. This needs to be handled in a separate issue.

Not all of the columns requested in the issues are currently in use. Page was created with only currently valid content.
![screen shot 2017-03-06 at 5 21 35 pm](https://cloud.githubusercontent.com/assets/17851674/23632823/68594626-0291-11e7-9d28-d06eaec36abf.png)

@projecthydra-labs/hyrax-code-reviewers

