### PR TITLE
Moves .curation_concern_type= Hyrax::WorksControllerBehavior

### DIFF
--- a/app/controllers/concerns/hyrax/breadcrumbs_for_works.rb
+++ b/app/controllers/concerns/hyrax/breadcrumbs_for_works.rb
@@ -9,7 +9,6 @@ module Hyrax
       def curation_concern_type=(curation_concern_type)
         super
         before_action :build_breadcrumbs, only: [:edit, :show, :new]
-        before_action :save_permissions, only: :update
       end
     end
 

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -28,6 +28,9 @@ module Hyrax
         load_resource class: curation_concern_type, instance_name: :curation_concern, only: :file_manager
 
         self._curation_concern_type = curation_concern_type
+        # We don't want the breadcrumb action to occur until after the concern has
+        # been loaded and authorized
+        before_action :save_permissions, only: :update
       end
 
       def curation_concern_type


### PR DESCRIPTION
Moves the following:
```ruby
        before_action :save_permissions, only: :update
```
...to the Concern implementation as a class method, as recommended in https://github.com/projecthydra-labs/hyrax/issues/512#issuecomment-283147334

Resolves #512 