### PR TITLE
Change "Rights" to "License"

### DIFF
--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -58,7 +58,7 @@ module Hyrax
         # also remove any blank assertions
         # TODO this method could move to the work form.
         def clean_attributes(attributes)
-          attributes[:rights] = Array(attributes[:rights]) if attributes.key? :rights
+          attributes[:license] = Array(attributes[:license]) if attributes.key? :license
           attributes[:rights_statement] = Array(attributes[:rights_statement]) if attributes.key? :rights_statement
           remove_blank_attributes!(attributes)
         end

--- a/app/forms/hyrax/forms/batch_edit_form.rb
+++ b/app/forms/hyrax/forms/batch_edit_form.rb
@@ -3,7 +3,7 @@ module Hyrax
     class BatchEditForm < Hyrax::Forms::WorkForm
       # Used for drawing the fields that appear on the page
       self.terms = [:creator, :contributor, :description,
-                    :keyword, :resource_type, :rights, :publisher, :date_created,
+                    :keyword, :resource_type, :license, :publisher, :date_created,
                     :subject, :language, :identifier, :based_near,
                     :related_url]
       self.required_fields = []

--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -15,7 +15,7 @@ module Hyrax
       delegate :human_readable_type, :member_ids, to: :model
 
       self.terms = [:resource_type, :title, :creator, :contributor, :description,
-                    :keyword, :rights, :publisher, :date_created, :subject, :language,
+                    :keyword, :license, :publisher, :date_created, :subject, :language,
                     :representative_id, :thumbnail_id, :identifier, :based_near,
                     :related_url, :visibility]
 
@@ -35,7 +35,7 @@ module Hyrax
          :contributor,
          :description,
          :keyword,
-         :rights,
+         :license,
          :publisher,
          :date_created,
          :subject,

--- a/app/forms/hyrax/forms/file_set_edit_form.rb
+++ b/app/forms/hyrax/forms/file_set_edit_form.rb
@@ -5,12 +5,12 @@ module Hyrax::Forms
 
     delegate :depositor, :permissions, to: :model
 
-    self.required_fields = [:title, :creator, :keyword, :rights]
+    self.required_fields = [:title, :creator, :keyword, :license]
 
     self.model_class = ::FileSet
 
     self.terms = [:resource_type, :title, :creator, :contributor, :description,
-                  :keyword, :rights, :publisher, :date_created, :subject, :language,
+                  :keyword, :license, :publisher, :date_created, :subject, :language,
                   :identifier, :based_near, :related_url,
                   :visibility_during_embargo, :visibility_after_embargo, :embargo_release_date,
                   :visibility_during_lease, :visibility_after_lease, :lease_expiration_date,

--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -18,7 +18,7 @@ module Hyrax
       attr_reader :agreement_accepted
 
       self.terms = [:title, :creator, :contributor, :description,
-                    :keyword, :rights, :rights_statement, :publisher, :date_created,
+                    :keyword, :license, :rights_statement, :publisher, :date_created,
                     :subject, :language, :identifier, :based_near, :related_url,
                     :representative_id, :thumbnail_id, :files,
                     :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
@@ -26,7 +26,7 @@ module Hyrax
                     :visibility, :ordered_member_ids, :source, :in_works_ids,
                     :member_of_collection_ids, :admin_set_id]
 
-      self.required_fields = [:title, :creator, :keyword, :rights_statement, :rights]
+      self.required_fields = [:title, :creator, :keyword, :rights_statement, :license]
 
       def initialize(model, current_ability, controller)
         @current_ability = current_ability

--- a/app/helpers/hyrax/citations_behaviors/formatters/open_url_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/open_url_formatter.rb
@@ -29,7 +29,7 @@ module Hyrax
           language: 'language',
           keyword: 'relation',
           based_near: 'coverage',
-          rights: 'rights'
+          license: 'license'
         }.freeze
       end
     end

--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -30,7 +30,7 @@ module Hyrax
       end
 
       # Used for a license
-      property :rights, predicate: ::RDF::Vocab::DC.rights do |index|
+      property :license, predicate: ::RDF::Vocab::DC.rights do |index|
         index.as :stored_searchable
       end
 

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -147,8 +147,8 @@ module Hyrax
       self[Hydra.config.permissions.lease.expiration_date]
     end
 
-    def rights
-      fetch(Solrizer.solr_name('rights'), [])
+    def license
+      fetch(Solrizer.solr_name('license'), [])
     end
 
     def mime_type

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -20,14 +20,14 @@ module Hyrax
 
     # Metadata Methods
     delegate :title, :description, :creator, :contributor, :subject, :publisher, :keyword, :language,
