### PR TITLE
Make dashboard section headings a bit stronger

### DIFF
--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -285,8 +285,8 @@ body.dashboard {
     .panel-title {
       color: $title-text-color;
       display: block;
-      font-size: 16px;
-      font-weight: 400;
+      font-size: 18px;
+      font-weight: 600;
       line-height: 30px;
     }
   }

--- a/app/views/hyrax/dashboard/_collections.html.erb
+++ b/app/views/hyrax/dashboard/_collections.html.erb
@@ -2,10 +2,8 @@
   <div class="col-md-12">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <div class="panel-title">
-          <h3><%= t('.title') %></h3>
-          <div><%= t('.subtitle') %></div>
-        </div>
+        <h3 class="panel-title"><%= t('.title') %></h3>
+        <div><%= t('.subtitle') %></div>
       </div>
       <div class="panel-body">
         <table class="table table-striped">


### PR DESCRIPTION
Fairly minor change, just trying to make the panel headings stand out a bit more from the subtitles. This update might affect some headings in Hyku that are not present in Hyrax, but I will fix them in Hyku if necessary.

![show_dashboard____hyrax](https://cloud.githubusercontent.com/assets/101482/24777811/13191e6c-1adc-11e7-9bff-25e58ff6bff1.png)

