### PR TITLE
Tidying up rubocop violations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -59,7 +59,6 @@ Metrics/MethodLength:
     - 'app/services/hyrax/workflow/permission_query.rb'
     - 'lib/generators/hyrax/templates/migrations/create_local_authorities.rb'
     - 'lib/generators/hyrax/install_generator.rb'
-    - 'lib/hyrax/configuration.rb'
     - 'lib/hyrax/rails/routes.rb'
     - 'spec/support/**/*'
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,7 +49,6 @@ Metrics/ModuleLength:
 
 Metrics/MethodLength:
   Exclude:
-    - 'app/actors/hyrax/actors/add_to_work_actor.rb'
     - 'app/actors/hyrax/actors/apply_order_actor.rb'
     - 'app/controllers/concerns/hyrax/api.rb'
     - 'app/controllers/concerns/hyrax/controller.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,7 +49,6 @@ Metrics/ModuleLength:
 
 Metrics/MethodLength:
   Exclude:
-    - 'app/actors/hyrax/actors/apply_order_actor.rb'
     - 'app/controllers/concerns/hyrax/api.rb'
     - 'app/controllers/concerns/hyrax/controller.rb'
     - 'app/controllers/concerns/hyrax/curation_concern_controller.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -57,7 +57,6 @@ Metrics/MethodLength:
     - 'app/inputs/multi_value_select_input.rb'
     - 'app/models/concerns/hyrax/solr_document/export.rb'
     - 'app/services/hyrax/workflow/permission_query.rb'
-    - 'lib/generators/hyrax/templates/migrations/create_local_authorities.rb'
     - 'lib/generators/hyrax/install_generator.rb'
     - 'lib/hyrax/rails/routes.rb'
     - 'spec/support/**/*'
@@ -75,11 +74,6 @@ Rails/Output:
   Exclude:
     - 'lib/generators/**/*'
 
-Rails/HasAndBelongsToMany:
-  Exclude:
-    - 'app/models/domain_term.rb'
-    - 'app/models/local_authority.rb'
-
 RSpec/NamedSubject:
   Enabled: false
 
@@ -88,7 +82,6 @@ RSpec/ExampleLength:
   Exclude:
     - 'spec/actors/hyrax/actors/file_set_actor_spec.rb'
     - 'spec/actors/hyrax/actors/generic_work_actor_spec.rb'
-    - 'spec/controllers/authorities_controller_spec.rb'
     - 'spec/controllers/hyrax/api/items_controller_spec.rb'
     - 'spec/controllers/hyrax/batch_uploads_controller_spec.rb'
     - 'spec/controllers/hyrax/collections_controller_spec.rb'

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -192,6 +192,7 @@ module Hyrax
     # @!attribute [w] dashboard_configuration
     #   Configuration for dashboard rendering.
     attr_writer :dashboard_configuration
+    # rubocop:disable Metrics/MethodLength
     def dashboard_configuration
       @dashboard_configuration ||= {
         menu: {
@@ -223,6 +224,7 @@ module Hyrax
         }
       }
     end
+    # rubocop:enable Metrics/MethodLength
 
     callback.enable :after_create_concern, :after_create_fileset,
                     :after_update_content, :after_revert_content,


### PR DESCRIPTION
## Removing Rubocop violation through extract method

@1e4ccc71ae40e787dea187f34b051e2ae528650a


## Removing Rubocop violation through extract method

@c18ae88217a18279f378b04912b83f6ad96269a2

Note there is duplication between this change and changes to
`Hyrax::Actors::AddToWorkActor`

## Narrowing scope of rubocop exclusion

@a9735672e3474f3583c33269983c60da4d06459c

Targeting the specific method that is in violation.

## Removing an exclusion for a non-existent file

@801e498f08510d0e313ddedbe07cb6e63941c38c

Using the following script, found several files that were not
referenced.

```ruby
require 'psych'
yaml = Psych.load_file('./.rubocop.yml')

def read(node)
  if node.is_a?(Hash)
    node.each_pair do |key, value|
      read(value)
    end
  elsif node.is_a?(Array)
    node.each do |value|
      read(value)
    end
  elsif node.is_a?(String)
    return unless node =~ /.rb\Z/
    return if node =~ /\*/
    return if File.exist?(node)
    puts node
  end
end
read(yaml)
```

@projecthydra-labs/hyrax-code-reviewers
