### PR TITLE
Extracting methods for ProxyDepositRequest

### DIFF
--- a/app/controllers/concerns/hyrax/dashboard_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/dashboard_controller_behavior.rb
@@ -28,12 +28,13 @@ module Hyrax
       # Gathers all the information that we'll display in the user's dashboard.
       # Override this method if you want to exclude or gather additional data elements
       # in your dashboard view.  You'll need to alter dashboard/index.html.erb accordingly.
+      # @todo Consolidate these 5 instance variables into a presenter object for the Dashboard
       def gather_dashboard_information
         @user = current_user
         @activity = current_user.all_user_activity(params[:since].blank? ? DateTime.current.to_i - Hyrax.config.activity_to_show_default_seconds_since_now : params[:since].to_i)
         @notifications = current_user.mailbox.inbox
-        @incoming = ProxyDepositRequest.where(receiving_user_id: current_user.id).reject(&:deleted_work?)
-        @outgoing = ProxyDepositRequest.where(sending_user_id: current_user.id)
+        @incoming = ProxyDepositRequest.incoming_for(user: current_user)
+        @outgoing = ProxyDepositRequest.outgoing_for(user: current_user)
       end
 
       # Formats the user's activities into human-readable strings used for rendering JSON

--- a/app/controllers/concerns/hyrax/transfers_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/transfers_controller_behavior.rb
@@ -32,9 +32,10 @@ module Hyrax
       end
     end
 
+    # @todo Consolidate the incoming/outgoing instance variables into a TransfersIndexPresenter; We should aim to set one instance variable per controller action
     def index
-      @incoming = ProxyDepositRequest.where(receiving_user_id: current_user.id).reject(&:deleted_work?)
-      @outgoing = ProxyDepositRequest.where(sending_user_id: current_user.id)
+      @incoming = ProxyDepositRequest.incoming_for(user: current_user)
+      @outgoing = ProxyDepositRequest.outgoing_for(user: current_user)
     end
 
     # Kicks of a job that completes the transfer. If params[:reset] is set, it will revoke

--- a/app/services/hyrax/work_query_service.rb
+++ b/app/services/hyrax/work_query_service.rb
@@ -1,0 +1,58 @@
+module Hyrax
+  # Responsible for retrieving information based on the given work.
+  #
+  # @see ProxyDepositRequest
+  # @see Hyrax::WorkRelation
+  # @see SolrDocument
+  # @see ActiveFedora::SolrService
+  # @see ActiveFedora::SolrQueryBuilder
+  # @note This was extracted from the ProxyDepositRequest, which was coordinating lots of effort. It was also an ActiveRecord object that required lots of Fedora/Solr interactions.
+  class WorkQueryService
+    # @param [String] id - The id of the work
+    # @param [#exists?, #find] work_relation - How we will query some of the related information
+    def initialize(id:, work_relation: default_work_relation)
+      @id = id
+      @work_relation = work_relation
+    end
+    attr_reader :id, :work_relation
+
+    private
+
+      def default_work_relation
+        Hyrax::WorkRelation.new
+      end
+
+    public
+
+    # @return [Boolean] if the work has been deleted
+    def deleted_work?
+      !work_relation.exists?(id)
+    end
+
+    def work
+      @work ||= work_relation.find(id)
+    end
+
+    def to_s
+      if deleted_work?
+        'work not found'
+      else
+        solr_doc.to_s
+      end
+    end
+
+    private
+
+      def solr_doc
+        @solr_doc ||= ::SolrDocument.new(solr_response['response']['docs'].first, solr_response)
+      end
+
+      def solr_response
+        @solr_response ||= ActiveFedora::SolrService.get(query)
+      end
+
+      def query
+        ActiveFedora::SolrQueryBuilder.construct_query_for_ids([id])
+      end
+  end
+end

--- a/spec/services/hyrax/work_query_service_spec.rb
+++ b/spec/services/hyrax/work_query_service_spec.rb
@@ -1,0 +1,50 @@
+module Hyrax
+  RSpec.describe WorkQueryService do
+    let(:user) { create(:user) }
+    let(:work_id) { 'abc' }
+    let(:work_relation) { double('Work Relation') }
+    let(:work_query_service) { described_class.new(id: work_id, work_relation: work_relation) }
+
+    describe '#default_work_relation' do
+      subject { work_query_service.send(:default_work_relation) }
+      it { is_expected.to respond_to(:find).with(1).arguments }
+      it { is_expected.to respond_to(:exists?).with(1).arguments }
+    end
+
+    describe '#deleted_work?' do
+      subject { work_query_service.deleted_work? }
+      context 'when not in SOLR' do
+        before { allow(work_relation).to receive(:exists?).with(work_id).and_return(false) }
+        it { is_expected.to be_truthy }
+      end
+      context 'when in SOLR' do
+        before { allow(work_relation).to receive(:exists?).with(work_id).and_return(true) }
+        it { is_expected.to be_falsey }
+      end
+    end
+    describe '#work' do
+      let(:expected_work) { double('Work') }
+      subject { work_query_service.work }
+      context 'when not in SOLR' do
+        before { allow(work_relation).to receive(:find).with(work_id).and_return(expected_work) }
+        it { is_expected.to eq(expected_work) }
+      end
+    end
+    describe '#to_s' do
+      subject { work_query_service.to_s }
+      context 'when the work is deleted' do
+        before { allow(work_relation).to receive(:exists?).with(work_id).and_return(false) }
+        it { is_expected.to eq('work not found') }
+      end
+
+      context 'when the work is not deleted' do
+        # NOTE: This is testing the full behavior of finding
+        let!(:work_query_service) { described_class.new(id: work.id) }
+        let!(:work) { GenericWork.create(title: ["Test work"]) }
+        it 'will retrieve the SOLR document and use the #to_s method of that' do
+          expect(subject).to eq(work.title.first)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This involves:

