### PR TITLE
Remove deprecated configuration methods

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -87,8 +87,6 @@ module Hyrax
       return @display_microdata unless @display_microdata.nil?
       @display_microdata = true
     end
-    alias display_microdata display_microdata?
-    deprecation_deprecate display_microdata: "use display_microdata? instead"
 
     attr_writer :microdata_default_type
     def microdata_default_type
@@ -105,8 +103,6 @@ module Hyrax
       return @enable_noids unless @enable_noids.nil?
       @enable_noids = true
     end
-    alias enable_noids enable_noids?
-    deprecation_deprecate enable_noids: "use enable_noids? instead"
 
     attr_writer :noid_template
     def noid_template
@@ -128,8 +124,6 @@ module Hyrax
       return @display_media_download_link unless @display_media_download_link.nil?
       @display_media_download_link = true
     end
-    alias display_media_download_link display_media_download_link?
-    deprecation_deprecate display_media_download_link: "use display_media_download_link? instead"
 
     attr_writer :fits_path
     def fits_path
@@ -290,22 +284,16 @@ module Hyrax
     def browse_everything?
       @browse_everything ||= nil
     end
-    alias browse_everything browse_everything?
-    deprecation_deprecate browse_everything: "use browse_everything? instead"
 
     attr_writer :analytics
     def analytics?
       @analytics ||= false
     end
-    alias analytics analytics?
-    deprecation_deprecate analytics: "use analytics? instead"
 
     attr_writer :citations
     def citations?
       @citations ||= false
     end
-    alias citations citations?
-    deprecation_deprecate citations: "use citations? instead"
 
     attr_writer :max_notifications_for_dashboard
     def max_notifications_for_dashboard
@@ -321,8 +309,6 @@ module Hyrax
     def arkivo_api?
       @arkivo_api ||= false
     end
-    alias arkivo_api arkivo_api?
-    deprecation_deprecate arkivo_api: "use arkivo_api? instead"
 
     def geonames_username=(username)
       Qa::Authorities::Geonames.username = username
@@ -333,16 +319,12 @@ module Hyrax
       return true if @active_deposit_agreement_acceptance.nil?
       @active_deposit_agreement_acceptance
     end
-    alias active_deposit_agreement_acceptance active_deposit_agreement_acceptance?
-    deprecation_deprecate active_deposit_agreement_acceptance: "use active_deposit_agreement_acceptance? instead"
 
     attr_writer :work_requires_files
     def work_requires_files?
       return true if @work_requires_files.nil?
       @work_requires_files
     end
-    alias work_requires_files work_requires_files?
-    deprecation_deprecate work_requires_files: "use work_requires_files? instead"
 
     attr_writer :batch_user_key
     def batch_user_key
@@ -371,8 +353,6 @@ module Hyrax
       return true if @always_display_share_button.nil?
       @always_display_share_button
     end
-    alias always_display_share_button always_display_share_button?
-    deprecation_deprecate always_display_share_button: "use always_display_share_button? instead"
 
     attr_writer :google_analytics_id
     def google_analytics_id

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -17,25 +17,25 @@ RSpec.describe Hyrax::Configuration do
   end
 
   it { is_expected.to respond_to(:active_deposit_agreement_acceptance?) }
-  it { is_expected.to respond_to(:active_deposit_agreement_acceptance) }
+  it { is_expected.to respond_to(:active_deposit_agreement_acceptance=) }
   it { is_expected.to respond_to(:activity_to_show_default_seconds_since_now) }
   it { is_expected.to respond_to(:always_display_share_button?) }
-  it { is_expected.to respond_to(:always_display_share_button) }
+  it { is_expected.to respond_to(:always_display_share_button=) }
   it { is_expected.to respond_to(:analytic_start_date) }
   it { is_expected.to respond_to(:analytics?) }
   it { is_expected.to respond_to(:analytics) }
   it { is_expected.to respond_to(:arkivo_api?) }
-  it { is_expected.to respond_to(:arkivo_api) }
+  it { is_expected.to respond_to(:arkivo_api=) }
   it { is_expected.to respond_to(:audit_user_key) }
   it { is_expected.to respond_to(:batch_user_key) }
   it { is_expected.to respond_to(:browse_everything?) }
-  it { is_expected.to respond_to(:browse_everything) }
+  it { is_expected.to respond_to(:browse_everything=) }
   it { is_expected.to respond_to(:cache_path) }
   it { is_expected.to respond_to(:citations?) }
-  it { is_expected.to respond_to(:citations) }
+  it { is_expected.to respond_to(:citations=) }
   it { is_expected.to respond_to(:contact_email) }
   it { is_expected.to respond_to(:display_media_download_link?) }
-  it { is_expected.to respond_to(:display_media_download_link) }
+  it { is_expected.to respond_to(:display_media_download_link=) }
   it { is_expected.to respond_to(:display_microdata?) }
   it { is_expected.to respond_to(:enable_noids?) }
   it { is_expected.to respond_to(:feature_config_path) }


### PR DESCRIPTION
These were deprecated in Hyrax 1.0, so we can remove them for 2.0