-             :embargo_release_date, :lease_expiration_date, :rights, :date_created,
+             :embargo_release_date, :lease_expiration_date, :license, :date_created,
              :resource_type, :based_near, :related_url, :identifier, to: :solr_document
 
     # Terms is the list of fields displayed by
     # app/views/collections/_show_descriptions.html.erb
     def self.terms
       [:total_items, :size, :resource_type, :creator, :contributor, :keyword,
-       :rights, :publisher, :date_created, :subject, :language, :identifier,
+       :license, :publisher, :date_created, :subject, :language, :identifier,
        :based_near, :related_url]
     end
 

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -25,7 +25,7 @@ module Hyrax
 
     # Metadata Methods
     delegate :title, :label, :description, :creator, :contributor, :subject,
-             :publisher, :language, :date_uploaded, :rights,
+             :publisher, :language, :date_uploaded,
              :embargo_release_date, :lease_expiration_date,
              :depositor, :keyword, :title_or_label, :keyword,
              :date_created, :date_modified, :itemtype,
@@ -58,9 +58,9 @@ module Hyrax
       TwitterPresenter.twitter_handle_for(user_key: depositor)
     end
 
-    def rights
-      return if solr_document.rights.nil?
-      solr_document.rights.first
+    def license
+      return if solr_document.license.nil?
+      solr_document.license.first
     end
 
     def stats_path

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -36,7 +36,7 @@ module Hyrax
     # Metadata Methods
     delegate :title, :date_created, :date_modified, :date_uploaded, :description,
              :creator, :contributor, :subject, :publisher, :language, :embargo_release_date,
-             :lease_expiration_date, :rights, :source, :thumbnail_id, :representative_id,
+             :lease_expiration_date, :license, :source, :thumbnail_id, :representative_id,
              :member_of_collection_ids, to: :solr_document
 
     def workflow

--- a/app/renderers/hyrax/renderers/license_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/license_attribute_renderer.rb
@@ -1,16 +1,14 @@
 module Hyrax
   module Renderers
-    class RightsAttributeRenderer < AttributeRenderer
+    # This is used by PresentsAttributes to show licenses
+    #   e.g.: presenter.attribute_to_html(:license, render_as: :license)
+    class LicenseAttributeRenderer < AttributeRenderer
       private
-
-        def attribute_value_to_html(value)
-          rights_attribute_to_html(value)
-        end
 
         ##
         # Special treatment for license/rights.  A URL from the Hyrax gem's config/hyrax.rb is stored in the descMetadata of the
         # curation_concern.  If that URL is valid in form, then it is used as a link.  If it is not valid, it is used as plain text.
-        def rights_attribute_to_html(value)
+        def attribute_value_to_html(value)
           begin
             parsed_uri = URI.parse(value)
           rescue

--- a/app/services/hyrax/file_set_csv_service.rb
+++ b/app/services/hyrax/file_set_csv_service.rb
@@ -16,7 +16,7 @@ module Hyrax
     def initialize(file, terms = nil, multi_value_separator = '|')
       @file_set = file
       @terms = terms
-      @terms ||= [:id, :title, :depositor, :creator, :visibility, :resource_type, :rights, :file_format]
+      @terms ||= [:id, :title, :depositor, :creator, :visibility, :resource_type, :license, :file_format]
       @multi_value_separator = multi_value_separator
     end
 

--- a/app/views/hyrax/base/_attributes.html.erb
+++ b/app/views/hyrax/base/_attributes.html.erb
@@ -8,7 +8,7 @@
     <%= presenter.attribute_to_html(:permission_badge, label: 'Visibility') %>
     <%= presenter.attribute_to_html(:embargo_release_date, render_as: :date) %>
     <%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date) %>
-    <%= presenter.attribute_to_html(:rights, render_as: :rights) %>
+    <%= presenter.attribute_to_html(:license, render_as: :license) %>
     <% if defined?(presenter.member_of_collection_presenters) && presenter.member_of_collection_presenters.size > 0 %>
       <%= render 'member_of_collections', presenter: presenter %>
     <% end %>

--- a/app/views/hyrax/base/_metadata.html.erb
+++ b/app/views/hyrax/base/_metadata.html.erb
@@ -7,6 +7,6 @@
     <%= render 'attribute_rows', presenter: presenter %>
     <%= presenter.attribute_to_html(:embargo_release_date, render_as: :date) %>
     <%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date) %>
-    <%= presenter.attribute_to_html(:rights, render_as: :rights) %>
+    <%= presenter.attribute_to_html(:license, render_as: :license) %>
   </tbody>
 </table>

--- a/app/views/records/edit_fields/_license.html.erb
+++ b/app/views/records/edit_fields/_license.html.erb
@@ -1,5 +1,5 @@
 <% license_service = Hyrax::LicenseService.new %>
