### PR TITLE
Require Hyrax::Name before it is used

### DIFF
--- a/app/models/concerns/hyrax/naming.rb
+++ b/app/models/concerns/hyrax/naming.rb
@@ -1,3 +1,4 @@
+require 'hyrax/name'
 module Hyrax
   module Naming
     extend ActiveSupport::Concern

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -43,7 +43,6 @@ module Hyrax
 
     initializer 'requires' do
       require 'hydra/derivatives'
-      require 'hyrax/name'
       require 'hyrax/controller_resource'
       require 'hyrax/search_state'
       require 'hyrax/single_use_error'


### PR DESCRIPTION
Fixes #733 