### PR TITLE
Styling and layout improvements to Admin UI

### DIFF
--- a/app/assets/stylesheets/hyrax/admin.scss
+++ b/app/assets/stylesheets/hyrax/admin.scss
@@ -7,6 +7,7 @@ $tab-active-accent-color: $brand-primary !default;
 $admin-sidebar-background-color: #686868 !default;
 $admin-sidebar-link-color: #ffffff !default;
 $admin-sidebar-link-hover-color: #000000 !default;
+$admin-sidebar-link-background-color: #505050 !default;
 $admin-content-background-color: #f0f0f0 !default;
 $admin-vertical-padding: 10px !default;
 
@@ -99,6 +100,31 @@ fieldset {
   a:hover {
     color: $admin-sidebar-link-hover-color;
   }
+}
+
+.admin-sidebar {
+  margin-left: 0;
+  margin-right: 0;
+
+  li .fa {
+    margin-right: $padding-base-horizontal;
+  }
+}
+
+.nav-pills > li > a {
+  border-radius: 0;
+  padding: 15px 10px 15px 15px;
+
+  &:focus {
+    background-color: transparent;
+    color: $admin-sidebar-link-color;
+  }
+}
+
+.nav-pills > li.active > a,
+.nav-pills > li.active > a:focus,
+.nav-pills > li.active > a:hover {
+  background-color: $admin-sidebar-link-background-color;
 }
 
 .navbar {

--- a/app/assets/stylesheets/hyrax/admin.scss
+++ b/app/assets/stylesheets/hyrax/admin.scss
@@ -2,8 +2,9 @@
 @import 'bootstrap/variables';
 $tab-margin: 44px !default;
 $title-text-color: #4e4a42 !default;
+$body-background-color: #f0f0f0 !default;
 $tab-active-accent-color: $brand-primary !default;
-$admin-sidebar-background-color: #808080 !default;
+$admin-sidebar-background-color: #686868 !default;
 $admin-sidebar-link-color: #ffffff !default;
 $admin-sidebar-link-hover-color: #000000 !default;
 $admin-content-background-color: #f0f0f0 !default;
@@ -30,8 +31,27 @@ $admin-vertical-padding: 10px !default;
   border-top: 2px solid $tab-active-accent-color;
 }
 
+/* The #masthead selector below could (and ideally, should) be removed if we can
+ * replace the "navbar-static-top" class with "navbar-fixed-top" for the Admin UI only
+ */
+#masthead {
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+
+  @media only screen and (max-width : 767px) {
+    position: initial;
+  }
+}
+
 body {
-  background-color: $admin-sidebar-background-color;
+  background-color: $body-background-color;
+  padding-top: 51px;
+
+  @media only screen and (max-width : 767px) {
+    padding-top: 0;
+  }
 }
 
 /* This is needed in Chrome for the admin/admin_sets edit view to render the participants tab
@@ -44,6 +64,11 @@ fieldset {
 
 #content-wrapper {
   padding-bottom: 0;
+
+  &.container-fluid {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 .main-content {
@@ -53,8 +78,19 @@ fieldset {
 }
 
 .sidebar {
+  background-color: $admin-sidebar-background-color;
+  bottom: 0;
+  left: 0;
   padding-bottom: $admin-vertical-padding;
+  padding-left: 0;
+  padding-right: 0;
   padding-top: $admin-vertical-padding;
+  position: fixed;
+  top: 51px;
+
+  @media only screen and (max-width : 767px) {
+    position: initial;
+  }
 
   a {
     color: $admin-sidebar-link-color;

--- a/app/assets/stylesheets/hyrax/admin.scss
+++ b/app/assets/stylesheets/hyrax/admin.scss
@@ -78,6 +78,22 @@ fieldset {
   background-color: $admin-content-background-color;
 }
 
+.main-header {
+  margin-bottom: 0;
+  margin-top: 0;
+
+  h1 {
+    font-size: $font-size-h2;
+    margin-left: $padding-xs-horizontal;
+    margin-top: $padding-base-vertical;
+  }
+
+  .fa {
+    color: $gray;
+    margin-right: $padding-xs-horizontal;
+  }
+}
+
 .sidebar {
   background-color: $admin-sidebar-background-color;
   bottom: 0;


### PR DESCRIPTION
This PR addresses some layout and visual appearance issues with the current Admin UI. 

Although all changes are confined to the `admin.scss` file and thus I assume should not impact any existing implementations based on Hyrax, I'm not familiar enough with Hyrax and how it's being used to be sure, so reviewers of this PR should definitely consider the implications of the updates. 

The most significant change is making the position of the top bar and sidebar fixed. This only affects the Admin UI; the top bar outside of the Admin UI is not affected. Note that things don't look so good at viewports below 768px, but that is also the case currently; I don't think the updates in this PR made anything worse at the smaller viewports.

I can make further styling improvements to the Hyku version of the sidebar after this PR is merged.

@projecthydra-labs/hyrax-code-reviewers

The issues addressed are:

1. Excessive margin between page headers and the breadcrumbs
2. Styling issues with links in the sidebar
3. The fact that the sidebar does not extend to the footer of the page, which makes the sidebar less distinct and doesn't follow the common layout pattern of sidebars, where the sidebar column is a distinct column vertically.

See the before and after screenshots below for visual reference to the points above.

### Before
![before](https://cloud.githubusercontent.com/assets/101482/24056893/9562c7b8-0b02-11e7-9a54-b32ec99341aa.jpg)

### After
![after](https://cloud.githubusercontent.com/assets/101482/24056898/98c50ec0-0b02-11e7-8fd8-03150db887f3.png)

