### PR TITLE
Adding a migration to remove :workflow_id

### DIFF
--- a/db/migrate/20170307142607_tidy_up_because_of_bad_exception.rb
+++ b/db/migrate/20170307142607_tidy_up_because_of_bad_exception.rb
@@ -1,0 +1,13 @@
+class TidyUpBecauseOfBadException < ActiveRecord::Migration
+  def change
+    if Hyrax::PermissionTemplate.column_names.include?('workflow_id')
+      Hyrax::PermissionTemplate.all.each do |permission_template|
+        workflow_id = permission_template.workflow_id
+        next unless workflow_id
+        Sipity::Workflow.find(workflow_id).update(active: true)
+      end
+
+      remove_column Hyrax::PermissionTemplate.table_name, :workflow_id
+    end
+  end
+end


### PR DESCRIPTION
In the previous migration, due to an exception being raised, the
remove_column was not happening for the PermissionTemplate

`Hyrax::PermissionTemplate.each` raises an exception

@projecthydra-labs/hyrax-code-reviewers
