### PR TITLE
Update layout of Workflow Roles page

### DIFF
--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -162,6 +162,16 @@ body.dashboard {
     margin-bottom: 6px;
   }
 
+  .workflow-roles {
+    list-style-type: none;
+    margin-bottom: 0;
+    padding-left: 0;
+
+    .fa-remove {
+      color: $brand-danger;
+    }
+  }
+
   .navbar {
     margin-bottom: 0;
   }
@@ -169,6 +179,7 @@ body.dashboard {
   .panel {
     border: 1px solid $admin-panel-border-color;
     float: left;
+    margin-top: $padding-large-vertical;
     width: 100%;
 
     .panel-heading,

--- a/app/views/hyrax/admin/workflow_roles/index.html.erb
+++ b/app/views/hyrax/admin/workflow_roles/index.html.erb
@@ -1,44 +1,63 @@
-<div class="<%= "dashboard-#{action_name}" %>">
-  <div class="wrapper">
-    <div class="widget widget-default">
-      <table class="table table-striped">
-        <thead>
-          <th><%= t('.header.user') %></th>
-          <th><%= t('.header.roles') %></th>
-        </thead>
-        <tbody>
-        <% @presenter.users.each do |user| %>
-          <tr>
-            <td><%= user.user_key %></td>
-            <% agent_presenter = @presenter.presenter_for(user) %>
-            <% if agent_presenter && agent_presenter.responsibilities_present? %>
-              <td>
-                <ul>
-                  <% agent_presenter.responsibilities do |responsibility_presenter| %>
-                    <li><%= responsibility_presenter.label %>
-                      <%= link_to hyrax.admin_workflow_role_path(responsibility_presenter.responsibility),
-                                  method: :delete,
-                                  data: { confirm: t('.delete.confirm') } do %>
-                        <span class="delete">&times;</span>
-                      <% end %>
-                    </li>
-                  <% end %>
-                </ul>
-              </td>
-            <% else %>
-              <td><%= t('.no_roles') %></td>
-            <% end %>
-          </tr>
-        <% end %>
-        </tbody>
-      </table>
+<% provide :page_header do %>
+  <h1><span class="fa fa-users"></span>  <%= t("hyrax.admin.workflow_roles.header") %></h1>
+<% end %>
 
-      <h2><%= t('.new_role') %></h2>
-      <%= simple_form_for Hyrax::Forms::WorkflowResponsibilityForm.new, url: hyrax.admin_workflow_roles_path do |f| %>
-        <%= f.input :user_id, as: :select, collection: f.object.user_options %>
-        <%= f.input :workflow_role_id, as: :select, collection: f.object.workflow_role_options %>
-        <%= f.submit %>
-      <% end %>
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h2 class="panel-title h2"><%= t('.new_role') %></h2>
+      </div>
+      <div class="panel-body">
+        <%= simple_form_for Hyrax::Forms::WorkflowResponsibilityForm.new, url: hyrax.admin_workflow_roles_path do |f| %>
+          <%= f.input :user_id, as: :select, collection: f.object.user_options %>
+          <%= f.input :workflow_role_id, as: :select, collection: f.object.workflow_role_options %>
+          <%= f.submit class: 'btn btn-sm btn-primary' %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h2 class="panel-title h2"><%= t('.current_roles') %></h3>
+      </div>
+      <div class="panel-body">
+        <table class="table table-striped">
+          <thead>
+            <th><%= t('.header.user') %></th>
+            <th><%= t('.header.roles') %></th>
+          </thead>
+          <tbody>
+          <% @presenter.users.each do |user| %>
+            <tr>
+              <td><%= user.user_key %></td>
+              <% agent_presenter = @presenter.presenter_for(user) %>
+              <% if agent_presenter && agent_presenter.responsibilities_present? %>
+                <td>
+                  <ul class="workflow-roles">
+                    <% agent_presenter.responsibilities do |responsibility_presenter| %>
+                      <li><%= responsibility_presenter.label %>
+                        <%= link_to hyrax.admin_workflow_role_path(responsibility_presenter.responsibility),
+                                    method: :delete,
+                                    data: { confirm: t('.delete.confirm') } do %>
+                          <span class="fa fa-remove"></span>
+                        <% end %>
+                      </li>
+                    <% end %>
+                  </ul>
+                </td>
+              <% else %>
+                <td><%= t('.no_roles') %></td>
+              <% end %>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/hyrax/transfers/index.html.erb
+++ b/app/views/hyrax/transfers/index.html.erb
@@ -6,7 +6,7 @@
   <div class="col-md-12">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h2 class="panel-title h2"><%= t("hyrax.dashboard.transfers_sent") %></h3>
+        <h2 class="panel-title h2"><%= t("hyrax.dashboard.transfers_sent") %></h2>
       </div>
       <div class="panel-body">
         <%= @presenter.render_sent_transfers %>
@@ -19,7 +19,7 @@
   <div class="col-md-12">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h2 class="panel-title h2"><%= t("hyrax.dashboard.transfers_received") %></h3>
+        <h2 class="panel-title h2"><%= t("hyrax.dashboard.transfers_received") %></h2>
       </div>
       <div class="panel-body">
         <%= @presenter.render_received_transfers %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -206,8 +206,9 @@ en:
           header:
             roles:  Roles
             user:   User
-          new_role: "Grant a role to a user:"
+          new_role: "Assign Role"
           no_roles: No roles
+          current_roles: "Current Roles"
       workflows:
         index:
           header: "Review Submissions"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -205,8 +205,9 @@ es:
           header:
             roles: "Roles"
             user: "Usuario"
-          new_role: "Asignar un papel a un usuario:"
+          new_role: "Asignar papel"
           no_roles: "Ningunos roles"
+          current_roles: "Presente papeles"
       workflows:
         index:
           header: "Revise Ofertas"


### PR DESCRIPTION
Fixes #721 

Improves the layout of the Workflow Roles page:

* Adds standard page header
* Moves assign role form to top of page, so it'll be easier to get to when the number of assigned roles becomes long
* Better separates the Assign Role and Current Roles elements
* Improves presentation of the roles currently assigned to a user

I think we can further improve the Assign Role section (e.g., I don't think the required labels are really necessary here and it would be nice for the select menus to display "Select user..." and "Select workflow role..." instead of being blank) but this is probably fine for the time being.

### Before
![before](https://cloud.githubusercontent.com/assets/101482/24822500/80134078-1baa-11e7-9092-1759d7d71f77.png)

### After
![after](https://cloud.githubusercontent.com/assets/101482/24822505/85753d00-1baa-11e7-8762-ea2769f491bb.png)
