### PR TITLE
Adding enumeration to Hyrax::Operation#status

### DIFF
--- a/app/models/hyrax/operation.rb
+++ b/app/models/hyrax/operation.rb
@@ -6,6 +6,15 @@ module Hyrax
     FAILURE = 'failure'.freeze
     SUCCESS = 'success'.freeze
 
+    enum(
+      status: {
+        FAILURE => FAILURE,
+        PENDING => PENDING,
+        PERFORMING => PERFORMING,
+        SUCCESS => SUCCESS
+      }
+    )
+
     self.table_name = 'curation_concerns_operations'
     acts_as_nested_set
     define_callbacks :success, :failure

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -13,7 +13,7 @@ describe ImportUrlJob do
     end
   end
 
-  let(:log) { create(:operation) }
+  let(:operation) { create(:operation) }
   let(:success_service) { instance_double(Hyrax::ImportUrlSuccessService) }
   let(:actor) { instance_double(Hyrax::Actors::FileSetActor, create_content: true) }
 
@@ -32,11 +32,11 @@ describe ImportUrlJob do
       allow(file_set).to receive(:reload)
     end
 
-    it 'creates the content' do
+    it 'creates the content and updates the associated operation' do
       expect(success_service).to receive(:call)
       expect(actor).to receive(:create_content).with(Tempfile, 'original_file', false).and_return(true)
-      described_class.perform_now(file_set, log)
-      expect(log.status).to eq 'success'
+      described_class.perform_now(file_set, operation)
+      expect(operation).to be_success
     end
   end
 
@@ -58,7 +58,7 @@ describe ImportUrlJob do
       expect(success_service).to receive(:call)
 
       # run the import job
-      described_class.perform_now(file_set, log)
+      described_class.perform_now(file_set, operation)
 
       # import job should not override the title set another process
       file = FileSet.find(file_set_id)

--- a/spec/models/hyrax/operation_spec.rb
+++ b/spec/models/hyrax/operation_spec.rb
@@ -1,6 +1,19 @@
 require 'spec_helper'
 
 describe Hyrax::Operation do
+  context '#status' do
+    it 'is protected by enum enforcement' do
+      expect { described_class.new(status: 'not_valid') }.to raise_error(ArgumentError)
+    end
+
+    # Because the Rails documentation says "Declare an enum attribute where the values map to integers in the database, but can be queried by name." but appears to not be the case.
+    it 'is persisted as a string' do
+      create(:operation, :pending)
+      values = described_class.connection.execute("SELECT * FROM #{described_class.quoted_table_name}")
+      expect(values.first.fetch('status')).to eq(described_class::PENDING)
+    end
+  end
+
   describe "#rollup_status" do
     let(:parent) { create(:operation, :pending) }
     describe "with a pending process" do


### PR DESCRIPTION
The `enum` declaration ensures that we only set valid states. It also
exposes methods related to the status (e.g. success?, pending?) which
can be useful upstream.

@projecthydra-labs/hyrax-code-reviewers
