### PR TITLE
Remove hard coded autocomplete fields

### DIFF
--- a/app/assets/javascripts/hyrax/app.js
+++ b/app/assets/javascripts/hyrax/app.js
@@ -43,19 +43,21 @@ Hyrax = {
     },
 
     autocomplete: function () {
-        var Autocomplete = require('hyrax/autocomplete');
-        var autocomplete = new Autocomplete({
-	    "autocompleteFields":
-	    ["subject","language","creator","based_near","work"]
-	});
+        var Autocomplete = require('hyrax/autocomplete')
+        var autocomplete = new Autocomplete()
+
+        $('[data-autocomplete]').each((function() {
+          var data = $(this).data()
+          autocomplete.setup({'element' : $(this), 'data': data})
+        }))
+
         $('.multi_value.form-group').manage_fields({
           add: function(e, element) {
-              autocomplete.fieldAdded(element);
+              autocomplete.setup({'element':$(element), 'data':$(element).data()})
 	      // Don't mark an added element as readonly even if previous element was
-	      $(element).attr('readonly',false);
+	      $(element).attr('readonly', false)
           }
-        });
-        autocomplete.setup();
+        })
     },
 
     editor: function () {

--- a/app/assets/javascripts/hyrax/authority_select.es6
+++ b/app/assets/javascripts/hyrax/authority_select.es6
@@ -44,8 +44,6 @@ export default class AuthoritySelect {
 	observer.observe(document.body, config);
     }
 
-    
-
     /**
      * Initialize bindings
      */
@@ -60,16 +58,5 @@ export default class AuthoritySelect {
  * intialize the Hyrax autocomplete with the fields that you are using
  */
 function setupAutocomplete() {
-    var Autocomplete = require('hyrax/autocomplete');
-    var autocomplete = new Autocomplete({
-	"autocompleteFields":
-	["creator","contributor"]
-    });
-
-    $('.multi_value.form-group').manage_fields({
-        add: function(e, element) {
-	    autocomplete.fieldAdded(element);
-        }
-    });
-    autocomplete.setup();
+  Hyrax.autocomplete()
 };

--- a/app/assets/javascripts/hyrax/autocomplete.es6
+++ b/app/assets/javascripts/hyrax/autocomplete.es6
@@ -1,44 +1,24 @@
-import Default from './autocomplete/default';
-import Work from './autocomplete/work';
+import Default from './autocomplete/default'
+import Work from './autocomplete/work'
 
 export default class Autocomplete {
-    constructor(options) {
-	this.autocompleteFields = options.autocompleteFields;
+  // This is the initial setup for the form.
+  setup (options) {
+    var data = options.data
+    var element = options.element
+    switch (data.autocomplete) {
+      case 'work':
+        new Work(
+          element,
+          data.autocompleteUrl,
+          data.user,
+          data.id
+        )
+        break
+      default:
+        new Default(element, data.autocompleteUrl)
+        break
     }
-    // This is the initial setup for the form.
-    setup() {
-	$('[data-autocomplete]').each((index, value) => {
-            let selector = $(value);
-	    let autocompleteData = selector.data('autocomplete');
-	    this.activateFields(autocompleteData,selector);
-	});
-    }
-    // This activates autocomplete for added fields
-    fieldAdded(cloneElem) {
-	let selector = $(cloneElem);
-	let autocompleteData = selector.data('autocomplete');
-	this.activateFields(autocompleteData,selector);
-    }
-    autocomplete(field) {
-	let fieldName = field.data('autocomplete');
-	switch (fieldName) {
-	case "work":
-	    new Work(
-              field,
-              field.data('autocomplete-url'),
-              field.data('exclude-work')
-	    );
-	    break;
-	default:
-	    new Default(field, field.data('autocomplete-url'));
-	    break;
-	}
-    }
-    activateFields(autocompleteData, selector) {
-	for (let field in this.autocompleteFields) {
-	    if (autocompleteData === this.autocompleteFields[field]) {
-		this.autocomplete(selector);
-	    }
-	}
-    }
+  }
 }
+


### PR DESCRIPTION
Right now, there are hard coded arrays in the JS that are used for activating autocomplete fields. 
This removes them in favor of activating all the fields that have a `data-autocomplete-url` attribute on them. 

If a person wants to add autocomplete to a new field in Hyray they would need to initialize the Autocomplete class and pass it an array of the fields they want to be activated. This removes that step.

@projecthydra-labs/hyrax-code-reviewers
