### PR TITLE
Update header/footer text and link colors for better contrast

### DIFF
--- a/app/assets/stylesheets/hyrax/_footer.scss
+++ b/app/assets/stylesheets/hyrax/_footer.scss
@@ -22,6 +22,11 @@ body {
   bottom: 0;
   height: $footer-height;
   width: 100%;
+
+  a,
+  &.navbar-inverse .navbar-link {
+    color: #e27800;
+  }
 }
 
 @media (max-width: $screen-sm) {

--- a/app/assets/stylesheets/hyrax/_footer.scss
+++ b/app/assets/stylesheets/hyrax/_footer.scss
@@ -22,11 +22,6 @@ body {
   bottom: 0;
   height: $footer-height;
   width: 100%;
-
-  a,
-  &.navbar-inverse .navbar-link {
-    color: #e27800;
-  }
 }
 
 @media (max-width: $screen-sm) {

--- a/app/controllers/hyrax/admin/appearances_controller.rb
+++ b/app/controllers/hyrax/admin/appearances_controller.rb
@@ -18,6 +18,8 @@ module Hyrax
         def update_params
           params.require(:admin_appearance).permit(:header_background_color,
                                                    :header_text_color,
+                                                   :link_color,
+                                                   :footer_link_color,
                                                    :primary_button_background_color)
         end
 

--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -29,7 +29,7 @@ module Hyrax
         end
 
         def header_text_color
-          block_for('header_text_color', '#9d9d9d')
+          block_for('header_text_color', '#DCDCCE')
         end
 
         def primary_button_background_color

--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -29,7 +29,15 @@ module Hyrax
         end
 
         def header_text_color
-          block_for('header_text_color', '#DCDCCE')
+          block_for('header_text_color', '#dcdcce')
+        end
+
+        def link_color
+          block_for('link_color', '#e27800')
+        end
+
+        def footer_link_color
+          block_for('footer_link_color', '#e27800')
         end
 
         def primary_button_background_color
@@ -67,6 +75,7 @@ module Hyrax
         def update!
           update_block('header_background_color', attributes[:header_background_color])
           update_block('header_text_color', attributes[:header_text_color])
+          update_block('footer_link_color', attributes[:footer_link_color])
           update_block('primary_button_background_color', attributes[:primary_button_background_color])
         end
 

--- a/app/views/hyrax/admin/appearances/show.html.erb
+++ b/app/views/hyrax/admin/appearances/show.html.erb
@@ -7,6 +7,8 @@
     <%= simple_form_for @form, url: admin_appearance_path do |f| %>
       <%= f.input :header_background_color, required: false, input_html: { type: 'color' } %>
       <%= f.input :header_text_color, required: false, input_html: { type: 'color' }  %>
+      <%= f.input :link_color, required: false, input_html: { type: 'color' }  %>
+      <%= f.input :footer_link_color, required: false, input_html: { type: 'color' }  %>
       <%= f.input :primary_button_background_color, required: false, input_html: { type: 'color' }  %>
       <%= f.submit class: 'btn btn-primary' %>
     <% end %>

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -1,6 +1,9 @@
 <% # Dynamic styles added by the admin in the appearances page %>
 <style>
 <% appearance = Hyrax::Forms::Admin::Appearance.new %>
+a { color: <%= appearance.link_color %>; }
+.navbar-inverse .navbar-link { color: <%= appearance.footer_link_color %>; }
+
 .navbar-inverse { background-color: <%= appearance.header_background_color %>; }
 
 .navbar-inverse .navbar-nav > .open > a,

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -237,7 +237,7 @@ en:
       unprocessable_entity:
         default: "The resource you attempted to modify cannot be modified according to your request."
         empty_file: "The file you uploaded has no content."
-    background_attribution_html: "Background image CC by-nc-sa by <a href=\"https://flic.kr/p/eirxaf\">f2b1610</a>"
+    background_attribution_html: "Background image CC by-nc-sa by <a href=\"https://flic.kr/p/eirxaf\" class=\"navbar-link\">f2b1610</a>"
     base:
       citations:
         header: 'Citations:'

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -236,7 +236,7 @@ es:
       unprocessable_entity:
         default: "El recurso que intentó modificar no se puede modificar de acuerdo con su solicitud."
         empty_file: "El archivo que subiste no tiene contenido."
-    background_attribution_html: "Imagen de fondo CC by-nc-sa por <a href=\"https://flic.kr/p/eirxaf\">f2b1610</a>"
+    background_attribution_html: "Imagen de fondo CC by-nc-sa por <a href=\"https://flic.kr/p/eirxaf\" class=\"navbar-link\">f2b1610</a>"
     base:
       citations:
         header: 'Citaciones:'

--- a/spec/controllers/hyrax/admin/appearances_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/appearances_controller_spec.rb
@@ -33,21 +33,30 @@ RSpec.describe Hyrax::Admin::AppearancesController do
       sign_in user
     end
     let(:user) { create(:user) }
+
     context "when authorized" do
       before do
         allow(controller).to receive_messages(current_user: user)
         expect(user).to receive(:groups).and_return(['admin', 'registered'])
       end
 
-      it "is successful" do
-        patch :update, params: {
-          admin_appearance: {
-            "header_background_color" => "#00ff00",
-            "header_text_color" => "#17557b",
-            "primary_button_background_color" => "#00ff00"
-          }
+      let(:form) { instance_double(Hyrax::Forms::Admin::Appearance, update!: true) }
+      let(:attributes) do
+        {
+          "header_background_color" => "#00ff00",
+          "link_color" => "#e02020",
+          "footer_link_color" => "#e02020",
+          "header_text_color" => "#17557b",
+          "primary_button_background_color" => "#00ff00"
         }
-        expect(ContentBlock.find_by(name: 'primary_button_background_color').value).to eq '#00ff00'
+      end
+
+      it "is successful" do
+        expect(Hyrax::Forms::Admin::Appearance).to receive(:new)
+          .with(ActionController::Parameters.new(attributes).permit!)
+          .and_return(form)
+
+        patch :update, params: { admin_appearance: attributes }
         expect(response).to be_redirect
       end
     end


### PR DESCRIPTION
Current text and link colors in the header and footer do not pass AA minimum contrast:

![before](https://cloud.githubusercontent.com/assets/101482/24716810/0c7f47a4-19e5-11e7-96e7-26102614b97a.png)

This PR brightens the colors to pass at AA (I'm not super excited by this color palette, but maybe we can revisit it in the future; presumably implementors will change the colors anyway):

![after](https://cloud.githubusercontent.com/assets/101482/24716854/3ac89c46-19e5-11e7-834e-0a8163e2388e.png)
