### PR TITLE
Move "Review Submissions" to a top level task

### DIFF
--- a/app/presenters/hyrax/menu_presenter.rb
+++ b/app/presenters/hyrax/menu_presenter.rb
@@ -10,12 +10,6 @@ module Hyrax
     delegate :controller, :controller_name, :action_name, :content_tag,
              :current_page?, :link_to, to: :view_context
 
-    # Returns true if the current controller happens to be one of the controllers that deals
-    # with workflow.  This is used to keep the parent section on the sidebar open.
-    def workflows_section?
-      controller.instance_of? Hyrax::Admin::WorkflowRolesController
-    end
-
     # @param options [Hash, String] a hash or string representing the path. Hash is prefered as it
     #                              allows us to workaround https://github.com/rails/rails/issues/28253
     # @param also_active_for [Hash, String] a hash or string with alternative paths that should be 'active'

--- a/app/views/hyrax/dashboard/_sidebar.html.erb
+++ b/app/views/hyrax/dashboard/_sidebar.html.erb
@@ -37,6 +37,10 @@
         <span class="fa fa-paint-brush"></span> <%= t('hyrax.admin.sidebar.appearance') %>
       <% end %>
     <% end %>
+
+    <%= menu.nav_link(hyrax.admin_workflow_roles_path) do %>
+      <span class="fa fa-users"></span> <%= t('hyrax.admin.sidebar.workflow_roles') %>
+    <% end %>
   <% end %>
 
   <li class="h5"><%= t('hyrax.admin.sidebar.repository_objects') %></li>
@@ -59,20 +63,9 @@
   <% if can? :read, :admin_dashboard %>
 
     <li class="h5"><%= t('hyrax.admin.sidebar.tasks') %></li>
-
-    <li>
-      <%= menu.collapsable_section t('hyrax.admin.sidebar.workflow'),
-                                   icon_class: "fa fa-code-fork",
-                                   id: 'collapseWorkflows',
-                                   open: menu.workflows_section? do %>
-        <%= menu.nav_link(hyrax.admin_workflows_path) do %>
-          <span class="fa fa-flag"></span> <%= t('hyrax.admin.sidebar.workflow_review') %>
-        <% end %>
-        <%= menu.nav_link(hyrax.admin_workflow_roles_path) do %>
-          <span class="fa fa-users"></span> <%= t('hyrax.admin.sidebar.workflow_roles') %>
-        <% end %>
-      <% end %>
-    </li>
+    <%= menu.nav_link(hyrax.admin_workflows_path) do %>
+      <span class="fa fa-flag"></span> <%= t('hyrax.admin.sidebar.workflow_review') %>
+    <% end %>
   <% end %>
 
   <% if can? :manage, User %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -170,9 +170,8 @@ en:
         statistics:         "Statistics"
         tasks:              "Tasks"
         users:              "Manage Users"
-        workflow:           "Workflows"
         workflow_review:    "Review Submissions"
-        workflow_roles:     "Roles"
+        workflow_roles:     "Workflow Roles"
         works:              "Works"
       stats:
         deposited_form:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -159,7 +159,7 @@ es:
       sidebar:
         activity:           "Actividad"
         admin_sets:         "Conjuntos Administrativos"
-        appearance:      "Apariencia"
+        appearance:         "Apariencia"
         collections:        "Colecciones"
         configuration:      "Configuración"
         notifications:      "Notificaciones"
@@ -169,9 +169,8 @@ es:
         statistics:         "Estadísticas"
         tasks:              'Tareas'
         users:              "Usarios"
-        workflow:           "Flujos de Trabajo"
         workflow_review:    "Revise Ofertas"
-        workflow_roles:     "Roles"
+        workflow_roles:     "Funciones del flujo de trabajo"
         works:              "Trabajos"
       stats:
         deposited_form:

--- a/spec/presenters/hyrax/menu_presenter_spec.rb
+++ b/spec/presenters/hyrax/menu_presenter_spec.rb
@@ -5,19 +5,6 @@ RSpec.describe Hyrax::MenuPresenter do
   let(:context) { ActionView::TestCase::TestController.new.view_context }
   let(:controller_name) { controller.controller_name }
 
-  describe "#workflows_section?" do
-    before do
-      allow(context).to receive(:controller_name).and_return(controller_name)
-      allow(context).to receive(:controller).and_return(controller)
-    end
-    subject { instance.workflows_section? }
-
-    context "for the WorkflowRolesController" do
-      let(:controller) { Hyrax::Admin::WorkflowRolesController.new }
-      it { is_expected.to be true }
-    end
-  end
-
   describe "#collapsable_section" do
     subject do
       instance.collapsable_section('link title',


### PR DESCRIPTION
Get rid of the collapsing Workflow section and move "Workflow Roles" to
the configuration section
