### PR TITLE
Move configuration to bottom. Add "Your activity" collapsing section

### DIFF
--- a/app/assets/stylesheets/hyrax/sidebar.scss
+++ b/app/assets/stylesheets/hyrax/sidebar.scss
@@ -27,7 +27,7 @@ $gutter-width: $grid-gutter-width/2;
   min-height: 100vh;
 
   &.maximized {
-    .h5, .sidebar-action-text, .profile {
+    .h5, .sidebar-action-text, .profile, .collapse-toggle::after {
       opacity: 1;
     }
     width: $drawer-large;
@@ -115,7 +115,10 @@ $gutter-width: $grid-gutter-width/2;
   }
 
   // submenu items
-  ul.collapse > li > a,
+  &.maximized ul.collapse > li > a {
+    // only indent when the drawer is maximized
+    padding-left: 25px;
+  }
   ul.collapsing > li > a {
     padding-left: 25px;
   }
@@ -125,7 +128,9 @@ $gutter-width: $grid-gutter-width/2;
 
     &::after {
       content: "❯";
-      float: right;
+      opacity: 0;
+      position: absolute;
+      right: $gutter-width;
       transform: rotate(90deg);
     }
 

--- a/app/presenters/hyrax/menu_presenter.rb
+++ b/app/presenters/hyrax/menu_presenter.rb
@@ -23,6 +23,19 @@ module Hyrax
       end
     end
 
+    # @return [Boolean] true if the current controller happens to be one of the controllers that deals
+    # with user activity  This is used to keep the parent section on the sidebar open.
+    def user_activity_section?
+      # we're using a case here because we need to differentiate UsersControllers
+      # in different namespaces (Hyrax & Admin)
+      case controller
+      when Hyrax::UsersController, Hyrax::NotificationsController, Hyrax::TransfersController
+        true
+      else
+        false
+      end
+    end
+
     # Draw a collaspable menu section. The passed block should contain <li> items.
     def collapsable_section(text, id:, icon_class:, open:, &block)
       CollapsableSectionPresenter.new(view_context: view_context,

--- a/app/views/hyrax/dashboard/_sidebar.html.erb
+++ b/app/views/hyrax/dashboard/_sidebar.html.erb
@@ -13,37 +13,29 @@
   </li>
   <li class="h5"><%= t('hyrax.admin.sidebar.activity') %></li>
 
-  <%= menu.nav_link(hyrax.dashboard_profile_path(current_user),
-                    also_active_for: hyrax.edit_dashboard_profile_path(current_user)) do %>
-    <span class="fa fa-id-card"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.profile') %></span>
-  <% end %>
+  <li>
+    <%= menu.collapsable_section t('hyrax.admin.sidebar.user_activity'),
+                                 icon_class: "fa fa-line-chart",
+                                 id: 'collapseUserActivity',
+                                 open: menu.user_activity_section? do %>
+      <%= menu.nav_link(hyrax.dashboard_profile_path(current_user),
+                        also_active_for: hyrax.edit_dashboard_profile_path(current_user)) do %>
+        <span class="fa fa-id-card"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.profile') %></span>
+      <% end %>
 
-  <%= menu.nav_link(hyrax.notifications_path) do %>
-    <span class="fa fa-bell"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.notifications') %></span>
-  <% end %>
+      <%= menu.nav_link(hyrax.notifications_path) do %>
+        <span class="fa fa-bell"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.notifications') %></span>
+      <% end %>
 
-  <%= menu.nav_link(hyrax.transfers_path) do %>
-    <span class="fa fa-arrows-h"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.transfers') %></span>
-  <% end %>
+      <%= menu.nav_link(hyrax.transfers_path) do %>
+        <span class="fa fa-arrows-h"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.transfers') %></span>
+      <% end %>
+    <% end %>
+  </li>
 
   <% if can? :read, :admin_dashboard %>
     <%= menu.nav_link(hyrax.admin_stats_path) do %>
       <span class="fa fa-bar-chart"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.statistics') %></span>
-    <% end %>
-
-    <li class="h5"><%= t('hyrax.admin.sidebar.configuration') %></li>
-    <%= menu.nav_link(hyrax.admin_features_path) do %>
-      <span class="fa fa-cog"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.settings') %></span>
-    <% end %>
-
-    <% if can?(:update, :appearance) %>
-      <%= menu.nav_link(hyrax.admin_appearance_path) do %>
-        <span class="fa fa-paint-brush"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.appearance') %></span>
-      <% end %>
-    <% end %>
-
-    <%= menu.nav_link(hyrax.admin_workflow_roles_path) do %>
-      <span class="fa fa-users"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_roles') %></span>
     <% end %>
   <% end %>
 
@@ -75,6 +67,23 @@
   <% if can? :manage, User %>
     <%= menu.nav_link(hyrax.admin_users_path) do %>
       <span class="fa fa-user"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.users') %></span>
+    <% end %>
+  <% end %>
+
+  <% if can? :read, :admin_dashboard %>
+    <li class="h5"><%= t('hyrax.admin.sidebar.configuration') %></li>
+    <%= menu.nav_link(hyrax.admin_features_path) do %>
+      <span class="fa fa-cog"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.settings') %></span>
+    <% end %>
+
+    <% if can?(:update, :appearance) %>
+      <%= menu.nav_link(hyrax.admin_appearance_path) do %>
+        <span class="fa fa-paint-brush"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.appearance') %></span>
+      <% end %>
+    <% end %>
+
+    <%= menu.nav_link(hyrax.admin_workflow_roles_path) do %>
+      <span class="fa fa-users"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_roles') %></span>
     <% end %>
   <% end %>
 </ul>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -171,6 +171,7 @@ en:
         tasks:              "Tasks"
         transfers:          "Transfers"
         users:              "Manage Users"
+        user_activity:      "Your activity"
         workflow_review:    "Review Submissions"
         workflow_roles:     "Workflow Roles"
         works:              "Works"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -170,6 +170,7 @@ es:
         tasks:              "Tareas"
         transfers:          "Transferencias"
         users:              "Usarios"
+        user_activity:      "Su actividad"
         workflow_review:    "Revise Ofertas"
         workflow_roles:     "Funciones del flujo de trabajo"
         works:              "Trabajos"

--- a/spec/features/proxy_spec.rb
+++ b/spec/features/proxy_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'proxy', type: :feature do
   describe 'add proxy in profile', :js do
     it "creates a proxy" do
       sign_in user
+      click_link "Your activity"
       click_link "Profile"
       click_link "Edit Profile"
       expect(first("td.depositor-name")).to be_nil

--- a/spec/presenters/hyrax/menu_presenter_spec.rb
+++ b/spec/presenters/hyrax/menu_presenter_spec.rb
@@ -16,8 +16,10 @@ RSpec.describe Hyrax::MenuPresenter do
     end
 
     let(:rendered) { Capybara::Node::Simple.new(subject) }
+
     context "when collapsed" do
       let(:open) { false }
+
       it "draws a collapsable section" do
         expect(rendered).to have_content "Some content"
         expect(rendered).to have_selector "span.fa.fa-cog"
@@ -28,12 +30,33 @@ RSpec.describe Hyrax::MenuPresenter do
 
     context "when open" do
       let(:open) { true }
+
       it "draws a collapsable section" do
         expect(rendered).to have_content "Some content"
         expect(rendered).to have_selector "span.fa.fa-cog"
         expect(rendered).to have_selector "a.collapse-toggle[href='#mySection']"
         expect(rendered).to have_selector "ul#mySection.in"
       end
+    end
+  end
+
+  describe "#user_activity_section?" do
+    before do
+      allow(context).to receive(:controller_name).and_return(controller_name)
+      allow(context).to receive(:controller).and_return(controller)
+    end
+    subject { instance.user_activity_section? }
+
+    context "for the Hyrax::UsersController" do
+      let(:controller) { Hyrax::UsersController.new }
+
+      it { is_expected.to be true }
+    end
+
+    context "for the Admin::UsersController" do
+      let(:controller) { Hyrax::Admin::UsersController.new }
+
+      it { is_expected.to be false }
     end
   end
 end


### PR DESCRIPTION
Configuration isn't used much, so the bottom is the best place for it.

<img width="224" alt="screen shot 2017-04-07 at 10 16 40 am" src="https://cloud.githubusercontent.com/assets/92044/24806846/c2f16c8c-1b7b-11e7-9229-83cf4451b39d.png">
