### PR TITLE
Decreasing abc acceptable size

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,7 @@ Metrics/LineLength:
   Max: 200
 
 Metrics/AbcSize:
-  Max: 29
+  Max: 28
 
 Metrics/MethodLength:
   Max: 15

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,7 @@ Metrics/LineLength:
   Max: 200
 
 Metrics/AbcSize:
-  Max: 30
+  Max: 29
 
 Metrics/MethodLength:
   Max: 15

--- a/app/forms/hyrax/forms/permission_template_form.rb
+++ b/app/forms/hyrax/forms/permission_template_form.rb
@@ -196,6 +196,7 @@ module Hyrax
         # @param [Hash] attributes
         # @return [String, Nil] the error code if invalid, nil if valid
         # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/PerceivedComplexity
         def validate_visibility_combinations(attributes)
           return unless attributes.key?(:visibility) # only the visibility tab has validations
@@ -217,6 +218,7 @@ module Hyrax
         end
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/app/services/hyrax/workflow/state_machine_generator.rb
+++ b/app/services/hyrax/workflow/state_machine_generator.rb
@@ -31,69 +31,72 @@ module Hyrax
 
       def call
         create_workflow_action!
+        build_workflow_attributes
+        build_strategy_state_entries
+        build_transition_to_state
+        build_email_generator
+        build_action_methods
+      end
 
-        if config.key?(:attributes)
-          build_attributes(config.fetch(:attributes).stringify_keys)
+      private
+
+        def build_workflow_attributes
+          return unless config.key?(:attributes)
+          action_attributes = config.fetch(:attributes).stringify_keys
+          action_attributes.delete('presentation_sequence') # TODO: remove this line when we want to support presentation_sequence
+          existing_action_attributes = action.attributes.slice(*action_attributes.keys)
+          return if action_attributes == existing_action_attributes
+          action.update_attributes!(action_attributes)
         end
 
-        # Strategy State
-        config.fetch(:from_states, []).each do |entry|
-          build_from_state(entry.fetch(:names), entry.fetch(:roles))
+        def build_transition_to_state
+          return unless config.key?(:transition_to)
+          name = config.fetch(:transition_to).to_s
+          transition_to_state = Sipity::WorkflowState.find_or_create_by!(workflow: workflow, name: name)
+          return if action.resulting_workflow_state == transition_to_state
+          action.resulting_workflow_state = transition_to_state
+          action.save!
         end
 
-        # Transitions
-        if config.key?(:transition_to)
-          build_transitions(config.fetch(:transition_to).to_s)
+        def build_strategy_state_entries
+          config.fetch(:from_states, []).each do |entry|
+            build_from_state(entry.fetch(:names), entry.fetch(:roles))
+          end
         end
 
-        send(email_generator_method_name, workflow: workflow, config: config)
-
-        # Methods
-        return unless config.key?(:methods)
-        build_methods(Array.wrap(config.fetch(:methods)))
-      end
-
-      def build_attributes(action_attributes)
-        action_attributes.delete('presentation_sequence') # TODO: remove this line when we want to support presentation_sequence
-        existing_action_attributes = action.attributes.slice(*action_attributes.keys)
-        return if action_attributes == existing_action_attributes
-        action.update_attributes!(action_attributes)
-      end
-
-      def build_transitions(name)
-        transition_to_state = Sipity::WorkflowState.find_or_create_by!(workflow: workflow, name: name)
-        return if action.resulting_workflow_state == transition_to_state
-        action.resulting_workflow_state = transition_to_state
-        action.save!
-      end
-
-      # @param [Array] state_names
-      # @param [Array] state_roles
-      def build_from_state(state_names, state_roles)
-        Array.wrap(state_names).each do |state_name|
-          workflow_state = Sipity::WorkflowState.find_or_create_by!(workflow: workflow, name: state_name.to_s)
-          PermissionGenerator.call(
-            actors: [],
-            roles: state_roles,
-            workflow_state: workflow_state,
-            action_names: action_name,
-            workflow: workflow
-          )
+        # @param [Array] state_names
+        # @param [Array] state_roles
+        def build_from_state(state_names, state_roles)
+          Array.wrap(state_names).each do |state_name|
+            workflow_state = Sipity::WorkflowState.find_or_create_by!(workflow: workflow, name: state_name.to_s)
+            PermissionGenerator.call(
+              actors: [],
+              roles: state_roles,
+              workflow_state: workflow_state,
+              action_names: action_name,
+              workflow: workflow
+            )
+          end
         end
-      end
 
-      def build_methods(method_list)
-        MethodGenerator.call(action: action, list: method_list)
-      end
-
-      def schema_based_email_generator_method(workflow:, config:)
-        Array.wrap(config.fetch(:notifications, [])).each do |configuration|
-          notification_configuration = NotificationConfigurationParameter.build_from_workflow_action_configuration(
-            workflow_action: action_name, config: configuration
-          )
-          NotificationGenerator.call(workflow: workflow, notification_configuration: notification_configuration)
+        def build_action_methods
+          return unless config.key?(:methods)
+          method_list = Array.wrap(config.fetch(:methods))
+          MethodGenerator.call(action: action, list: method_list)
         end
-      end
+
+        def build_email_generator
+          send(email_generator_method_name, workflow: workflow, config: config)
+        end
+
+        def schema_based_email_generator_method(workflow:, config:)
+          Array.wrap(config.fetch(:notifications, [])).each do |configuration|
+            notification_configuration = NotificationConfigurationParameter.build_from_workflow_action_configuration(
+              workflow_action: action_name, config: configuration
+            )
+            NotificationGenerator.call(workflow: workflow, notification_configuration: notification_configuration)
+          end
+        end
     end
   end
 end


### PR DESCRIPTION
## Reducing complexity of object

@0be7babc9a38586c93f63e1c5ecd83c20ff61b7f

Reducing the threshold for ABC complexity to 29. This involved tidying
up the StateMachineGenerator by extracting methods (and renaming).

## Tweaking Rubocop's ABC Size to 28

@f6db0c3aa4cae7f577736940438cba87e673ad62

This involves one exception as it is a rather complicated bit of logic
for a complicated multi-tier form.

@projecthydra-labs/hyrax-code-reviewers
