### PR TITLE
Show non-approved status works

### DIFF
--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -15,7 +15,7 @@ module Hyrax
     self.single_item_search_builder_class = Hyrax::SingleAdminSetSearchBuilder
 
     # Used to get the members for the show action
-    self.member_search_builder_class = Hyrax::AdminSetMemberSearchBuilder
+    self.member_search_builder_class = Hyrax::AdminAdminSetMemberSearchBuilder
 
     # Used to get a list of admin sets for the index action
     self.list_search_builder_class = Hyrax::AdminSetSearchBuilder
@@ -28,7 +28,7 @@ module Hyrax
       add_breadcrumb t(:'hyrax.controls.home'), root_path
       add_breadcrumb t(:'hyrax.toolbar.admin.menu'), hyrax.admin_path
       add_breadcrumb t(:'hyrax.admin.sidebar.admin_sets'), hyrax.admin_admin_sets_path
-      add_breadcrumb 'View Set', request.path
+      add_breadcrumb t(:'hyrax.admin.admin_sets.show.breadcrumb'), request.path
       super
     end
 

--- a/app/search_builders/hyrax/admin_admin_set_member_search_builder.rb
+++ b/app/search_builders/hyrax/admin_admin_set_member_search_builder.rb
@@ -1,0 +1,14 @@
+module Hyrax
+  # Builds a query to find the members of an admin set.
+  # For use on the admin menu, so it includes works regardless of status.
+  class AdminAdminSetMemberSearchBuilder < ::SearchBuilder
+    self.default_processor_chain += [:in_admin_set]
+    self.default_processor_chain -= [:only_active_works]
+
+    # include filters into the query to only include the admin_set members (regardless of status)
+    def in_admin_set(solr_parameters)
+      solr_parameters[:fq] ||= []
+      solr_parameters[:fq] << "{!term f=isPartOf_ssim}#{blacklight_params.fetch('id')}"
+    end
+  end
+end

--- a/app/views/hyrax/admin/admin_sets/_show_document_list.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_show_document_list.html.erb
@@ -1,0 +1,16 @@
+<table class="table table-striped">
+  <caption class="sr-only">List of items in this administrative set</caption>
+  <thead>
+  <tr>
+    <th>&nbsp;</th>
+    <th>Title</th>
+    <th>Date Uploaded</th>
+    <th>Visibility</th>
+    <th>Status</th>
+    <th>Action</th>
+  </tr>
+  </thead>
+  <tbody>
+    <%= render partial: 'show_document_list_row', collection: documents %>
+  </tbody>
+</table>

--- a/app/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb
@@ -1,0 +1,51 @@
+<% document = show_document_list_row %>
+<% id = document.id %>
+<tr id="document_<%= id %>">
+  <td>&nbsp;
+    <% if current_user and document.depositor != current_user.user_key %>
+      <i class="glyphicon glyphicon-share-alt"/>
+    <% end %>
+  </td>
+  <td>
+    <div class="media">
+      <%= link_to [main_app, document], class: "media-left" do %>
+        <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
+      <% end %>
+      <div class="media-body">
+        <h4 class="media-heading">
+          <%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %>
+          <a href="#" class="small" title="Click for more details"><i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right"></i></a>
+        </h4>
+        <%= render_collection_links(document) %>
+      </div>
+    </div>
+  </td>
+  <td class="text-center"><%= document.date_uploaded %> </td>
+  <td class="text-center">
+    <%= render_visibility_link(document) %>
+  </td>
+  <td class="text-center">
+    <%= document.workflow_state %>
+  </td>
+  <td class="text-center">
+    <%= render 'show_document_list_menu', document: document %>
+  </td>
+</tr>
+<tr id="detail_<%= id %>"> <!--  document detail"> -->
+  <td colspan="6">
+    <dl class="expanded-details row">
+      <dt class="col-xs-3 col-lg-2">Creator:</dt>
+      <dd class="col-xs-9 col-lg-4"><%= document.creator.to_a.to_sentence %></dd>
+      <dt class="col-xs-3 col-lg-2">Depositor:</dt>
+      <dd class="col-xs-9 col-lg-4"><%= link_to_profile document.depositor %></dd>
+      <dt class="col-xs-3 col-lg-2">Edit Access:</dt>
+      <dd class="col-xs-9 col-lg-10">
+        <% if document.edit_groups.present? %>
+          Groups: <%= document.edit_groups.join(', ') %>
+          <br/>
+        <% end %>
+        Users: <%= document.edit_people.join(', ') %>
+      </dd>
+    </dl>
+  </td>
+</tr>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -44,6 +44,10 @@ en:
     active_consent_to_agreement:  "I have read and agree to the"
     admin:
       admin_sets:
+        document_list:
+          edit:     "Edit"
+          no_works: "The administrative set does not contain any works."
+          title:    "List of items in this administrative set"
         delete:
           error_default_set: "Administrative set cannot be deleted as it is the default set"
           error_not_empty:   "Administrative set cannot be deleted as it is not empty"
@@ -130,6 +134,7 @@ en:
         new:
           header:         "Create New Administrative Set"
         show:
