### PR TITLE
Further cleaning violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,10 +26,6 @@ Metrics/AbcSize:
 Metrics/MethodLength:
   Max: 15
 
-Style/SymbolProc: # https://github.com/bbatsov/rubocop/issues/3071
-  Exclude:
-    - 'app/models/hyrax/uploaded_file.rb'
-
 Style/IndentationConsistency:
   EnforcedStyle: rails
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,12 +105,7 @@ RSpec/DescribeClass:
 #   Prefer have_received for setting message expectations. Setup form as a spy using allow or instance_spy.
 # The default assumes EnforcedStyle is 'have_received'. Most of our specs are 'receive'
 RSpec/MessageSpies:
-  Enabled: true
-  EnforcedStyle: receive
-  Exclude:
-    - 'spec/controllers/hyrax/api/zotero_controller_spec.rb'
-    - 'spec/controllers/hyrax/generic_works_controller_spec.rb'
-    - 'spec/services/hyrax/workflow/workflow_importer_spec.rb'
+  Enabled: false
 
 RSpec/InstanceVariable:
   Exclude:
@@ -132,7 +127,4 @@ RSpec/NestedGroups:
   Enabled: false
 
 RSpec/LeadingSubject:
-  Enabled: false
-
-RSpec/MessageSpies:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,10 +37,6 @@ Style/CollectionMethods:
     detect: 'find'
     find_all: 'select'
 
-Style/CommentIndentation:
-  Exclude:
-    - 'app/actors/hyrax/actors/add_to_work_actor.rb'
-
 Style/MethodMissing:
   Exclude:
     - 'app/models/concerns/hyrax/file_set/characterization.rb'

--- a/app/models/hyrax/uploaded_file.rb
+++ b/app/models/hyrax/uploaded_file.rb
@@ -6,8 +6,6 @@ module Hyrax
     mount_uploader :file, UploadedFileUploader
     belongs_to :user, class_name: '::User'
 
-    before_destroy do |obj|
-      obj.remove_file!
-    end
+    before_destroy :remove_file!
   end
 end


### PR DESCRIPTION
## Removing rubocop violation

@132cbc391d01a6b858dcdc06f55df747dbc4a720

In removing the violation, I'm also exposing a method that can be
overridden or extended in a downstream implementation.

## Removing exclusion that no longer applies

@b8c1aa9504f873c358f301ba4aa9e7152ea1b9dc


## Removing duplicate Rubocop key

@32dae1a1a4485357e82d5ccdd2b82517d1a4fd4d

With the key being declared twice, the last declaration was overriding
the initial declaration. So I'm taking the later declaration and moving
it up.

@projecthydra-labs/hyrax-code-reviewers
