### PR TITLE
Read-only autocomplete inputs for controlled vocabs

### DIFF
--- a/app/assets/javascripts/hyrax/app.js
+++ b/app/assets/javascripts/hyrax/app.js
@@ -52,7 +52,9 @@ Hyrax = {
 	});
         $('.multi_value.form-group').manage_fields({
           add: function(e, element) {
-            autocomplete.fieldAdded(element)
+              autocomplete.fieldAdded(element);
+	      // Don't mark an added element as readonly even if previous element was
+	      $(element).attr('readonly',false);
           }
         });
         autocomplete.setup();
@@ -60,7 +62,7 @@ Hyrax = {
 
     saveWorkControl: function () {
         var SaveWorkControl = require('hyrax/save_work/save_work_control');
-        var control = new SaveWorkControl($("#form-progress"))
+        var control = new SaveWorkControl($("#form-progress"));
     },
 
     saveWorkFixed: function () {
@@ -110,13 +112,13 @@ Hyrax = {
     selectWorkType: function () {
         var SelectWorkType = require('hyrax/select_work_type');
         $("[data-behavior=select-work]").each(function () {
-            new SelectWorkType($(this))
+            new SelectWorkType($(this));
         });
     },
 
     fileManager: function () {
         var FileManager = require('hyrax/file_manager');
-        new FileManager()
+        new FileManager();
     },
 
     // Saved so that inline javascript can put data somewhere.

--- a/app/assets/javascripts/hyrax/autocomplete/default.es6
+++ b/app/assets/javascripts/hyrax/autocomplete/default.es6
@@ -1,9 +1,9 @@
 export default class Default {
   constructor(element, url) {
     this.url = url;
-    element.autocomplete(this.options());
+    element.autocomplete(this.options(element));
   }
-  options() {
+  options(element) {
     return {
       minLength: 2,
       source: (request, response) => {
@@ -17,7 +17,13 @@ export default class Default {
       },
       complete: function(event) {
         $('.ui-autocomplete-loading').removeClass("ui-autocomplete-loading");
+      },
+      select: function() {
+	  if (element.data('autocomplete-read-only') === true) {
+           element.attr('readonly', true);
+	}
       }
+	
     };
   }
 }


### PR DESCRIPTION
This allows you to mark an autocomplete field as read only in a view.

If you are using a controlled vocabulary for autocomplete you may not want users changing 
the vocab term after selection. If you put a `data-autocomplete-read-only` attribute on your input in the field partial this behavior will be turned on. 

Example input field:
```erb
<%=
  f.input key,
  as: :multi_value,
  input_html: {
  class: 'form-control',
  data: { 'autocomplete-url' => "/authorities/search/loc/names",
'autocomplete' => key, 'autocomplete-read-only' => 'true' }
} ,
required: f.object.required?(key) %>
```

So after selecting your term it's added to the input field and marked as read only:

![screenshot from 2017-03-17 12-13-36](https://cloud.githubusercontent.com/assets/4324761/24052260/3ef46be4-0b0b-11e7-8b41-2a6077be1bb7.png)

If you want to change you remove it and pick another term. 

@projecthydra-labs/hyrax-code-reviewers
