### PR TITLE
Removing duplication of code

### DIFF
--- a/app/presenters/hyrax/admin_stats_presenter.rb
+++ b/app/presenters/hyrax/admin_stats_presenter.rb
@@ -8,12 +8,21 @@ module Hyrax
     end
 
     def start_date
-      @start_date ||= Time.zone.parse(stats_filters[:start_date]).beginning_of_day if stats_filters[:start_date].present?
+      @start_date ||= extract_date_from_stats_filters(key: :start_date, as_of: :beginning_of_day)
     end
 
     def end_date
-      @end_date ||= Time.zone.parse(stats_filters[:end_date]).end_of_day if stats_filters[:end_date].present?
+      @end_date ||= extract_date_from_stats_filters(key: :end_date, as_of: :end_of_day)
     end
+
+    private
+
+      def extract_date_from_stats_filters(key:, as_of:)
+        return unless stats_filters[key].present?
+        Time.zone.parse(stats_filters[key]).public_send(as_of)
+      end
+
+    public
 
     def depositors
       @depositors ||= Hyrax::Statistics::Depositors::Summary.new(start_date, end_date).depositors

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -55,12 +55,7 @@ module Hyrax
     end
 
     def tweeter
-      user = ::User.find_by_user_key(depositor)
-      if user.try(:twitter_handle).present?
-        "@#{user.twitter_handle}"
-      else
-        I18n.translate('hyrax.product_twitter_handle')
-      end
+      TwitterPresenter.twitter_handle_for(user_key: depositor)
     end
 
     def rights

--- a/app/presenters/hyrax/twitter_presenter.rb
+++ b/app/presenters/hyrax/twitter_presenter.rb
@@ -1,0 +1,18 @@
+module Hyrax
+  # Repeatable logic for presenting twitter handles.
+  #
+  # @note The duplication of code was found via the flay gem
+  module TwitterPresenter
+    # @api public
+    # @param [String] user_key for which we will find the appropriate twitter handle
+    # @return [String] the twitter handle appropriate for the given user key
+    def self.twitter_handle_for(user_key:)
+      user = ::User.find_by_user_key(user_key)
+      if user.try(:twitter_handle).present?
+        "@#{user.twitter_handle}"
+      else
+        I18n.translate('hyrax.product_twitter_handle')
+      end
+    end
+  end
+end

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -90,12 +90,7 @@ module Hyrax
     end
 
     def tweeter
-      user = ::User.find_by_user_key(depositor)
-      if user.try(:twitter_handle).present?
-        "@#{user.twitter_handle}"
-      else
-        I18n.translate('hyrax.product_twitter_handle')
-      end
+      TwitterPresenter.twitter_handle_for(user_key: depositor)
     end
 
     def presenter_types

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -8,6 +8,7 @@ describe Hyrax::FileSetPresenter do
           id: '123abc',
           user: user,
           title: ["File title"],
+          depositor: user.user_key,
           label: "filename.tif")
   end
   let(:user) { double(user_key: 'sarah') }
@@ -91,20 +92,9 @@ describe Hyrax::FileSetPresenter do
 
   describe '#tweeter' do
     subject { presenter.tweeter }
-
-    context "with a user that can be found" do
-      let(:user) { create :user, twitter_handle: 'test' }
-      it { is_expected.to eq '@test' }
-    end
-
-    context "with a user that doesn't have a twitter handle" do
-      let(:user) { create :user, twitter_handle: '' }
-      it { is_expected.to eq '@HydraSphere' }
-    end
-
-    context "with a user that can't be found" do
-      let(:user) { double(user_key: 'sarah') }
-      it { is_expected.to eq '@HydraSphere' }
+    it 'delegates the depositor as the user_key to TwitterPresenter.call' do
+      expect(Hyrax::TwitterPresenter).to receive(:twitter_handle_for).with(user_key: solr_document.depositor)
+      subject
     end
   end
 

--- a/spec/presenters/hyrax/twitter_presenter_spec.rb
+++ b/spec/presenters/hyrax/twitter_presenter_spec.rb
@@ -1,0 +1,23 @@
+module Hyrax
+  RSpec.describe TwitterPresenter do
+    describe '.twitter_handle_for' do
+      let(:user_key) { 'user_key' }
+      subject { described_class.twitter_handle_for(user_key: user_key) }
+      context "with a found user that has a twitter handle" do
+        before { allow(::User).to receive(:find_by_user_key).with(user_key).and_return(user) }
+        let(:user) { instance_double(::User, twitter_handle: 'test', user_key: user_key) }
+        it { is_expected.to eq '@test' }
+      end
+
+      context "with a found user that doesn't have a twitter handle" do
+        before { allow(::User).to receive(:find_by_user_key).with(user_key).and_return(user) }
+        let(:user) { instance_double(::User, twitter_handle: '', user_key: user_key) }
+        it { is_expected.to eq '@HydraSphere' }
+      end
+
+      context "with a user that can't be found" do
+        it { is_expected.to eq '@HydraSphere' }
+      end
+    end
+  end
+end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -1,13 +1,15 @@
 describe Hyrax::WorkShowPresenter do
   let(:solr_document) { SolrDocument.new(attributes) }
   let(:request) { double }
+  let(:user_key) { 'a_user_key' }
 
   let(:attributes) do
     { "id" => '888888',
       "title_tesim" => ['foo', 'bar'],
       "human_readable_type_tesim" => ["Generic Work"],
       "has_model_ssim" => ["GenericWork"],
-      "date_created_tesim" => ['an unformatted date'] }
+      "date_created_tesim" => ['an unformatted date'],
+      "depositor_tesim" => user_key }
   end
   let(:ability) { nil }
   let(:presenter) { described_class.new(solr_document, ability, request) }
@@ -94,6 +96,15 @@ describe Hyrax::WorkShowPresenter do
     describe "#editor?" do
       subject { presenter.editor? }
       it { is_expected.to be true }
+    end
+  end
+
+  describe '#tweeter' do
+    let(:user) { instance_double(User, user_key: 'user_key') }
+    subject { presenter.tweeter }
+    it 'delegates the depositor as the user_key to TwitterPresenter.twitter_handle_for' do
+      expect(Hyrax::TwitterPresenter).to receive(:twitter_handle_for).with(user_key: user_key)
+      subject
     end
   end
 


### PR DESCRIPTION
## Extracting common method #tweeter

@529c8e802032425a4b87a8d7100a9ddb70986820

I've been leveraging the flay gem to find duplication in code. This was
an easy and quick fix. It consolidates duplicate logic into a module.

The added benefit is that untested code in one of the presenters is now
tested.

## Extracting duplicate behavior to method

@bbd99861ea3a314a94dd9e4ee15706ed4e369654

Teasing out a common behavior to reduce repetition of behavior.

Detected via flog

## Extracting common method to reduce repetition

@8acc8b054716a1333b2a2fa0094baf697186a558

The consolidates the logic for dates into a common method.

Detected via flog

@projecthydra-labs/hyrax-code-reviewers
