### PR TITLE
Prefer provide over content_for

### DIFF
--- a/app/views/hyrax/admin/admin_sets/edit.html.erb
+++ b/app/views/hyrax/admin/admin_sets/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="fa fa-edit"></span> <%= t('.header') %></h1>
 <% end %>
 

--- a/app/views/hyrax/admin/admin_sets/index.html.erb
+++ b/app/views/hyrax/admin/admin_sets/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="fa fa-sitemap"></span> Administrative Sets</h1>
   <div class="pull-right">
     <%= link_to hyrax.new_admin_admin_set_path, class: 'btn btn-primary' do %>

--- a/app/views/hyrax/admin/admin_sets/new.html.erb
+++ b/app/views/hyrax/admin/admin_sets/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="fa fa-edit"></span> <%= t('.header') %></h1>
 <% end %>
 

--- a/app/views/hyrax/admin/admin_sets/show.html.erb
+++ b/app/views/hyrax/admin/admin_sets/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="fa fa-sitemap"></span> <%= t('.header') %></h1>
 <% end %>
 

--- a/app/views/hyrax/admin/appearances/show.html.erb
+++ b/app/views/hyrax/admin/appearances/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="fa fa-paint-brush"></span> <%= t('.header') %></h1>
 <% end %>
 

--- a/app/views/hyrax/admin/features/index.html.erb
+++ b/app/views/hyrax/admin/features/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="fa fa-cog"></span> Settings</h1>
 <% end %>
 <div class="flip row">

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="fa fa-user"></span> <%= t('hyrax.admin.users.index.title') %></h1>
 <% end %>
 

--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="glyphicon glyphicon-ok-circle"></span> <%= t('.header') %></h1>
 <% end %>
 

--- a/app/views/hyrax/base/_form.html.erb
+++ b/app/views/hyrax/base/_form.html.erb
@@ -12,7 +12,7 @@
     </div>
   <% end %>
   <% unless f.object.persisted? %>
-    <% content_for :metadata_tab do %>
+    <% provide :metadata_tab do %>
       <p class="switch-upload-type">To create a separate work for each of the files, go to <%= link_to "Batch upload", hyrax.new_batch_upload_path %></p>
     <% end %>
   <% end %>

--- a/app/views/hyrax/batch_uploads/_form.html.erb
+++ b/app/views/hyrax/batch_uploads/_form.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for [hyrax, @form], html: { multipart: true } do |f| %>
-  <% content_for :files_tab do %>
+  <% provide :files_tab do %>
     <p class="instructions"><%= t("hyrax.batch_uploads.files.instructions") %></p>
     <p class="switch-upload-type"><%= t("hyrax.batch_uploads.files.upload_type_instructions") %>
       <%= link_to t("hyrax.batch_uploads.files.button_label"), [main_app, :new, Hyrax.primary_work_type.model_name.singular_route_key] %>

--- a/app/views/hyrax/dashboard/profiles/edit.html.erb
+++ b/app/views/hyrax/dashboard/profiles/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="fa fa-id-card"></span> Edit Profile</h1>
 <% end %>
 <div class="panel panel-default">

--- a/app/views/hyrax/dashboard/profiles/show.html.erb
+++ b/app/views/hyrax/dashboard/profiles/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="fa fa-id-card"></span> <%= t("hyrax.admin.sidebar.profile") %></h1>
   <% if can? :edit, current_user %>
     <div class="pull-right">

--- a/app/views/hyrax/dashboard/show_user.html.erb
+++ b/app/views/hyrax/dashboard/show_user.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><%= t("hyrax.dashboard.title") %></h1>
 <% end %>
 

--- a/app/views/hyrax/my/collections/index.html.erb
+++ b/app/views/hyrax/my/collections/index.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, t("hyrax.admin.sidebar.collections") %>
 
-<% content_for :head do %>
+<% provide :head do %>
   <%= rss_feed_link_tag route_set: hyrax %>
   <%= atom_feed_link_tag route_set: hyrax %>
 <% end %>
@@ -9,7 +9,7 @@
   <%= render partial: 'scripts', formats: [:js] %>
 <% end %>
 
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="fa fa-folder-open"></span> <%= t("hyrax.admin.sidebar.collections") %></h1>
   <div class="pull-right">
     <% if can?(:create, Collection) %>

--- a/app/views/hyrax/my/index.html.erb
+++ b/app/views/hyrax/my/index.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, t("hyrax.admin.sidebar.works") %>
 
-<% content_for :head do %>
+<% provide :head do %>
   <%= rss_feed_link_tag route_set: hyrax %>
   <%= atom_feed_link_tag route_set: hyrax %>
 <% end %>
@@ -9,7 +9,7 @@
   <%= render partial: 'scripts', formats: [:js] %>
 <% end %>
 
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="fa fa-file"></span> <%= t("hyrax.admin.sidebar.works") %></h1>
 <% end %>
 

--- a/app/views/hyrax/my/works/index.html.erb
+++ b/app/views/hyrax/my/works/index.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, t("hyrax.admin.sidebar.works") %>
 
-<% content_for :head do %>
+<% provide :head do %>
   <%= rss_feed_link_tag route_set: hyrax %>
   <%= atom_feed_link_tag route_set: hyrax %>
 <% end %>
@@ -9,7 +9,7 @@
   <%= render partial: 'scripts', formats: [:js] %>
 <% end %>
 
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="fa fa-file"></span> <%= t("hyrax.admin.sidebar.works") %></h1>
   <div class="pull-right">
     <% if create_work_presenter.many? %>

--- a/app/views/hyrax/notifications/index.html.erb
+++ b/app/views/hyrax/notifications/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_header do %>
+<% provide :page_header do %>
   <h1><span class="fa fa-bell"></span>  <%= t("hyrax.admin.sidebar.notifications") %></h1>
   <%= link_to hyrax.delete_all_notifications_path,
               method: :delete,


### PR DESCRIPTION
Provide knows to expect no more input for this block after it's been
called once. This enables streaming responses.

See:
http://api.rubyonrails.org/classes/ActionController/Streaming.html#module-ActionController::Streaming-label-Communication+between+layout+and+template

Fixes #issuenumber ; refs #issuenumber

Present tense short summary (50 characters or less)

More detailed description, if necessary. Try to be as descriptive as you can: even if you think that the PR content is obvious, it may not be obvious to others. Include tracebacks if helpful, and be sure to call out any bits of the PR that may be work-in-progress.

Description can have multiple paragraphs and you can use code examples inside:

``` ruby
class PostsController
  def index
    respond_with Post.limit(10)
  end
end
```

Changes proposed in this pull request:
* 
* 
* 

@projecthydra-labs/hyrax-code-reviewers
