### PR TITLE
Adding constants

### DIFF
--- a/app/models/proxy_deposit_request.rb
+++ b/app/models/proxy_deposit_request.rb
@@ -43,16 +43,26 @@ class ProxyDepositRequest < ActiveRecord::Base
 
   def send_request_transfer_message
     if updated_at == created_at
+      send_request_transfer_message_as_part_of_create
+    else
+      send_request_transfer_message_as_part_of_update
+    end
+  end
+
+  private
+
+    def send_request_transfer_message_as_part_of_create
       user_link = link_to(sending_user.name, Hyrax::Engine.routes.url_helpers.profile_path(sending_user.user_key))
       transfer_link = link_to('transfer requests', Hyrax::Engine.routes.url_helpers.transfers_path)
       message = "#{user_link} wants to transfer a work to you. Review all #{transfer_link}"
       User.batch_user.send_message(receiving_user, message, "Ownership Change Request")
-    else
+    end
+
+    def send_request_transfer_message_as_part_of_update
       message = "Your transfer request was #{status}."
       message += " Comments: #{receiver_comment}" unless receiver_comment.blank?
       User.batch_user.send_message(sending_user, message, "Ownership Change #{status}")
     end
-  end
 
   def pending?
     status == 'pending'

--- a/app/models/proxy_deposit_request.rb
+++ b/app/models/proxy_deposit_request.rb
@@ -15,11 +15,17 @@ class ProxyDepositRequest < ActiveRecord::Base
 
   after_save :send_request_transfer_message
 
-  attr_reader :transfer_to
+  # @param [String] user_key - The key of the user that will receive the transfer
+  # @note The HTML form for creating a ProxyDepositRequest requires this method
+  def transfer_to=(user_key)
+    self.receiving_user = User.find_by_user_key(user_key)
+  end
 
-  def transfer_to=(key)
-    @transfer_to = key
-    self.receiving_user = User.find_by_user_key(key)
+  # @return [nil, String] nil if we don't have a receiving user, otherwise it returns the receiving_user's user_key
+  # @note The HTML form for creating a ProxyDepositRequest requires this method
+  # @see User#user_key
+  def transfer_to
+    receiving_user.try(:user_key)
   end
 
   def transfer_to_should_be_a_valid_username


### PR DESCRIPTION
## Reworking ProxyDepositRequest#transfer_to=

@ca104a651b8ce4297ffc634d76606a4bae1a28ef

Instead of relying setting an instance variable, instead prefer the more
direct method. This commit also includes documentation about the methods
usage as well as expectations.

## Extracting methods to reduce complexity

@b39c45885186d3a2173726c3615edca7f962761e


## Extracting ProxyDepositRequest constants and enum

@ebb16743fc414f23408325cff71838574dd29a6e

* Leveraging the enum to enforce the valid states for a
  ProxyDepositRequest.
* Creating constants to remove "magic strings"
* Extracting a `#fulfill!` method to encapsulate the common logic
* Adding spec to verify that we are persisting strings in the database
  for the enum values

@projecthydra-labs/hyrax-code-reviewers