-<%= f.input :rights, as: :multi_value_select,
+<%= f.input :license, as: :multi_value_select,
     collection: license_service.select_active_options,
     include_blank: true,
     item_helper: license_service.method(:include_current_value),

--- a/app/views/shared/_citations.html.erb
+++ b/app/views/shared/_citations.html.erb
@@ -10,8 +10,8 @@
   <meta property="og:url" content="<%= polymorphic_path([main_app, @presenter]) %>"/>
   <meta name="twitter:data1" content="<%= @presenter.keyword.join(', ') %>"/>
   <meta name="twitter:label1" content="Keywords"/>
-  <meta name="twitter:data2" content="<%= @presenter.rights %>"/>
-  <meta name="twitter:label2" content="Rights"/>
+  <meta name="twitter:data2" content="<%= @presenter.license %>"/>
+  <meta name="twitter:label2" content="License"/>
 <% end %>
 
 <% content_for(:gscholar_meta) do %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -688,7 +688,7 @@ en:
         publisher: "The person or group making the collection available. Generally this is the institution."
         related_url: "A link to a website or other specific content (audio, video, PDF document) related to the collection. An example is the URL of a research project from which the collection was derived."
         resource_type: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."
-        rights: "Licensing and distribution information governing access to the collection. Select from the provided drop-down list."
+        license: "Licensing and distribution information governing access to the collection. Select from the provided drop-down list."
         subject: "Headings or index terms describing what the collection is about; these do need to conform to an existing vocabulary."
         title: "A name to aid in identifying a collection."
       defaults:
@@ -703,7 +703,7 @@ en:
         publisher: "The person or group making the work available. Generally this is the institution."
         related_url: "A link to a website or other specific content (audio, video, PDF document) related to the work. An example is the URL of a research project from which the work was derived."
         resource_type: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."
-        rights: "Licensing and distribution information governing access to the work. Select from the provided drop-down list."
+        license: "Licensing and distribution information governing access to the work. Select from the provided drop-down list."
         subject: "Headings or index terms describing what the work is about; these do need to conform to an existing vocabulary."
         title: "A name to aid in identifying a work."
     labels:
@@ -722,7 +722,7 @@ en:
         keyword:                   "Keyword"
         lease_expiration_date:     'until'
         related_url:               "Related URL"
-        rights:                    "Rights"
+        license:                   "License"
         title:                     "Title"
         visibility_after_embargo:  'then open it up to'
         visibility_after_lease:    'then restrict it to'

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -687,7 +687,7 @@ es:
         publisher: "La persona o grupo que hizo disponible la colección. Generalmente ésta es una institución."
         related_url: "Un vínculo a una página web u otro contenido específico (audio, video, un documento PDF) relacionado a la colección. Un ejemplo es la URL de un proyecto de investigación de la cual proviene la colección"
         resource_type: "Categorías predefinidas que describen el tipo de contenido que se ha cargado, tal como &quot;artículo&quot; or &quot;conjunto de datos.&quot;  Más de un tipo puede ser seleccionado."
-        rights: "Licencias e información de distribución sobre la colección. Seleccionar uno de la lista."
+        license: "Licencias e información de distribución sobre la colección. Seleccionar uno de la lista."
         subject: "Cabeceras o términos de índices que describen de qué trata la colección; éstos no tienen que pertenecer a un vocabulario existente.."
         title: "Un nombre para ayudar a la identificación de una colección."
       defaults:
@@ -702,7 +702,7 @@ es:
         publisher: "La persona o grupo que hizo disponible el trabajo. Generalmente ésta es una institución."
         related_url: "Un vínculo a una página web u otro contenido específico (audio, video, un documento PDF) relacionado a el trabajo. Un ejemplo es la URL de un proyecto de investigación de la cual proviene el trabajo"
         resource_type: "Categorías predefinidas que describen el tipo de contenido que se ha cargado, tal como &quot;artículo&quot; or &quot;conjunto de datos.&quot;  Más de un tipo puede ser seleccionado."
-        rights: "Licencias e información de distribución sobre el trabajo. Seleccionar uno de la lista."
+        license: "Licencias e información de distribución sobre el trabajo. Seleccionar uno de la lista."
         subject: "Cabeceras o términos de índices que describen de qué trata el trabajo; éstos no tienen que pertenecer a un vocabulario existente.."
         title: "Un nombre para ayudar a la identificación de un trabajo."
     labels:
@@ -721,7 +721,7 @@ es:
         keyword:          "Palabra Clave"
         lease_expiration_date:     'hasta'
         related_url:      "URL relacionada"
-        rights:           "Derechos"
+        license:          "Licencia"
         title:            "Título"
         visibility_after_embargo:  'luego abrirlo a'
         visibility_after_lease:    'luego restringirlo a'

