### PR TITLE
Move microdata out of translation files. Fixes #536

### DIFF
--- a/app/presenters/hyrax/presents_attributes.rb
+++ b/app/presenters/hyrax/presents_attributes.rb
@@ -34,7 +34,7 @@ module Hyrax
 
     def microdata_type_to_html
       return "" unless display_microdata?
-      value = I18n.t(microdata_type_key, default: Hyrax.config.microdata_default_type)
+      value = Microdata.fetch(microdata_type_key, default: Hyrax.config.microdata_default_type)
       " itemscope itemtype=\"#{value}\"".html_safe
     end
 
@@ -64,7 +64,7 @@ module Hyrax
       end
 
       def microdata_type_key
-        "hyrax.schema_org.resource_type.#{human_readable_type}"
+        "resource_type.#{human_readable_type}"
       end
   end
 end

--- a/app/renderers/hyrax/renderers/configured_microdata.rb
+++ b/app/renderers/hyrax/renderers/configured_microdata.rb
@@ -1,8 +1,6 @@
 module Hyrax
   module Renderers
     module ConfiguredMicrodata
-      PREFIX = 'hyrax.schema_org'.freeze
-
       def microdata?(field)
         return false unless Hyrax.config.display_microdata?
         translate_microdata(field: field, field_context: 'property', default: false)
@@ -41,7 +39,7 @@ module Hyrax
       private
 
         def translate_microdata(field:, field_context:, default: true)
-          t("#{PREFIX}.#{field}.#{field_context}", default: default)
+          Microdata.fetch("#{field}.#{field_context}", default: default)
         end
     end
   end

--- a/app/services/hyrax/microdata.rb
+++ b/app/services/hyrax/microdata.rb
@@ -1,0 +1,66 @@
+module Hyrax
+  class Microdata
+    include Singleton
+    FILENAME = 'config/schema_org.yml'.freeze
+    TOP_KEY = 'schema_org'.freeze
+
+    def self.fetch(key, options = {})
+      instance.fetch(key, options)
+    end
+
+    def fetch(key, options)
+      data.fetch(key) { options[:default] }
+    end
+
+    # Allow clients to register paths providing config data sources.
+    # Register a config files like this:
+    #   Microdata.load_path << 'path/to/locale/en.yml'
+    def self.load_path
+      @load_path ||= [FILENAME]
+    end
+
+    # Sets the load path instance.
+    class << self
+      attr_writer :load_path
+    end
+
+    def self.reload!
+      instance.reload!
+    end
+
+    def reload!
+      @data = nil
+    end
+
+    private
+
+      def data
+        @data ||= begin
+          flatten(yaml)
+        end
+      end
+
+      def yaml
+        yaml = {}
+        self.class.load_path.each do |path|
+          from_file = YAML.safe_load(File.open(path))[TOP_KEY]
+          yaml.deep_merge!(from_file) if from_file
+        end
+        yaml
+      end
+
+      # Given a deeply nested hash, return a single hash
+      def flatten(hash)
+        hash.each_with_object({}) do |(key, value), h|
+          if value.instance_of?(Hash)
+            value.map do |k, v|
+              # We could add recursion here if we ever had more than 2 levels
+              h["#{key}.#{k}"] = v
+            end
+          else
+            h[key] = value
+          end
+        end
+      end
+  end
+end

--- a/app/services/hyrax/resource_types_service.rb
+++ b/app/services/hyrax/resource_types_service.rb
@@ -16,8 +16,7 @@ module Hyrax
     # @param [String] id identifier of the resource type
     def self.microdata_type(id)
       return Hyrax.config.microdata_default_type if id.nil?
-      I18n.t("#{Hyrax::Renderers::ConfiguredMicrodata::PREFIX}.resource_type.#{id}",
-             default: Hyrax.config.microdata_default_type)
+      Microdata.fetch("resource_type.#{id}", default: Hyrax.config.microdata_default_type)
     end
   end
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -482,52 +482,6 @@ en:
         subject: "Batch upload complete"
         title:  "Files uploaded successfully"
     passive_consent_to_agreement: "By saving this work I agree to the"
-    schema_org:
-      based_near:
-        property: contentLocation
-        type: "http://schema.org/Place"
-        value: name
-      contributor:
-        property: contributor
-        # used as the itemprop value for itemscoped attributes
-        type: "http://schema.org/Person"
-        value: name
-      creator:
-        property: creator
-        type: "http://schema.org/Person"
-        value: name
-      date_created:
-        property: dateCreated
-      description:
-        property: description
-      keyword:
-        property: keywords
-      language:
-        property: inLanguage
-      publisher:
-        property: publisher
-        type: "http://schema.org/Organization"
-        value: name
-      resource_type:
-        Article: "http://schema.org/Article"
-        Audio: "http://schema.org/AudioObject"
-        Book: "http://schema.org/Book"
-        Conference Proceeding: "http://schema.org/ScholarlyArticle"
-        Dataset: "http://schema.org/Dataset"
-        Dissertation: "http://schema.org/ScholarlyArticle"
-        Image: "http://schema.org/ImageObject"
-        Map or Cartographic Material: "http://schema.org/Map"
-        Masters Thesis: "http://schema.org/ScholarlyArticle"
-        Part of Book: "http://schema.org/Book"
-        Research Paper: "http://schema.org/ScholarlyArticle"
-        Software or Program Code: "http://schema.org/Code"
-        Video: "http://schema.org/VideoObject"
-      subject:
-        property: about
-        type: "http://schema.org/Thing"
-        value: name
-      title:
-        property: name
     search:
       button:
         html: '<span class="glyphicon glyphicon-search"></span> Go'

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -482,52 +482,6 @@ es:
         subject: "Carga en lote completa"
         title:  "Archivos cargados satisfactoriamente"
     passive_consent_to_agreement: "Al salvar este trabajo yo acepto a"
