### PR TITLE
853 fix missing attribute

### DIFF
--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -48,7 +48,7 @@ module Hyrax
         when "visibility"
           error_code = update_visibility_options(attributes)
         when "workflow"
-          update_workflow_options(attributes)
+          grant_workflow_roles(attributes)
         end
         return_info[:error_code] = error_code if error_code
         return_info[:updated] = error_code ? false : true
@@ -77,12 +77,6 @@ module Hyrax
           update_permission_template(attributes)
         end
 
-        # @return [Void]
-        def update_workflow_options(attributes)
-          update_permission_template(attributes)
-          grant_workflow_roles(attributes)
-        end
-
         def activate_workflow_from(attributes)
           new_active_workflow_id = attributes[:workflow_id] || attributes['workflow_id']
           if active_workflow
@@ -95,6 +89,7 @@ module Hyrax
 
         # If the workflow has been changed, ensure that all the AdminSet managers
         # have all the roles for the new workflow
+        # @return [Void]
         # @todo Instead of granting the manage users all of the roles (which means lots of emails), can we agree on a Managing role that all workflows should have?
         def grant_workflow_roles(attributes)
           new_active_workflow = activate_workflow_from(attributes)

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -166,6 +166,21 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
         expect(permission_template.release_date).to eq(today + 2.years)
       end
     end
+
+    context "for a workflow change" do
+      let(:permission_template) { create(:permission_template, admin_set_id: admin_set.id, with_active_workflow: true) }
+      let(:new_workflow) { create(:workflow, permission_template: permission_template, active: false) }
+      let(:input_params) do
+        ActionController::Parameters.new(
+          workflow_id: new_workflow.id
+        ).permit!
+      end
+
+      it "changes the workflow" do
+        expect { subject }.to change { permission_template.reload.active_workflow }.to(new_workflow)
+        expect(new_workflow.reload).to be_active
+      end
+    end
   end
 
   describe "#grant_workflow_roles" do


### PR DESCRIPTION
Remove obsolete update to permission template

Resolves projecthydra-labs/hyku#853

Work on permission template visibility options conflicted with work on workflows, and resulted in an obsolete update remaining in the code. 

Now that the workflow migration patch (#548) has been merged, there is a way to create a failing test. Prior to this migration, even the existence of this spec would not have caused a failing test because the issue was caused by an incompatibility between the permission template in Hyrax vs the one in Hyku (which had gotten migrated). This test was most likely another victim of the merge conflict which caused the problematic code to remain in the first place. But regardless, the issue is now resolved.

@projecthydra-labs/hyrax-code-reviewers