--- a/lib/hyrax/arkivo/schema_validator.rb
+++ b/lib/hyrax/arkivo/schema_validator.rb
@@ -11,7 +11,7 @@ module Hyrax
           required: true,
           properties: {
             title: { type: 'string', required: true },
-            rights: { type: 'string', required: true },
+            license: { type: 'string', required: true },
             resourceType: { type: 'string' },
             description: { type: 'string' },
             publisher: { type: 'string' },

--- a/spec/actors/hyrax/actors/generic_work_actor_spec.rb
+++ b/spec/actors/hyrax/actors/generic_work_actor_spec.rb
@@ -67,7 +67,7 @@ describe Hyrax::Actors::GenericWorkActor do
               files: [
                 file
               ],
-              rights: ['http://creativecommons.org/licenses/by/3.0/us/'] }
+              license: ['http://creativecommons.org/licenses/by/3.0/us/'] }
           end
 
           it "applies embargo to attached files" do

--- a/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
+++ b/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-describe Hyrax::Actors::InterpretVisibilityActor do
+RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
   let(:user) { create(:user) }
   let(:curation_concern) { GenericWork.new }
   let(:attributes) { { admin_set_id: admin_set.id } }
@@ -89,7 +89,7 @@ describe Hyrax::Actors::InterpretVisibilityActor do
           visibility_during_embargo: 'authenticated', embargo_release_date: date.to_s,
           visibility_after_embargo: 'open', visibility_during_lease: 'open',
           lease_expiration_date: '2014-06-12', visibility_after_lease: 'restricted',
-          rights: ['http://creativecommons.org/licenses/by/3.0/us/'] }
+          license: ['http://creativecommons.org/licenses/by/3.0/us/'] }
       end
 
       context 'with a valid embargo date (and no template requirements)' do
@@ -400,7 +400,7 @@ describe Hyrax::Actors::InterpretVisibilityActor do
           visibility_during_embargo: 'authenticated', embargo_release_date: '2099-05-12',
           visibility_after_embargo: 'open', visibility_during_lease: 'open',
           lease_expiration_date: date.to_s, visibility_after_lease: 'restricted',
-          rights: ['http://creativecommons.org/licenses/by/3.0/us/'] }
+          license: ['http://creativecommons.org/licenses/by/3.0/us/'] }
       end
 
       context 'with a valid lease date' do

--- a/spec/factories/api_items.rb
+++ b/spec/factories/api_items.rb
@@ -35,7 +35,7 @@ FactoryGirl.define do
         identifier: 'isbn:1234567890',
         url: 'http://example.org/nsf/2013/datasets/',
         language: 'English--New Jerseyan',
-        rights: 'http://creativecommons.org/licenses/by-sa/3.0/us/',
+        license: 'http://creativecommons.org/licenses/by-sa/3.0/us/',
         tags: [
           'datasets',
           'nsf',
@@ -72,7 +72,7 @@ FactoryGirl.define do
             name: 'Babs McGee'
           }
         ],
-        rights: 'http://creativecommons.org/licenses/by-sa/3.0/us/',
+        license: 'http://creativecommons.org/licenses/by-sa/3.0/us/',
         tags: [
           'datasets'
         ]

--- a/spec/forms/hyrax/forms/batch_edit_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_edit_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Hyrax::Forms::BatchEditForm do
            language: ['en'],
            contributor: ['contributor1'],
            description: ['description1'],
-           rights: ['rights1'],
+           license: ['license1'],
            subject: ['subject1'],
            identifier: ['id1'],
            based_near: ['based_near1'],
@@ -25,7 +25,7 @@ RSpec.describe Hyrax::Forms::BatchEditForm do
            resource_type: ['bar'],
            contributor: ['contributor2'],
            description: ['description2'],
-           rights: ['rights2'],
+           license: ['license2'],
            subject: ['subject2'],
            identifier: ['id2'],
            based_near: ['based_near2'],
@@ -44,7 +44,7 @@ RSpec.describe Hyrax::Forms::BatchEditForm do
                          :description,
                          :keyword,
                          :resource_type,
-                         :rights,
+                         :license,
                          :publisher,
                          :date_created,
                          :subject,
@@ -62,7 +62,7 @@ RSpec.describe Hyrax::Forms::BatchEditForm do
       expect(form.model.description).to match_array ["description1", "description2"]
       expect(form.model.keyword).to match_array ["abc", "123"]
       expect(form.model.resource_type).to match_array ["bar"]