-    schema_org:
-      based_near:
-        property: contentLocation
-        type: "http://schema.org/Place"
-        value: name
-      contributor:
-        property: contributor
-        # used as the itemprop value for itemscoped attributes
-        type: "http://schema.org/Person"
-        value: name
-      creator:
-        property: creator
-        type: "http://schema.org/Person"
-        value: name
-      date_created:
-        property: dateCreated
-      description:
-        property: description
-      keyword:
-        property: keywords
-      language:
-        property: inLanguage
-      publisher:
-        property: publisher
-        type: "http://schema.org/Organization"
-        value: name
-      resource_type:
-        Article: "http://schema.org/Article"
-        Audio: "http://schema.org/AudioObject"
-        Book: "http://schema.org/Book"
-        Conference Proceeding: "http://schema.org/ScholarlyArticle"
-        Dataset: "http://schema.org/Dataset"
-        Dissertation: "http://schema.org/ScholarlyArticle"
-        Image: "http://schema.org/ImageObject"
-        Map or Cartographic Material: "http://schema.org/Map"
-        Masters Thesis: "http://schema.org/ScholarlyArticle"
-        Part of Book: "http://schema.org/Book"
-        Research Paper: "http://schema.org/ScholarlyArticle"
-        Software or Program Code: "http://schema.org/Code"
-        Video: "http://schema.org/VideoObject"
-      subject:
-        property: about
-        type: "http://schema.org/Thing"
-        value: name
-      title:
-        property: name
     search:
       button:
         html: '<span class="glyphicon glyphicon-search"></span> Ir'

--- a/config/schema_org.yml
+++ b/config/schema_org.yml
@@ -1,0 +1,46 @@
+schema_org:
+  based_near:
+    property: contentLocation
+    type: "http://schema.org/Place"
+    value: name
+  contributor:
+    property: contributor
+    # used as the itemprop value for itemscoped attributes
+    type: "http://schema.org/Person"
+    value: name
+  creator:
+    property: creator
+    type: "http://schema.org/Person"
+    value: name
+  date_created:
+    property: dateCreated
+  description:
+    property: description
+  keyword:
+    property: keywords
+  language:
+    property: inLanguage
+  publisher:
+    property: publisher
+    type: "http://schema.org/Organization"
+    value: name
+  resource_type:
+    Article: "http://schema.org/Article"
+    Audio: "http://schema.org/AudioObject"
+    Book: "http://schema.org/Book"
+    Conference Proceeding: "http://schema.org/ScholarlyArticle"
+    Dataset: "http://schema.org/Dataset"
+    Dissertation: "http://schema.org/ScholarlyArticle"
+    Image: "http://schema.org/ImageObject"
+    Map or Cartographic Material: "http://schema.org/Map"
+    Masters Thesis: "http://schema.org/ScholarlyArticle"
+    Part of Book: "http://schema.org/Book"
+    Research Paper: "http://schema.org/ScholarlyArticle"
+    Software or Program Code: "http://schema.org/Code"
+    Video: "http://schema.org/VideoObject"
+  subject:
+    property: about
+    type: "http://schema.org/Thing"
+    value: name
+  title:
+    property: name

--- a/spec/fixtures/config/schema_org.yml
+++ b/spec/fixtures/config/schema_org.yml
@@ -1,0 +1,5 @@
+schema_org:
+  name:
+    type: "http://schema.org/Person"
+    property: name
+    value: firstName

--- a/spec/fixtures/config/schema_org.yml
+++ b/spec/fixtures/config/schema_org.yml
@@ -3,3 +3,5 @@ schema_org:
     type: "http://schema.org/Person"
     property: name
     value: firstName
+  first_only:
+    value: iAmTheFirstOnly

--- a/spec/fixtures/config/schema_org_second.yml
+++ b/spec/fixtures/config/schema_org_second.yml
@@ -1,0 +1,7 @@
+schema_org:
+  name:
+    type: "http://schema.org/SecondaryPerson"
+    property: secondName
+    value: secondFirstName
+  second_only:
+    value: iAmTheSecondOnly

--- a/spec/fixtures/locales/renderer.en.yml
+++ b/spec/fixtures/locales/renderer.en.yml
@@ -1,7 +1,0 @@
-en:
-  hyrax:
-    schema_org:
-      name:
-        type: "http://schema.org/Person"
-        property: name
-        value: firstName

