### PR TITLE
Return a json response to show a FileSet

### DIFF
--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -27,7 +27,7 @@ module Hyrax
     delegate :title, :label, :description, :creator, :contributor, :subject,
              :publisher, :language, :date_uploaded, :rights,
              :embargo_release_date, :lease_expiration_date,
-             :depositor, :keyword, :title_or_label, :depositor, :keyword,
+             :depositor, :keyword, :title_or_label, :keyword,
              :date_created, :date_modified, :itemtype,
              to: :solr_document
 

--- a/app/views/hyrax/file_sets/show.json.jbuilder
+++ b/app/views/hyrax/file_sets/show.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! @presenter, :id, :title, :label, :creator, :date_uploaded,
+              :depositor, :date_modified

--- a/spec/views/hyrax/file_sets/show.json.jbuilder_spec.rb
+++ b/spec/views/hyrax/file_sets/show.json.jbuilder_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe 'hyrax/file_sets/show.json.jbuilder' do
+  let(:presenter) do
+    instance_double(Hyrax::FileSetPresenter,
+                    id: '123',
+                    title: ['title'],
+                    label: '',
+                    creator: ['Janet'],
+                    depositor: '',
+                    date_uploaded: '',
+                    date_modified: '')
+  end
+
+  before do
+    assign(:presenter, presenter)
+    render
+  end
+
+  it "renders json of the curation_concern" do
+    json = JSON.parse(rendered)
+    expect(json['id']).to eq presenter.id
+    expect(json['title']).to match_array presenter.title
+    expected_fields = [:title, :label, :creator, :depositor, :date_uploaded, :date_modified]
+    expected_fields.each do |field_symbol|
+      expect(json).to have_key(field_symbol.to_s)
+    end
+  end
+end


### PR DESCRIPTION
Add a JSON view for a FileSet show

Prior to this it was attempting to use
app/view/hyrax/base/show.json.jbuilder which was failing.

Fixes projecthydra-labs/hyku#870
Fixes projecthydra-labs/hyku#874
@projecthydra-labs/hyrax-code-reviewers