+          breadcrumb:       "View Set"
           confirm_delete:   "Are you sure you wish to delete this Administrative Set? This action cannot be undone."
           header:           "Administrative Set"
           item_list_header: "Works in This Set"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -44,6 +44,9 @@ es:
     active_consent_to_agreement:  "He leído y estoy de acuerdo con"
     admin:
       admin_sets:
+        document_list:
+          edit: "Editar"
+          no_works: "El conjunto administrativo está vacío."
         delete:
           error_default_set: "El conjunto administrativo no se puede eliminar ya que es el conjunto predeterminado"
           error_not_empty:   "El conjunto administrativo no se puede eliminar ya que no está vacío"
@@ -130,6 +133,7 @@ es:
         new:
           header:         "Crear nuevo conjunto Administrativo"
         show:
+          breadcrumb:       "Ver Conjunto"
           confirm_delete:   "¿Está seguro de que desea eliminar este conjunto administrativo? Esta acción no se puede deshacer."
           header:           "Conjunto Administrativo"
           item_list_header: "Trabajos en este conjunto"

--- a/spec/search_builders/hyrax/admin_admin_set_member_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/admin_admin_set_member_search_builder_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe Hyrax::AdminAdminSetMemberSearchBuilder do
+  let(:context) do
+    double(blacklight_config: CatalogController.blacklight_config,
+           current_ability: ability)
+  end
+  let(:user_groups) { [] }
+  let(:ability) do
+    instance_double(Ability,
+                    admin?: true,
+                    user_groups: user_groups,
+                    current_user: user)
+  end
+  let(:user) { create(:user) }
+  let(:builder) { described_class.new(context, access) }
+
+  describe '#filter_models' do
+    before do
+      # This prevents any generated classes from interfering with this test:
+      allow(builder).to receive(:work_classes).and_return([GenericWork])
+      builder.filter_models(solr_params)
+    end
+    let(:access) { :read }
+    let(:solr_params) { { fq: [] } }
+
+    it 'searches for valid work types' do
+      expect(solr_params[:fq].first).to include('{!terms f=has_model_ssim}GenericWork,Collection')
+    end
+    it 'does not limit to active only' do
+      expect(solr_params[:fq].first).not_to include('-suppressed_bsi:true')
+    end
+  end
+
+  describe ".default_processor_chain" do
+    subject { described_class.default_processor_chain }
+    it { is_expected.to include :in_admin_set }
+    it { is_expected.not_to include :only_active_works }
+  end
+end

--- a/spec/views/hyrax/admin/admin_sets/_show_document_list.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/_show_document_list.html.erb_spec.rb
@@ -1,0 +1,27 @@
+
+describe 'hyrax/admin/admin_sets/_show_document_list.html.erb', type: :view do
+  let(:user) { create(:user, groups: 'admin') }
+
+  let(:work) do
+    GenericWork.create(creator: ["ggm"], title: ['One Hundred Years of Solitude']) do |gw|
+      gw.apply_depositor_metadata(user)
+    end
+  end
+
+  let(:documents) { [work] }
+
+  before do
+    view.blacklight_config = Blacklight::Configuration.new
+    allow(view).to receive(:current_user).and_return(user)
+    allow(work).to receive(:title_or_label).and_return("One Hundred Years of Solitude")
+    allow(work).to receive(:edit_groups).and_return([user])
+    allow(work).to receive(:edit_people).and_return([user])
+    allow(work).to receive(:workflow_state).and_return('deposited')
+    stub_template '_show_document_list_menu.erb' => ''
+  end
+
+  it "renders rows of works" do
+    render('hyrax/admin/admin_sets/show_document_list.html.erb', documents: documents)
+    expect(rendered).to have_content 'One Hundred Years of Solitude'
+  end
+end

--- a/spec/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb_spec.rb
@@ -1,0 +1,26 @@
+
+describe 'hyrax/admin/admin_sets/_show_document_list_row.html.erb', type: :view do
+  let(:user) { create(:user, groups: 'admin') }
+
+  let(:work) do
+    GenericWork.create(creator: ["ggm"], title: ['One Hundred Years of Solitude']) do |gw|
+      gw.apply_depositor_metadata(user)
+    end
+  end
+
+  before do
+    view.blacklight_config = Blacklight::Configuration.new
+    allow(view).to receive(:current_user).and_return(user)
+    allow(work).to receive(:title_or_label).and_return("One Hundred Years of Solitude")
+    allow(work).to receive(:edit_groups).and_return([user])
+    allow(work).to receive(:edit_people).and_return([user])
+    allow(work).to receive(:workflow_state).and_return('deposited')
+    stub_template '_show_document_list_menu.erb' => 'edit menu'
+  end
+
+  it "renders works" do
+    render 'hyrax/admin/admin_sets/show_document_list_row.html.erb', show_document_list_row: work
+    expect(rendered).to have_content 'One Hundred Years of Solitude'
+    expect(rendered).to have_content 'deposited'
+  end
+end


### PR DESCRIPTION
[WIP] 

The issue is to show all statuses of works on the admin/admin_set menu (which only admin can see), and add a column to the document list to show the column.

References https://github.com/projecthydra-labs/hyku/issues/726

@projecthydra-labs/hyrax-code-reviewers
