### PR TITLE
554 edit admin set redirect

### DIFF
--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -49,7 +49,7 @@ module Hyrax
 
     def update
       if @admin_set.update(admin_set_params)
-        redirect_to hyrax.admin_admin_sets_path
+        redirect_to hyrax.edit_admin_admin_set_path(@admin_set), notice: I18n.t('updated_admin_set', scope: 'hyrax.admin.admin_sets.form.permission_update_notices', name: @admin_set.title.first)
       else
         setup_form
         render :edit

--- a/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
+++ b/app/controllers/hyrax/admin/permission_template_accesses_controller.rb
@@ -8,7 +8,7 @@ module Hyrax
 
         redirect_to hyrax.edit_admin_admin_set_path(@permission_template_access.permission_template.admin_set_id,
                                                     anchor: 'participants'),
-                    notice: 'Permissions updated'
+                    notice: translate('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices')
       end
     end
   end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -51,6 +51,7 @@ en:
           cancel:               "Cancel"
           permission_update_notices:
             new_admin_set:      "The administrative set '%{name}' has been created. Use the additional tabs to define other aspects of the administrative set."
+            updated_admin_set:  "The administrative set '%{name}' has been updated."
             participants:       "The administrative set's participant rights have been updated"
             visibility:         "The administrative set's release & visibility settings have been updated."
             workflow:           "The administrative set's workflow has been updated."

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -51,6 +51,7 @@ es:
           cancel:               "Cancelar"
           permission_update_notices:
             new_admin_set:      "Se ha creado el conjunto administrativo '%{name}'. Utilice las pestañas adicionales para definir otros aspectos del conjunto administrativo."
+            updated_admin_set:  "El conjunto administrativo '%{name}' se ha actualizado."
             participants:       "Se han actualizado los derechos de participante del conjunto administrativo"
             visibility:         "La configuración de visibilidad del conjunto administrativo se ha actualizado."
             workflow:           "El flujo de trabajo del conjunto administrativo se ha actualizado."

--- a/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
@@ -116,7 +116,7 @@ describe Hyrax::Admin::AdminSetsController do
       it 'updates a record' do
         patch :update, params: { id: admin_set,
                                  admin_set: { title: "Improved title" } }
-        expect(response).to be_redirect
+        expect(response).to redirect_to(edit_admin_admin_set_path)
         expect(assigns[:admin_set].title).to eq ['Improved title']
       end
     end

--- a/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
           delete :destroy, params: { id: permission_template_access }
         end.to change { Hyrax::PermissionTemplateAccess.count }.by(-1)
         expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(admin_set_id, locale: 'en', anchor: 'participants'))
-        expect(flash[:notice]).to eq 'Permissions updated'
+        expect(flash[:notice]).to eq(I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices'))
       end
     end
   end


### PR DESCRIPTION
When an admin set title or description is updated, the redirect now sends an update message and remains on the same tab of the form.

Fixes https://github.com/projecthydra-labs/hyrax/issues/554

Also adds a translation for the permission template update message when a participant's rights are removed.

@projecthydra-labs/hyrax-code-reviewers
