### PR TITLE
Add JS to allow switching of vocab on input field

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -82,6 +82,7 @@
 //= require hyrax/file_manager/member
 //= require hyrax/file_manager
 //= require hyrax/workflow_actions_affix
+//= require hyrax/authority_select
 
 // this needs to be after batch_select so that the form ids get setup correctly
 //= require hyrax/batch_edit

--- a/app/assets/javascripts/hyrax/app.js
+++ b/app/assets/javascripts/hyrax/app.js
@@ -119,6 +119,12 @@ Hyrax = {
         new FileManager()
     },
 
+    authoritySelect: function(options) {
+	var AuthoritySelect = require('hyrax/authority_select');
+	var authoritySelect = new AuthoritySelect(options);
+	authoritySelect.initialize();
+    },
+
     // Saved so that inline javascript can put data somewhere.
     statistics: {}
 

--- a/app/assets/javascripts/hyrax/authority_select.es6
+++ b/app/assets/javascripts/hyrax/authority_select.es6
@@ -1,0 +1,75 @@
+/** Class for authority selection on an input field */
+export default class AuthoritySelect {
+    /**
+     * Create an AuthoritySelect
+     * @param {string} selectBox - The selector for the select box
+     * @param {string} inputField - The selector for the input field
+     */
+    constructor(options) {
+	this.selectBox = options.selectBox;
+	this.inputField = options.inputField;
+    }
+
+    /**
+     * Bind behavior for select box
+     */
+    selectBoxChange() {
+	var selectBox = this.selectBox;
+	var inputField = this.inputField;
+	
+	$(selectBox).on('change', function (data) {
+	    var selectBoxValue = $(this).val();
+	    $(inputField).each(function (data) { $(this).data('autocomplete-url', selectBoxValue);
+						 
+					       });
+	    setupAutocomplete();
+	});
+    }
+    /**
+     * Create an observer to watch for added input elements
+     */
+    observeAddedElement() {
+	var selectBox = this.selectBox;
+	var inputField = this.inputField;
+	
+	
+	var observer = new MutationObserver(function (mutations) {
+	    mutations.forEach(function (mutation) {
+		$(inputField).each(function (data) { $(this).data('autocomplete-url', $(selectBox).val()) });
+		setupAutocomplete();
+	    });
+	});
+
+	var config = { childList: true };
+	observer.observe(document.body, config);
+    }
+
+    
+
+    /**
+     * Initialize bindings
+     */
+    initialize() {
+	this.selectBoxChange();
+	this.observeAddedElement();
+	setupAutocomplete();
+    }
+}
+
+/**
+ * intialize the Hyrax autocomplete with the fields that you are using
+ */
+function setupAutocomplete() {
+    var Autocomplete = require('hyrax/autocomplete');
+    var autocomplete = new Autocomplete({
+	"autocompleteFields":
+	["creator","contributor"]
+    });
+
+    $('.multi_value.form-group').manage_fields({
+        add: function(e, element) {
+	    autocomplete.fieldAdded(element);
+        }
+    });
+    autocomplete.setup();
+};


### PR DESCRIPTION
This adds behavior to a select box to allow switching the autocomplete source. 

In your view you can do this: 
```erb
<% name_authorities = Hyrax::NameAuthorities.new %>

<%=
  f.input key,
  as: :multi_value,
  input_html: {
  class: 'form-control',
  data: { 'autocomplete-url' => "/authorities/search/loc/names",
'autocomplete' => key }
} ,
required: f.object.required?(key) %>

<%= f.input key, collection: name_authorities.select_active_options, prompt: "Authority/Vocabulary", label: false %>
```
You'll get a dropdown in your form with the authorities specified by the NameAuthorities service:
![screenshot from 2017-03-17 12-59-16](https://cloud.githubusercontent.com/assets/4324761/24054193/bff20110-0b11-11e7-93bf-332a42700402.png)

To activate it add this JS to your Hyrax app: 

```javascript
Blacklight.onLoad( function() {
	Hyrax.authoritySelect({ selectBox : "select#work_creator", inputField : "input.work_creator" });
});
```

The dropdown could be generated another way, but a class inheriting from `QASelectService` can be used to generate the select options from a YAML file. 

@projecthydra-labs/hyrax-code-reviewers
