### PR TITLE
Extracting method to encapsulate where / pluck

### DIFF
--- a/app/actors/hyrax/apply_permission_template_actor.rb
+++ b/app/actors/hyrax/apply_permission_template_actor.rb
@@ -12,10 +12,10 @@ module Hyrax
       def add_edit_users(attributes)
         return unless attributes[:admin_set_id].present?
         template = Hyrax::PermissionTemplate.find_by!(admin_set_id: attributes[:admin_set_id])
-        curation_concern.edit_users += template.access_grants.where(agent_type: 'user', access: 'manage').pluck(:agent_id)
-        curation_concern.edit_groups += template.access_grants.where(agent_type: 'group', access: 'manage').pluck(:agent_id)
-        curation_concern.read_users += template.access_grants.where(agent_type: 'user', access: 'view').pluck(:agent_id)
-        curation_concern.read_groups += template.access_grants.where(agent_type: 'group', access: 'view').pluck(:agent_id)
+        curation_concern.edit_users += template.agent_ids_for(agent_type: 'user', access: 'manage')
+        curation_concern.edit_groups += template.agent_ids_for(agent_type: 'group', access: 'manage')
+        curation_concern.read_users += template.agent_ids_for(agent_type: 'user', access: 'view')
+        curation_concern.read_groups += template.agent_ids_for(agent_type: 'group', access: 'view')
       end
   end
 end

--- a/app/models/concerns/hyrax/admin_set_behavior.rb
+++ b/app/models/concerns/hyrax/admin_set_behavior.rb
@@ -86,8 +86,8 @@ module Hyrax
     # Calculate and update who should have edit access based on who
     # has "manage" access in the PermissionTemplateAccess
     def update_access_controls!
-      update!(edit_users: permission_template.access_grants.where(access: 'manage', agent_type: 'user').pluck(:agent_id),
-              edit_groups: permission_template.access_grants.where(access: 'manage', agent_type: 'group').pluck(:agent_id))
+      update!(edit_users: permission_template.agent_ids_for(access: 'manage', agent_type: 'user'),
+              edit_groups: permission_template.agent_ids_for(access: 'manage', agent_type: 'group'))
     end
 
     private

--- a/app/models/hyrax/permission_template.rb
+++ b/app/models/hyrax/permission_template.rb
@@ -13,6 +13,15 @@ module Hyrax
     has_many :access_grants, class_name: 'Hyrax::PermissionTemplateAccess', dependent: :destroy
     accepts_nested_attributes_for :access_grants, reject_if: :all_blank
 
+    # @api public
+    # Retrieve the agent_ids associated with the given agent_type and access
+    # @param [String] agent_type
+    # @param [String] access
+    # @return [Array<String>] of agent_ids that match the given parameters
+    def agent_ids_for(agent_type:, access:)
+      access_grants.where(agent_type: agent_type, access: access).pluck(:agent_id)
+    end
+
     # The list of workflows that could be activated; It includes the active workflow
     has_many :available_workflows, class_name: 'Sipity::Workflow', dependent: :destroy, foreign_key: :permission_template_id
 

--- a/spec/models/hyrax/permission_template_spec.rb
+++ b/spec/models/hyrax/permission_template_spec.rb
@@ -39,6 +39,17 @@ describe Hyrax::PermissionTemplate do
     end
   end
 
+  describe '#agent_ids_for' do
+    it 'queries the underlying access_grants' do
+      template = create(:permission_template)
+      to_find = template.access_grants.create!(agent_type: 'user', access: 'manage', agent_id: '123')
+      template.access_grants.create!(agent_type: 'user', access: 'read', agent_id: '456')
+      template.access_grants.create!(agent_type: 'group', access: 'manage', agent_id: '789')
+
+      expect(template.agent_ids_for(agent_type: 'user', access: 'manage')).to eq([to_find.agent_id])
+    end
+  end
+
   describe "#admin_set" do
     it 'leverages AdminSet.find for the given permission_template' do
       expect(AdminSet).to receive(:find).with(permission_template.admin_set_id).and_return(admin_set)


### PR DESCRIPTION
There was a lot of external knowledge regarding the structure of the
permission template. Instead, encapsulate that knowledge in a method
on the permission template.

Related to #584

@projecthydra-labs/hyrax-code-reviewers
