### PR TITLE
Require dependency for hyrax/name

### DIFF
--- a/app/models/concerns/hyrax/naming.rb
+++ b/app/models/concerns/hyrax/naming.rb
@@ -1,4 +1,4 @@
-require 'hyrax/name'
+require_dependency 'hyrax/name'
 module Hyrax
   module Naming
     extend ActiveSupport::Concern


### PR DESCRIPTION
Otherwise code reloading will trigger `uninitialized constant
Hyrax::Name`