-      expect(form.model.rights).to match_array ["rights1", "rights2"]
+      expect(form.model.license).to match_array ["license1", "license2"]
       expect(form.model.publisher).to match_array ["Rand McNally"]
       expect(form.model.subject).to match_array ["subject1", "subject2"]
       expect(form.model.language).to match_array ["en"]
@@ -80,7 +80,7 @@ RSpec.describe Hyrax::Forms::BatchEditForm do
                          { description: [] },
                          { keyword: [] },
                          { resource_type: [] },
-                         { rights: [] },
+                         { license: [] },
                          { publisher: [] },
                          { date_created: [] },
                          { subject: [] },

--- a/spec/forms/hyrax/forms/batch_upload_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_upload_form_spec.rb
@@ -1,4 +1,4 @@
-describe Hyrax::Forms::BatchUploadForm do
+RSpec.describe Hyrax::Forms::BatchUploadForm do
   let(:model) { GenericWork.new }
   let(:controller) { instance_double(Hyrax::BatchUploadsController) }
   let(:form) { described_class.new(model, ability, controller) }
@@ -7,7 +7,7 @@ describe Hyrax::Forms::BatchUploadForm do
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:creator, :keyword, :rights_statement, :rights] }
+    it { is_expected.to eq [:creator, :keyword, :rights_statement, :license] }
     it { is_expected.not_to include(:title) }
   end
 
@@ -40,7 +40,7 @@ describe Hyrax::Forms::BatchUploadForm do
                          :contributor,
                          :description,
                          :keyword,
-                         :rights,
+                         :license,
                          :rights_statement,
                          :publisher,
                          :date_created,

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -1,4 +1,4 @@
-describe Hyrax::Forms::CollectionForm do
+RSpec.describe Hyrax::Forms::CollectionForm do
   describe "#terms" do
     subject { described_class.terms }
 
@@ -9,7 +9,7 @@ describe Hyrax::Forms::CollectionForm do
                          :contributor,
                          :description,
                          :keyword,
-                         :rights,
+                         :license,
                          :publisher,
                          :date_created,
                          :subject,
@@ -40,7 +40,7 @@ describe Hyrax::Forms::CollectionForm do
         :contributor,
         :description,
         :keyword,
-        :rights,
+        :license,
         :publisher,
         :date_created,
         :subject,
@@ -85,7 +85,7 @@ describe Hyrax::Forms::CollectionForm do
                          { contributor: [] },
                          { description: [] },
                          { keyword: [] },
-                         { rights: [] },
+                         { license: [] },
                          { publisher: [] },
                          { date_created: [] },
                          { subject: [] },

