### PR TITLE
Adding code to ensure workflows can be reloaded

### DIFF
--- a/app/services/hyrax/workflow/sipity_actions_generator.rb
+++ b/app/services/hyrax/workflow/sipity_actions_generator.rb
@@ -60,7 +60,7 @@ module Hyrax
         end
 
         def validate_states_to_be_removed
-          new_state_names = actions_configuration.map { |a| a[:transition_to] }.flatten
+          new_state_names = extract_new_state_names
           states_to_remove = []
           states_that_cannot_be_destroyed = []
           workflow.workflow_states.each do |state|
@@ -73,6 +73,14 @@ module Hyrax
             raise InvalidStateRemovalException.new(exception_message, states_that_cannot_be_destroyed)
           end
           states_to_remove
+        end
+
+        # @note Not all states are things that we tansition_to; They can be transitioned from_states as well.
+        def extract_new_state_names
+          (
+            actions_configuration.map { |a| a.fetch(:transition_to, nil) } +
+            actions_configuration.map { |a| a.fetch(:from_states, []).map { |fs| fs.fetch(:names, nil) } }
+          ).flatten.compact.uniq
         end
 
         def remove_unused_actions!

--- a/spec/services/hyrax/workflow/sipity_actions_generator_spec.rb
+++ b/spec/services/hyrax/workflow/sipity_actions_generator_spec.rb
@@ -10,13 +10,25 @@ module Hyrax
             name: "start_a_submission", transition_to: "new", emails: [
               { name: "confirmation_of_ulra_submission_started", to: "creating_user" }
             ]
-          }, { name: ["start", "potpie"] }
+          }, {
+            name: "submit", transition_to: "done", from_states: [{ names: ["new"], roles: ["submitting"] }]
+          }
         ]
       end
 
-      it 'exposes .call as a convenience method' do
-        expect_any_instance_of(described_class).to receive(:call)
-        described_class.call(workflow: workflow, actions_configuration: actions_configuration)
+      let(:new_actions_configuration) do
+        [
+          {
+            name: "submit", transition_to: "done", from_states: [{ names: ["new"], roles: ["submitting"] }]
+          }
+        ]
+      end
+
+      context '.call' do
+        it 'is a convenience method' do
+          expect_any_instance_of(described_class).to receive(:call)
+          described_class.call(workflow: workflow, actions_configuration: actions_configuration)
+        end
       end
 
       subject { described_class.new(workflow: workflow, actions_configuration: actions_configuration) }


### PR DESCRIPTION
As reported by @treypendragon, when Princeton went to reload a workflow,
having just added methods, it encounter issues in new workflow states
being created and breaking the Sipity::Entity relationship

I believe this addresses the major problem, by ensuring that we don't
delete both the states that we transition_to as well as the states
that we are transitioning from.

@projecthydra-labs/hyrax-code-reviewers
