### PR TITLE
Replacing browse_everything with browse_everything?

### DIFF
--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -45,7 +45,7 @@
      </div>
 
 <%= render 'hyrax/uploads/js_templates' %>
-<% if Hyrax.config.browse_everything %>
+<% if Hyrax.config.browse_everything? %>
   <h2><%= t('hyrax.base.form_files.external_upload') %></h2>
   <%= render 'browse_everything', f: f %>
 <% end %>

--- a/spec/views/hyrax/base/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form.html.erb_spec.rb
@@ -29,7 +29,7 @@ describe 'hyrax/base/_form.html.erb', type: :view do
     let(:work) { GenericWork.new }
     context 'with browse-everything disabled (default)' do
       before do
-        allow(Hyrax.config).to receive(:browse_everything) { nil }
+        allow(Hyrax.config).to receive(:browse_everything?) { nil }
       end
       it "draws the page" do
         expect(page).to have_selector("form[action='/concern/generic_works']")
@@ -44,7 +44,7 @@ describe 'hyrax/base/_form.html.erb', type: :view do
 
     context 'with browse-everything enabled' do
       before do
-        allow(Hyrax.config).to receive(:browse_everything) { 'not nil' }
+        allow(Hyrax.config).to receive(:browse_everything?) { 'not nil' }
       end
       it 'renders the BE upload widget' do
         expect(page).to have_selector('button#browse-btn')


### PR DESCRIPTION
```console
DEPRECATION WARNING: browse_everything is deprecated and will be removed
from a future release (use browse_everything? instead).
```

@projecthydra-labs/hyrax-code-reviewers
