### PR TITLE
Tweaking rubocop method length

### DIFF
--- a/app/controllers/concerns/hyrax/contact_form_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/contact_form_controller_behavior.rb
@@ -20,8 +20,12 @@ module Hyrax
         flash.now[:error] << @contact_form.errors.full_messages.map(&:to_s).join(", ")
       end
       render :new
-    rescue RuntimeError => e
-      logger.error("Contact form failed to send: #{e.inspect}")
+    rescue RuntimeError => exception
+      handle_create_exception(exception)
+    end
+
+    def handle_create_exception(exception)
+      logger.error("Contact form failed to send: #{exception.inspect}")
       flash.now[:error] = 'Sorry, this message was not delivered.'
       render :new
     end

--- a/app/helpers/hyrax/citations_behaviors/formatters/apa_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/apa_formatter.rb
@@ -7,27 +7,28 @@ module Hyrax
 
         def format(work)
           text = ''
-
-          # setup formatted author list
-          authors_list = author_list(work).select { |author| !author.blank? }
-          text << format_authors(authors_list)
-          unless text.blank?
-            text = "<span class=\"citation-author\">#{text}</span> "
-          end
-          # Get Pub Date
-          pub_date = setup_pub_date(work)
-          text << format_date(pub_date)
-
-          # setup title info
-          title_info = setup_title_info(work)
-          text << format_title(title_info)
-
-          # Publisher info
-          pub_info = clean_end_punctuation(setup_pub_info(work))
-          text << pub_info unless pub_info.nil?
+          text << authors_text_for(work)
+          text << pub_date_text_for(work)
+          text << add_title_text_for(work)
+          text << add_publisher_text_for(work)
           text << "." unless text.blank? || text =~ /\.$/
           text.html_safe
         end
+
+        private
+
+          def authors_text_for(work)
+            # setup formatted author list
+            authors_list = author_list(work).select { |author| !author.blank? }
+            author_text = format_authors(authors_list)
+            if author_text.blank?
+              author_text
+            else
+              "<span class=\"citation-author\">#{author_text}</span> "
+            end
+          end
+
+        public
 
         def format_authors(authors_list = [])
           authors_list = Array.wrap(authors_list).collect { |name| abbreviate_name(surname_first(name)).strip }
@@ -43,6 +44,32 @@ module Hyrax
           text << "." unless text =~ /\.$/
           text
         end
+
+        private
+
+          def pub_date_text_for(work)
+            # Get Pub Date
+            pub_date = setup_pub_date(work)
+            format_date(pub_date)
+          end
+
+          def add_title_text_for(work)
+            # setup title info
+            title_info = setup_title_info(work)
+            format_title(title_info)
+          end
+
+          def add_publisher_text_for(work)
+            # Publisher info
+            pub_info = clean_end_punctuation(setup_pub_info(work))
+            if pub_info.nil?
+              ''
+            else
+              pub_info
+            end
+          end
+
+        public
 
         def format_date(pub_date)
           pub_date.blank? ? "" : "(" + pub_date + "). "


### PR DESCRIPTION
## Reducing Metrics/MethodLength for ContactForm

@5f7c94c61b558d3cf63b513d652f48115380a5f7


## Extracting method to bring common abstraction

@976f6b43428deceaecef7efc3a3fa63323145a49

This extraction is to ensure there is a common level of abstraction
for the primary method. Also renaming method to better explain it's
purpose.

## Extracting method to better define method

@805ee3831b8056e4e03cb880e0e79f2a0773c7e0

This also involved removing a method that was dependent on a guard
condition from another method (`params[:user][:update_directory]`) was
built on the assumption that `params[:user]` existed (which was guarded
in the parent method).

## Extracting methods for ApaFormat to better clarify

@6ed952ece25ddc6cbdf76b78226cc81d65865c1f

This is an effort to remove some of the apparent complexity. I would
like to privatize other methods, however, they were part of the public
methods so I'm extracting what I hope to be a simple refactor.

@projecthydra-labs/hyrax-code-reviewers
