### PR TITLE
Reuse common point of override for labels

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -3,7 +3,7 @@
   <%= hidden_field_tag :search_field, 'all_fields' %>
   <div class="input-group">
 
-    <label class="sr-only" for="search-field-header"><%= t("hyrax.search.form.q.label") %></label>
+    <label class="sr-only" for="search-field-header"><%= t("hyrax.search.form.q.label", application_name: application_name) %></label>
     <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
     <div class="input-group-btn">
@@ -11,13 +11,13 @@
         <%= t('hyrax.search.button.html') %>
       </button>
       <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
-        <span data-search-element="label"><%= t("hyrax.search.form.option.all.label_long") %></span>
+        <span data-search-element="label"><%= t("hyrax.search.form.option.all.label_long", application_name: application_name) %></span>
         <span class="caret"></span>
       </button>
 
       <ul class="dropdown-menu pull-right">
         <li>
-          <%= link_to t("hyrax.search.form.option.all.label_long"), "#",
+          <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
               data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
         </li>
 

--- a/app/views/hyrax/my/_search_form.html.erb
+++ b/app/views/hyrax/my/_search_form.html.erb
@@ -2,7 +2,7 @@
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <div class="input-group">
 
-    <label class="sr-only" for="search-field-header"><%= t("hyrax.search.form.q.label") %></label>
+    <label class="sr-only" for="search-field-header"><%= t("hyrax.search.form.q.label", application_name: application_name) %></label>
     <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
 
     <div class="input-group-btn">

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -525,7 +525,7 @@ en:
       form:
         option:
           all:
-            label_long:   "All of Hyrax"
+            label_long:   "All of %{application_name}"
             label_short:  "All"
           my_collections:
             label_long:   "My Collections"
@@ -537,7 +537,7 @@ en:
             label_long:   "My Works"
             label_short:  "My Works"
         q:
-          label:          "Search Hyrax"
+          label:          "Search %{application_name}"
           placeholder:    "Enter search terms"
     select_type:
       description: "General purpose worktype"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -524,7 +524,7 @@ es:
       form:
         option:
           all:
-            label_long:   "Todo Hyrax"
+            label_long:   "Todo %{application_name}"
             label_short:  "Todo"
           my_collections:
             label_long:   "Mis Colecciones"
@@ -536,7 +536,7 @@ es:
             label_long:   "Mis trabajos"
             label_short:  "Mis trabajos"
         q:
-          label:          "Buscar en Hyrax"
+          label:          "Buscar en %{application_name}"
           placeholder:    "Introduce términos de búsqueda"
     select_type:
       description: "Tipo de trabajo de propósito general."


### PR DESCRIPTION
We know the `product_name` (via `application_name` helper method) is
going to be overridden every time.  So let's not force the users to
override additional labels that also hardcode the same "Hyrax" string.

See: https://github.com/projecthydra-labs/hyku/issues/904