### PR TITLE
Extract show_configuration? to a presenter

### DIFF
--- a/app/presenters/hyrax/menu_presenter.rb
+++ b/app/presenters/hyrax/menu_presenter.rb
@@ -8,7 +8,7 @@ module Hyrax
     attr_reader :view_context
 
     delegate :controller, :controller_name, :action_name, :content_tag,
-             :current_page?, :link_to, to: :view_context
+             :current_page?, :link_to, :can?, to: :view_context
 
     # @param options [Hash, String] a hash or string representing the path. Hash is prefered as it
     #                              allows us to workaround https://github.com/rails/rails/issues/28253
@@ -43,6 +43,13 @@ module Hyrax
                                       id: id,
                                       icon_class: icon_class,
                                       open: open).render(&block)
+    end
+
+    # @return [Boolean] will the configuration section be displayed to the user
+    def show_configuration?
+      can?(:update, :appearance) ||
+        can?(:manage, Sipity::WorkflowResponsibility) ||
+        can?(:read, :admin_dashboard)
     end
   end
 end

--- a/app/views/hyrax/dashboard/_sidebar.html.erb
+++ b/app/views/hyrax/dashboard/_sidebar.html.erb
@@ -70,7 +70,7 @@
     <% end %>
   <% end %>
 
-  <% if can? :read, :admin_dashboard %>
+  <% if menu.show_configuration? %>
     <li class="h5"><%= t('hyrax.admin.sidebar.configuration') %></li>
     <%= menu.nav_link(hyrax.admin_features_path) do %>
       <span class="fa fa-cog"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.settings') %></span>
@@ -85,5 +85,5 @@
     <%= menu.nav_link(hyrax.admin_workflow_roles_path) do %>
       <span class="fa fa-users"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_roles') %></span>
     <% end %>
-  <% end %>
+  <% end # end of configuration block %>
 </ul>

--- a/spec/presenters/hyrax/menu_presenter_spec.rb
+++ b/spec/presenters/hyrax/menu_presenter_spec.rb
@@ -59,4 +59,22 @@ RSpec.describe Hyrax::MenuPresenter do
       it { is_expected.to be false }
     end
   end
+
+  describe "#show_configuration?" do
+    subject { instance.show_configuration? }
+
+    context "for a regular user" do
+      before do
+        allow(instance.view_context).to receive(:can?).and_return(false)
+      end
+      it { is_expected.to be false }
+    end
+
+    context "for a user who can manage users" do
+      before do
+        allow(instance.view_context).to receive(:can?).and_return(true)
+      end
+      it { is_expected.to be true }
+    end
+  end
 end


### PR DESCRIPTION
Added the MenuPresenter#show_configuration? to the presenter so we can
customize the presenter rather than the view template to change behavior

Ref https://github.com/projecthydra-labs/hyku/issues/930