### PR TITLE
Update styling of Admin main content area

### DIFF
--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -12,6 +12,7 @@ $admin-sidebar-link-hover-color: #000000 !default;
 $admin-sidebar-link-background-color: #505050 !default;
 $admin-content-background-color: #f0f0f0 !default;
 $admin-vertical-padding: 0 !default;
+$admin-panel-border-color: #dedede !default;
 
 .my-works-list {
   .highlighted-work {
@@ -32,6 +33,11 @@ body.dashboard {
 }
 
 .dashboard {
+  .breadcrumb {
+    border: 1px solid $admin-panel-border-color;
+    margin-top: 0.5em;
+  }
+
   .tabs {
     margin-top: $tab-margin;
     position: relative;
@@ -260,7 +266,7 @@ body.dashboard {
   }
 
   .panel {
-    border: 0;
+    border: 1px solid $admin-panel-border-color;
     float: left;
     width: 100%;
 

--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -113,6 +113,10 @@ body.dashboard {
       color: $gray;
       margin-right: $padding-xs-horizontal;
     }
+
+    .btn {
+      margin-bottom: $padding-base-vertical;
+    }
   }
 
   // the span selector is required because Blacklight is using it.


### PR DESCRIPTION
* Adds light border around panels
* Adds small amount of space above breadcrumbs and below the action buttons that sit above panels  

### Before
![index_notification____hyrax](https://cloud.githubusercontent.com/assets/101482/24765327/437d247a-1aac-11e7-88fc-cf33572b322b.png)


### After
![after](https://cloud.githubusercontent.com/assets/101482/24765322/417bca82-1aac-11e7-8504-8dfa10a01a34.png)
