### PR TITLE
Update styling of select work type modal

### DIFF
--- a/app/assets/stylesheets/hyrax/_select_work_type.scss
+++ b/app/assets/stylesheets/hyrax/_select_work_type.scss
@@ -1,10 +1,21 @@
+.worktypes {
+  .modal-body {
+    padding: 0;
+  }
+
+  .modal-title {
+    font-size: $font-size-h3;
+  }
+}
+
 .select-worktype:first-child {
   border-top: none;
 }
+
 .select-worktype {
   border-top: 1px solid $table-border-color;
-  padding: 10px;
-  
+  padding: 15px 15px 0;
+
   label {
     margin: 0;
     width: 100%;
@@ -13,31 +24,37 @@
   input[type="radio"] {
     float: left;
     position: relative;
-    width: 10%;
+    width: 30px;
   }
 
   .select-work-icon {
+    color: $gray;
     float: left;
-    font-size: 400%;
+    font-size: 200%;
     line-height: 1;
+    margin-right: 10px;
     position: relative;
     text-align: center;
-    width: 20%;
+    width: 40px;
 
     .fa {
       vertical-align: top
     }
   }
+
   .select-work-description {
     float: left;
+    font-weight: normal;
     position: relative;
-    width: 70%;
-  }
+    width: 80%;
 
-  h3 {
-    margin-top: 0;
+    .work-type-title {
+      font-size: $font-size-h4;
+      margin-top: 0;
+    }
   }
 }
+
 .new-work-select {
   clear: both;
 }

--- a/app/views/shared/_select_work_type_modal.html.erb
+++ b/app/views/shared/_select_work_type_modal.html.erb
@@ -1,9 +1,9 @@
-<div class="modal fade" id="worktypes-to-create" tabindex="-1" role="dialog" aria-labelledby="select-worktype-label">
+<div class="modal worktypes fade" id="worktypes-to-create" tabindex="-1" role="dialog" aria-labelledby="select-worktype-label">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('hyrax.dashboard.heading_actions.close') %>"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="select-worktype-label"><%= t('hyrax.dashboard.heading_actions.select_type_of_work') %></h4>
+        <h2 class="modal-title" id="select-worktype-label"><%= t('hyrax.dashboard.heading_actions.select_type_of_work') %></h2>
       </div>
       <form class="new-work-select">
         <div class="modal-body">
@@ -17,7 +17,7 @@
                   <span class="<%= row_presenter.icon_class %>"></span>
                 </div>
                 <div class="select-work-description">
-                  <h3><%= row_presenter.name %></h3>
+                  <h3 class="work-type-title"><%= row_presenter.name %></h3>
                   <p><%= row_presenter.description %></p>
                 </div>
               </label>


### PR DESCRIPTION
This PR is a minor update to the styling of the select work type modal. The updates change the heading levels so that they will read more sensibly in a screen reader (the work types choices are now lower-level headings than the modal title, rather than vice versa), and otherwise mostly just reduces font sizes a bit so the modal will better support larger number of available work types and/or longer work type descriptions.

I also did some styling in preparation for highlighting the selected work type div but got confused because I don't see a checked attribute added to the input of the selected work type. Maybe we can come back to that sometime but it's not crucial for improving the visual appearance or UX of the modal (as long as we leave the radio buttons visible).

### Before
![before](https://cloud.githubusercontent.com/assets/101482/24064874/5f09f7dc-0b24-11e7-973e-0f5172b079a0.png)

### After
![after](https://cloud.githubusercontent.com/assets/101482/24064879/63955f80-0b24-11e7-9e39-29ecc6518930.png)

 
@projecthydra-labs/hyrax-code-reviewers
