### PR TITLE
Inject the actor factory on reload

### DIFF
--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -37,6 +37,10 @@ module Hyrax
       end
     end
 
+    config.to_prepare do
+      Hyrax::CurationConcern.actor_factory = Hyrax::ActorFactory
+    end
+
     initializer 'requires' do
       require 'hydra/derivatives'
       require 'hyrax/name'
@@ -72,8 +76,6 @@ module Hyrax
         ActiveFedora::Noid.config.minter_class = c.noid_minter_class
         ActiveFedora::Noid.config.statefile = c.minter_statefile
       end
-
-      Hyrax::CurationConcern.actor_factory = Hyrax::ActorFactory
     end
 
     initializer 'hyrax.assets.precompile' do |app|


### PR DESCRIPTION
In development mode, we have to reset this class variable after the code
is reloaded.  Using a to_prepare hook ensures it gets called on each
request.

Fixes #639