### PR TITLE
Remove break tag from admin users table.

### DIFF
--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -25,7 +25,6 @@
                     <%= image_tag(user.avatar.url(:thumb), width: 30) if user.avatar.file %>
                   <% end %>
               </td>
-              <br>
               <td><%= link_to user.email, hyrax.user_path(user) %></td>
               <td><% roles = @presenter.user_roles(user) %>
                   <ul><% roles.each do |role| %>


### PR DESCRIPTION
The Users table in the Manage Users interface includes a `<br>` inside the `<tr>`. This results in white space proportional to the number of entries in the table.

Changes proposed in this pull request:
* Remove the `<br>`.

@projecthydra-labs/hyrax-code-reviewers