--- a/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 describe Hyrax::Renderers::AttributeRenderer do
   let(:field) { :name }
   let(:renderer) { described_class.new(field, ['Bob', 'Jessica']) }
-  let(:yml_path) { File.join(fixture_path, 'locales', '*.{rb,yml}') }
+  let(:yml_path) { File.join(fixture_path, 'config', 'schema_org.{yml}') }
   before do
-    I18n.load_path += Dir[yml_path]
-    I18n.reload!
+    Hyrax::Microdata.load_path += Dir[yml_path]
+    Hyrax::Microdata.reload!
   end
   after do
-    I18n.load_path -= Dir[yml_path]
-    I18n.reload!
+    Hyrax::Microdata.load_path -= Dir[yml_path]
+    Hyrax::Microdata.reload!
   end
 
   describe "#attribute_to_html" do

--- a/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
@@ -5,11 +5,11 @@ describe Hyrax::Renderers::AttributeRenderer do
   let(:renderer) { described_class.new(field, ['Bob', 'Jessica']) }
   let(:yml_path) { File.join(fixture_path, 'config', 'schema_org.{yml}') }
   before do
-    Hyrax::Microdata.load_path += Dir[yml_path]
+    Hyrax::Microdata.load_paths += Dir[yml_path]
     Hyrax::Microdata.reload!
   end
   after do
-    Hyrax::Microdata.load_path -= Dir[yml_path]
+    Hyrax::Microdata.load_paths -= Dir[yml_path]
     Hyrax::Microdata.reload!
   end
 

--- a/spec/services/hyrax/microdata_spec.rb
+++ b/spec/services/hyrax/microdata_spec.rb
@@ -1,0 +1,87 @@
+module Hyrax
+  RSpec.describe Microdata do
+    let(:yml_path) { File.join(fixture_path, 'config', 'schema_org.yml') }
+    let(:yml_path_secondary) { File.join(fixture_path, 'config', 'schema_org_second.yml') }
+    before do
+      described_class.load_paths = yml_path
+      described_class.reload!
+    end
+
+    after do
+      # Need to reset as this is an instance variable
+      described_class.instance_variable_set("@load_paths", nil)
+    end
+
+    describe '.load_paths' do
+      subject { described_class.load_paths }
+      it { is_expected.to be_a(Array) }
+      it 'can be appended to' do
+        expect { subject << yml_path_secondary }.to change { described_class.load_paths.size }.by(1)
+      end
+    end
+    describe '.load_paths=' do
+      it 'replaces the existing' do
+        expect do
+          described_class.load_paths = yml_path_secondary
+        end.to change { described_class.load_paths }.to([yml_path_secondary])
+      end
+    end
+    describe '.fetch' do
+      describe 'with one file in the load path' do
+        describe 'with a default' do
+          describe 'and a miss on the key' do
+            it 'will be the given default value' do
+              expect(described_class.fetch('going.to.miss', default: "and a miss")).to eq('and a miss')
+            end
+          end
+          describe 'and hit on the key' do
+            subject { described_class.fetch('name.value') }
+            it 'will be the registered value' do
+              expect(subject).to eq('firstName')
+            end
+          end
+        end
+        describe 'without a default' do
+          describe 'and a miss on the key' do
+            subject { described_class.fetch('going.to.miss') }
+            it { is_expected.to be_nil }
+          end
+          describe 'and hit on the key' do
+            subject { described_class.fetch('name.value') }
+            it 'will be the registered value' do
+              expect(subject).to eq('firstName')
+            end
+          end
+        end
+      end
+      describe 'with multiple files in the load path' do
+        before do
+          described_class.load_paths = [yml_path, yml_path_secondary]
+        end
+        describe 'and a miss on the key' do
+          it 'will be the given default value' do
+            expect(described_class.fetch('going.to.miss', default: "and a miss")).to eq('and a miss')
+          end
+        end
+        describe 'and what would be a hit on the first and second loaded file' do
+          subject { described_class.fetch('name.value') }
+          it 'will be the second value loaded' do
+            expect(subject).to eq('secondFirstName')
+          end
+        end
+        describe 'and a hit on the first loaded file but not the second' do
+          subject { described_class.fetch('first_only.value') }
+          it 'will be the first loaded value' do
+            expect(subject).to eq('iAmTheFirstOnly')
+          end
+        end
+        describe 'and a hit on the second loaded file but not the first' do
+          subject { described_class.fetch('second_only.value') }
+          it 'will be the first loaded value' do
+            expect(subject).to eq('iAmTheSecondOnly')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
```console
Hyrax::Microdata
  .load_paths
    should be a kind of Array
    can be appended to
  .load_paths=
    replaces the existing
  .fetch
    with one file in the load path
      with a default
        and a miss on the key
          should be the given default value
        and hit on the key
          should be the registered value
      without a default
        and a miss on the key
          should be nil
        and hit on the key
          should be the registered value
    with multiple files in the load path
      and a miss on the key
        should be the given default value
      and what would be a hit on the first and second loaded file
        should be the second value loaded
      and a hit on the first loaded file but not the second
        should be the first loaded value
      and a hit on the second loaded file but not the first
        should be the first loaded value
```