### PR TITLE
Replacing ordered parameters with named parameters

### DIFF
--- a/app/presenters/hyrax/presenter_factory.rb
+++ b/app/presenters/hyrax/presenter_factory.rb
@@ -1,21 +1,43 @@
 module Hyrax
+  # Responsible building an Array of presenters based on IDs and presenter class given
+  # @todo Extract a SolrDocument finder class that takes a list of pids and returns/yields a ::SolrDocument for each hit in SOLR.
+  # @note The given IDs are loaded from SOLR
   class PresenterFactory
     class << self
+      # @todo Convert to find and yield only the found SOLR documents. There is a coupling of knowledge regarding the building of the presenter class and its parameters.
+      # @todo We are looping through SOLR docs three times; Can this be compressed into a single loop
+      #
+      # @param [Array] ids the list of ids to load
+      # @param [Class] presenter_class the class of presenter to make
+      # @param [Array] presenter_args any other arguments to pass to the presenters
+      # @return [Array] presenters for the documents in order of the ids (as given)
+      def build_for(ids:, presenter_class:, presenter_args: [])
+        new(ids: ids, presenter_class: presenter_class, presenter_args: presenter_args).build
+      end
+
+      # @deprecated use .build_for instead
       # @param [Array] ids the list of ids to load
       # @param [Class] klass the class of presenter to make
       # @param [Array] args any other arguments to pass to the presenters
       # @return [Array] presenters for the documents in order of the ids
       def build_presenters(ids, klass, *args)
-        new(ids, klass, *args).build
+        Deprecation.warn(to_s,
+                         Deprecation.deprecated_method_warning(to_s,
+                                                               :build_presenters,
+                                                               "use .build_for instead"))
+        build_for(ids: ids, presenter_class: klass, presenter_args: args)
       end
     end
 
-    attr_reader :ids, :klass, :args
+    attr_reader :ids, :presenter_class, :presenter_args
+    alias klass presenter_class
+    deprecation_deprecate klass: "use #presenter_class instead"
 
-    def initialize(ids, klass, *args)
+    def initialize(ids:, presenter_class:, presenter_args:)
       @ids = ids
-      @klass = klass
-      @args = args
+      @presenter_class = presenter_class
+      # In moving from splat args to named parameters, passing the parameters is a bit off.
+      @presenter_args = presenter_args.nil? ? [nil] : presenter_args
     end
 
     def build
@@ -23,7 +45,7 @@ module Hyrax
       docs = load_docs
       ids.map do |id|
         solr_doc = docs.find { |doc| doc.id == id }
-        klass.new(solr_doc, *args) if solr_doc
+        presenter_class.new(solr_doc, *presenter_args) if solr_doc
       end.compact
     end
 

--- a/spec/presenters/hyrax/presenter_factory_spec.rb
+++ b/spec/presenters/hyrax/presenter_factory_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Hyrax::PresenterFactory do
-  describe "#build_presenters" do
+  describe "#build_for" do
     let(:presenter_class) { Hyrax::FileSetPresenter }
 
     before do
@@ -10,7 +10,7 @@ RSpec.describe Hyrax::PresenterFactory do
         .and_return('response' => { 'docs' => results })
     end
 
-    subject { described_class.build_presenters(['12', '13'], presenter_class, nil) }
+    subject { described_class.build_for(ids: ['12', '13'], presenter_class: presenter_class, presenter_args: nil) }
 
     context "when some ids are found in solr" do
       let(:results) { [{ "id" => "12" }, { "id" => "13" }] }
@@ -38,10 +38,9 @@ RSpec.describe Hyrax::PresenterFactory do
       end
       let(:results) { [{ "id" => "12" }, { "id" => "13" }] }
       subject do
-        described_class.build_presenters(['12', '13'],
-                                         presenter_class,
-                                         'more',
-                                         'and more')
+        described_class.build_for(ids: ['12', '13'],
+                                  presenter_class: presenter_class,
+                                  presenter_args: ['more', 'and more'])
       end
       it 'passes all the arguments' do
         expect(subject.first.two).to eq 'more'


### PR DESCRIPTION
## Replacing ordered parameters with named parameters

@cbffa6d3757b9c20cffc846900853788bd947155

Given that the first parameter (e.g. `ids`) is an Array, I can see it
being rather easy to instead pass `build_presenters('1', '2', '3')`
which in turn would mean `ids == '1'`, `klass == '2'`, and `args == '3'`

By shifting to named parameters, I hope this clears up the likelihood
of that confusion and unexpected behavior.

@projecthydra-labs/hyrax-code-reviewers
