### PR TITLE
Select2 should not be wrapped in form-control

### DIFF
--- a/app/views/hyrax/admin/admin_sets/_form_participants.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_participants.html.erb
@@ -43,8 +43,7 @@
                       <div class="col-md-10 col-xs-8 form-group">
                         <%= builder.hidden_field :agent_type %>
                         <%= builder.text_field :agent_id,
-                                         placeholder: "Search for a user...",
-                                         class: 'form-control' %>
+                                         placeholder: "Search for a user..." %>
                         as
                         <%= builder.select :access,
                                      access_options,


### PR DESCRIPTION
Before:
<img width="627" alt="screen shot 2017-03-16 at 8 44 45 am" src="https://cloud.githubusercontent.com/assets/92044/23999097/4b0e1cea-0a25-11e7-9f11-e06249253272.png">

After:
<img width="640" alt="screen shot 2017-03-16 at 8 46 48 am" src="https://cloud.githubusercontent.com/assets/92044/23999109/527950ee-0a25-11e7-9171-e2f2b777cffe.png">
