### PR TITLE
Set link color in appearances config to BS default link color

### DIFF
--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -33,7 +33,7 @@ module Hyrax
         end
 
         def link_color
-          block_for('link_color', '#e27800')
+          block_for('link_color', '#337ab7')
         end
 
         def footer_link_color


### PR DESCRIPTION
Fixes #727.

Sets the link color that is the default in the appearances config to be the default Bootstrap link color. So unless the admin changes things, links in the app are default blue with the exception of the footer, where they are a color that has better contrast with the default background color.

![hyrax](https://cloud.githubusercontent.com/assets/101482/24777170/f96e3c48-1ad8-11e7-863a-f88d1e3dae89.png)