* Removing duplication of logic that spanned controllers. Instead push
that logic into a model. In an effort to ease the testing (just a bit),
injected a new query service.

The ActiveRecord model was requiring Fedora and SOLR to be up and
running. As a result this the work_query_service_spec was rather slow
for simple state changes.

In refactoring, I consolidated multiple `its` specs into single it
blocks. This is to bring a bit of speed back to the tests, each its
was performing two ActiveRecord updates. Now the it block performs
the two updates and we check the resulting data.

The refactor improves the individual spec time from 9.x seconds to 1.x
seconds.

Before this commit:

```console
$ rspec /Users/jfriesen/git/hyrax/spec/models/proxy_deposit_request_spec.rb

Top 10 slowest examples (5.74 seconds, 59.5% of total time):
  ProxyDepositRequest should be pending
    1.46 seconds ./spec/models/proxy_deposit_request_spec.rb:17
  ProxyDepositRequest After approval and the work is deleted to_s should eq "work not found"
    0.59047 seconds ./spec/models/proxy_deposit_request_spec.rb:69
  ProxyDepositRequest After approval and the work is deleted deleted_work? should equal true
    0.53268 seconds ./spec/models/proxy_deposit_request_spec.rb:70
  ProxyDepositRequest After approval deleted_work? should equal false
    0.50073 seconds ./spec/models/proxy_deposit_request_spec.rb:62
  ProxyDepositRequest After approval and the work transfer is canceled fulfillment_date should not be nil
    0.47824 seconds ./spec/models/proxy_deposit_request_spec.rb:79
  ProxyDepositRequest After approval and the work transfer is canceled canceled? should equal true
    0.46745 seconds ./spec/models/proxy_deposit_request_spec.rb:80
  ProxyDepositRequest After approval status should eq "accepted"
    0.46482 seconds ./spec/models/proxy_deposit_request_spec.rb:60
  ProxyDepositRequest After approval and the work transfer is canceled status should eq "canceled"
    0.46466 seconds ./spec/models/proxy_deposit_request_spec.rb:78
  ProxyDepositRequest After approval fulfillment_date should not be nil
    0.45107 seconds ./spec/models/proxy_deposit_request_spec.rb:61
  ProxyDepositRequest#status is persisted as a string
    0.3344 seconds ./spec/models/proxy_deposit_request_spec.rb:48

Finished in 9.65 seconds (files took 6.03 seconds to load)
```

After this commit:

```console
$ rspec /Users/jfriesen/git/hyrax/spec/models/proxy_deposit_request_spec.rb

Top 10 slowest examples (0.80964 seconds, 59.9% of total time):
  ProxyDepositRequest should delegate #deleted_work? to #work_query_service object
    0.14159 seconds ./spec/models/proxy_deposit_request_spec.rb:32
  ProxyDepositRequest#status is persisted as a string
    0.12206 seconds ./spec/models/proxy_deposit_request_spec.rb:65
  ProxyDepositRequest.incoming_for returns non-deleted requests for the receiving_user
    0.10165 seconds ./spec/models/proxy_deposit_request_spec.rb:36
  ProxyDepositRequest transfer when the work is already being transferred raises an error
    0.0816 seconds ./spec/models/proxy_deposit_request_spec.rb:131
  ProxyDepositRequest.outgoing_for returns only requests for the sending_user
    0.07472 seconds ./spec/models/proxy_deposit_request_spec.rb:52
  ProxyDepositRequest transfer when the work is already being transferred when the first transfer is closed does not raise an error
    0.06758 seconds ./spec/models/proxy_deposit_request_spec.rb:142
  ProxyDepositRequest#transfer! will change the status, fulfillment_date, and perform later the ContentDepositorChangeEventJob
    0.05973 seconds ./spec/models/proxy_deposit_request_spec.rb:73
  ProxyDepositRequest transfer when the transfer_to user is found creates a transfer_request
    0.05964 seconds ./spec/models/proxy_deposit_request_spec.rb:111
  ProxyDepositRequest#reject! will change the status, fulfillment_date, and receiver comment
    0.05142 seconds ./spec/models/proxy_deposit_request_spec.rb:92
  ProxyDepositRequest#cancel! will change the status, fulfillment_date
    0.04965 seconds ./spec/models/proxy_deposit_request_spec.rb:83

Finished in 1.35 seconds (files took 5.82 seconds to load)
```

@projecthydra-labs/hyrax-code-reviewers