--- a/spec/forms/hyrax/forms/file_set_edit_form_spec.rb
+++ b/spec/forms/hyrax/forms/file_set_edit_form_spec.rb
@@ -7,7 +7,7 @@ describe Hyrax::Forms::FileSetEditForm do
     it 'returns a list' do
       expect(subject.terms).to eq(
         [:resource_type, :title, :creator, :contributor, :description, :keyword,
-         :rights, :publisher, :date_created, :subject, :language, :identifier,
+         :license, :publisher, :date_created, :subject, :language, :identifier,
          :based_near, :related_url,
          :visibility_during_embargo, :visibility_after_embargo, :embargo_release_date,
          :visibility_during_lease, :visibility_after_lease, :lease_expiration_date,

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Hyrax::Forms::WorkForm, :no_clean do
         keyword: ['derp'],
         source: ['related'],
         rights_statement: 'http://rightsstatements.org/vocab/InC-EDU/1.0/',
-        rights: ['http://creativecommons.org/licenses/by/3.0/us/']
+        license: ['http://creativecommons.org/licenses/by/3.0/us/']
       }
     end
 
@@ -75,7 +75,7 @@ RSpec.describe Hyrax::Forms::WorkForm, :no_clean do
       expect(subject['title']).to eq ['foo']
       expect(subject['description']).to be_empty
       expect(subject['visibility']).to eq 'open'
-      expect(subject['rights']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
+      expect(subject['license']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
       expect(subject['rights_statement']).to eq 'http://rightsstatements.org/vocab/InC-EDU/1.0/'
       expect(subject['keyword']).to eq ['derp']
       expect(subject['source']).to eq ['related']
@@ -180,6 +180,6 @@ RSpec.describe Hyrax::Forms::WorkForm, :no_clean do
 
   describe ".required_fields" do
     subject { described_class.required_fields }
-    it { is_expected.to eq [:title, :creator, :keyword, :rights_statement, :rights] }
+    it { is_expected.to eq [:title, :creator, :keyword, :rights_statement, :license] }
   end
 end

--- a/spec/forms/hyrax/generic_work_form_spec.rb
+++ b/spec/forms/hyrax/generic_work_form_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe Hyrax::GenericWorkForm do
 
   describe "#required_fields" do
     subject { form.required_fields }
-    it { is_expected.to eq [:title, :creator, :keyword, :rights_statement, :rights] }
+    it { is_expected.to eq [:title, :creator, :keyword, :rights_statement, :license] }
   end
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :keyword, :rights_statement, :rights] }
+    it { is_expected.to eq [:title, :creator, :keyword, :rights_statement, :license] }
   end
 
   describe "#secondary_terms" do
     subject { form.secondary_terms }
     it do
-      is_expected.not_to include(:title, :creator, :keyword, :rights,
+      is_expected.not_to include(:title, :creator, :keyword, :license,
                                  :visibilty, :visibility_during_embargo,
                                  :embargo_release_date, :visibility_after_embargo,
                                  :visibility_during_lease, :lease_expiration_date,
@@ -53,7 +53,7 @@ RSpec.describe Hyrax::GenericWorkForm do
         representative_id: '456',
         thumbnail_id: '789',
         keyword: ['derp'],
-        rights: ['http://creativecommons.org/licenses/by/3.0/us/'],
+        license: ['http://creativecommons.org/licenses/by/3.0/us/'],
         member_of_collection_ids: ['123456', 'abcdef']
       )
     end
@@ -64,7 +64,7 @@ RSpec.describe Hyrax::GenericWorkForm do
       expect(subject['title']).to eq ['foo']
       expect(subject['description']).to be_empty
       expect(subject['visibility']).to eq 'open'
-      expect(subject['rights']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
+      expect(subject['license']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
       expect(subject['keyword']).to eq ['derp']
       expect(subject['member_of_collection_ids']).to eq ['123456', 'abcdef']
     end
@@ -75,7 +75,7 @@ RSpec.describe Hyrax::GenericWorkForm do
           title: [''],
           description: [''],
           keyword: [''],
-          rights: [''],
+          license: [''],
           member_of_collection_ids: [''],
           on_behalf_of: 'Melissa'
         )
@@ -84,7 +84,7 @@ RSpec.describe Hyrax::GenericWorkForm do
       it 'removes blank parameters' do
         expect(subject['title']).to be_empty
         expect(subject['description']).to be_empty
-        expect(subject['rights']).to be_empty
+        expect(subject['license']).to be_empty
         expect(subject['keyword']).to be_empty
         expect(subject['member_of_collection_ids']).to be_empty
         expect(subject['on_behalf_of']).to eq 'Melissa'

--- a/spec/indexers/hyrax/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/file_set_indexer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Hyrax::FileSetIndexer do
+RSpec.describe Hyrax::FileSetIndexer do
   include Hyrax::FactoryHelpers
 
   let(:file_set) do
@@ -17,7 +17,7 @@ describe Hyrax::FileSetIndexer do
       date_modified: Date.parse('2012-01-01'),
       subject: ['Theology'],
       language: ['Arabic'],
-      rights: ['Wide open, buddy.'],
+      license: ['Wide open, buddy.'],
       rights_statement: ['No Known Copyright'],
       resource_type: ['Book'],
       identifier: ['urn:isbn:1234567890'],
@@ -65,7 +65,7 @@ describe Hyrax::FileSetIndexer do
       expect(subject[Solrizer.solr_name('date_modified')]).to be_nil
       expect(subject[Solrizer.solr_name('date_uploaded', :stored_sortable, type: :date)]).to eq '2011-01-01T00:00:00Z'
       expect(subject[Solrizer.solr_name('date_modified', :stored_sortable, type: :date)]).to eq '2012-01-01T00:00:00Z'
-      expect(subject[Solrizer.solr_name('rights')]).to eq ['Wide open, buddy.']
+      expect(subject[Solrizer.solr_name('license')]).to eq ['Wide open, buddy.']
       expect(subject[Solrizer.solr_name('rights_statement')]).to eq ['No Known Copyright']
       expect(subject[Solrizer.solr_name('related_url')]).to eq ['http://example.org/TheWork/']
       expect(subject[Solrizer.solr_name('contributor')]).to eq ['Mohammad']

--- a/spec/lib/hyrax/arkivo/schema_validator_spec.rb
+++ b/spec/lib/hyrax/arkivo/schema_validator_spec.rb
@@ -28,11 +28,11 @@ describe Hyrax::Arkivo::SchemaValidator do
     end.to raise_error(Hyrax::Arkivo::InvalidItem, /required property of 'title'/)
   end
 
-  it 'ensures the metadata has rights' do
-    item['metadata'].delete('rights')
+  it 'ensures the metadata has license' do
+    item['metadata'].delete('license')
     expect do
       described_class.new(item).call
-    end.to raise_error(Hyrax::Arkivo::InvalidItem, /required property of 'rights'/)
+    end.to raise_error(Hyrax::Arkivo::InvalidItem, /required property of 'license'/)
   end
 
   it 'ensures the file has a b64-encoded content' do

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 # This tests the FileSet model that is inserted into the host app by hyrax:models
 # It includes the Hyrax::FileSetBehavior module and nothing else
 # So this test covers both the FileSetBehavior module and the generated FileSet model
-describe FileSet do
+RSpec.describe FileSet do
   include Hyrax::FactoryHelpers
 
   let(:user) { create(:user) }
@@ -92,7 +92,7 @@ describe FileSet do
       expect(subject).to respond_to(:date_modified)
       expect(subject).to respond_to(:subject)
       expect(subject).to respond_to(:language)
-      expect(subject).to respond_to(:rights)
+      expect(subject).to respond_to(:license)
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:identifier)
     end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -143,7 +143,7 @@ describe GenericWork do
       expect(subject).to respond_to(:date_modified)
       expect(subject).to respond_to(:subject)
       expect(subject).to respond_to(:language)
-      expect(subject).to respond_to(:rights)
+      expect(subject).to respond_to(:license)
       expect(subject).to respond_to(:resource_type)
       expect(subject).to respond_to(:identifier)
     end

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -1,9 +1,9 @@
-describe Hyrax::CollectionPresenter do
+RSpec.describe Hyrax::CollectionPresenter do
   describe ".terms" do
     subject { described_class.terms }
     it do
       is_expected.to eq [:total_items, :size, :resource_type, :creator,
-                         :contributor, :keyword, :rights, :publisher,
+                         :contributor, :keyword, :license, :publisher,
                          :date_created, :subject, :language, :identifier,
                          :based_near, :related_url]
     end

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -1,4 +1,4 @@
-describe Hyrax::FileSetPresenter do
+RSpec.describe Hyrax::FileSetPresenter do
   let(:solr_document) { SolrDocument.new(attributes) }
   let(:ability) { double "Ability" }
   let(:presenter) { described_class.new(solr_document, ability) }
@@ -48,7 +48,7 @@ describe Hyrax::FileSetPresenter do
     let(:solr_properties) do
       ["date_uploaded", "title_or_label",
        "contributor", "creator", "title", "description", "publisher",
-       "subject", "language", "rights", "format_label", "file_size",
+       "subject", "language", "license", "format_label", "file_size",
        "height", "width", "filename", "well_formed", "page_count",
        "file_title", "last_modified", "original_checksum", "mime_type",
        "duration", "sample_rate"]

--- a/spec/renderers/hyrax/renderers/license_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/license_attribute_renderer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe Hyrax::Renderers::RightsAttributeRenderer do
-  let(:field) { :rights }
+RSpec.describe Hyrax::Renderers::LicenseAttributeRenderer do
+  let(:field) { :license }
   let(:renderer) { described_class.new(field, ['http://creativecommons.org/licenses/by/3.0/us/', 'http://creativecommons.org/licenses/by-nd/3.0/us/']) }
 
   describe "#attribute_to_html" do
@@ -9,10 +9,10 @@ describe Hyrax::Renderers::RightsAttributeRenderer do
     let(:expected) { Nokogiri::HTML(tr_content) }
 
     let(:tr_content) do
-      "<tr><th>Rights</th>\n" \
+      "<tr><th>License</th>\n" \
        "<td><ul class='tabular'>\n" \
-       "<li class=\"attribute rights\"><a href=\"http://creativecommons.org/licenses/by/3.0/us/\" target=\"_blank\">Attribution 3.0 United States</a></li>\n" \
-       "<li class=\"attribute rights\"><a href=\"http://creativecommons.org/licenses/by-nd/3.0/us/\" target=\"_blank\">Attribution-NoDerivs 3.0 United States</a></li>\n" \
+       "<li class=\"attribute license\"><a href=\"http://creativecommons.org/licenses/by/3.0/us/\" target=\"_blank\">Attribution 3.0 United States</a></li>\n" \
+       "<li class=\"attribute license\"><a href=\"http://creativecommons.org/licenses/by-nd/3.0/us/\" target=\"_blank\">Attribution-NoDerivs 3.0 United States</a></li>\n" \
        "</ul></td></tr>"
     end
     it { expect(renderer).not_to be_microdata(field) }

--- a/spec/services/hyrax/file_set_csv_service_spec.rb
+++ b/spec/services/hyrax/file_set_csv_service_spec.rb
@@ -1,4 +1,4 @@
-describe Hyrax::FileSetCSVService do
+RSpec.describe Hyrax::FileSetCSVService do
   let(:mock_file) do
     Hydra::PCDM::File.new
   end
@@ -10,7 +10,7 @@ describe Hyrax::FileSetCSVService do
 
   let(:file) do
     FileSet.new(id: '123abc', title: ['My Title'], creator: ['Von, Creator'],
-                resource_type: ['Book', 'Other'], rights: ['Mine']) do |f|
+                resource_type: ['Book', 'Other'], license: ['Mine']) do |f|
       f.apply_depositor_metadata('jilluser@example.com')
     end
   end
@@ -30,7 +30,7 @@ describe Hyrax::FileSetCSVService do
 
     describe "csv_header" do
       subject { csv_service.csv_header }
-      it { is_expected.to eq "id,title,depositor,creator,visibility,resource_type,rights,file_format\n" }
+      it { is_expected.to eq "id,title,depositor,creator,visibility,resource_type,license,file_format\n" }
     end
   end
 
@@ -56,7 +56,7 @@ describe Hyrax::FileSetCSVService do
 
     describe "csv_header" do
       subject { csv_service.csv_header }
-      it { is_expected.to eq "id,title,depositor,creator,visibility,resource_type,rights,file_format\n" }
+      it { is_expected.to eq "id,title,depositor,creator,visibility,resource_type,license,file_format\n" }
     end
   end
 

--- a/spec/views/hyrax/batch_edits/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/batch_edits/edit.html.erb_spec.rb
@@ -1,5 +1,5 @@
 describe 'hyrax/batch_edits/edit.html.erb', type: :view do
-  let(:generic_work) { stub_model(GenericWork, id: '999', depositor: 'bob', rights: ['']) }
+  let(:generic_work) { stub_model(GenericWork, id: '999', depositor: 'bob', license: ['']) }
   let(:batch) { ['999'] }
   let(:form) { Hyrax::Forms::BatchEditForm.new(generic_work, nil, batch) }
 
@@ -11,7 +11,7 @@ describe 'hyrax/batch_edits/edit.html.erb', type: :view do
     allow(controller).to receive(:current_user).and_return(stub_model(User))
     allow(form).to receive(:model).and_return(generic_work)
     allow(form).to receive(:names).and_return(['title 1', 'title 2'])
-    allow(form).to receive(:terms).and_return([:description, :rights])
+    allow(form).to receive(:terms).and_return([:description, :license])
     assign :form, form
     view.extend Hyrax::PermissionsHelper
     view.lookup_context.prefixes.push "hyrax/base"

--- a/spec/views/hyrax/citations/work.html.erb_spec.rb
+++ b/spec/views/hyrax/citations/work.html.erb_spec.rb
@@ -1,5 +1,5 @@
 
-describe 'hyrax/citations/work.html.erb', type: :view do
+RSpec.describe 'hyrax/citations/work.html.erb', type: :view do
   let(:object_profile) { ["{\"id\":\"999\"}"] }
   let(:contributor) { ['Gandalf Grey'] }
   let(:creator)     { ['Bilbo Baggins', 'Baggins, Frodo'] }
@@ -11,7 +11,7 @@ describe 'hyrax/citations/work.html.erb', type: :view do
       human_readable_type_tesim: ['Generic Work'],
       contributor_tesim: contributor,
       creator_tesim: creator,
-      rights_tesim: ['http://creativecommons.org/licenses/by/3.0/us/'],
+      license_tesim: ['http://creativecommons.org/licenses/by/3.0/us/'],
       title_tesim: ['the Roared about the Langs'],
       based_near_tesim: ['London'],
       date_created_tesim: ['1969']

--- a/spec/views/hyrax/collections/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_form.html.erb_spec.rb
@@ -1,4 +1,4 @@
-describe 'hyrax/collections/_form.html.erb', type: :view do
+RSpec.describe 'hyrax/collections/_form.html.erb', type: :view do
   let(:collection) { build(:collection) }
   let(:collection_form) { Hyrax::Forms::CollectionForm.new(collection) }
 
@@ -27,7 +27,7 @@ describe 'hyrax/collections/_form.html.erb', type: :view do
     expect(rendered).to have_selector("input#collection_identifier")
     expect(rendered).to have_selector("input#collection_based_near")
     expect(rendered).to have_selector("input#collection_related_url")
-    expect(rendered).to have_selector("select#collection_rights")
+    expect(rendered).to have_selector("select#collection_license")
     expect(rendered).to have_selector("select#collection_resource_type")
     expect(rendered).not_to have_selector("input#collection_visibility")
   end


### PR DESCRIPTION
This just affects the labeling and the property name. The underlying
predicates are unchanged so there is no data migration. However, a solr
field changed, so reindexing all works, collections and FileSets is required.

This will make way for the "Rights Statement" which is different than
the license.

Ref https://github.com/projecthydra-labs/hyku/issues/293