### PR TITLE
Rename AddAsMemberOfCollectionsActor to CollectionsMembershipActor

### DIFF
--- a/app/actors/hyrax/actors/collections_membership_actor.rb
+++ b/app/actors/hyrax/actors/collections_membership_actor.rb
@@ -1,20 +1,21 @@
 module Hyrax
   module Actors
-    class AddAsMemberOfCollectionsActor < AbstractActor
+    # Adds membership to and removes membership from collections
+    class CollectionsMembershipActor < AbstractActor
       def create(attributes)
         collection_ids = attributes.delete(:member_of_collection_ids)
-        add_to_collections(collection_ids) && next_actor.create(attributes)
+        assign_collections(collection_ids) && next_actor.create(attributes)
       end
 
       def update(attributes)
         collection_ids = attributes.delete(:member_of_collection_ids)
-        add_to_collections(collection_ids) && next_actor.update(attributes)
+        assign_collections(collection_ids) && next_actor.update(attributes)
       end
 
       private
 
-        # Maps from collection ids to collection objects
-        def add_to_collections(collection_ids)
+        # Maps from collection ids to collection objects.
+        def assign_collections(collection_ids)
           return true unless collection_ids
           # grab/save collections this user has no edit access to
           other_collections = curation_concern.member_of_collections.select { |coll| ability.cannot?(:edit, coll) }

--- a/app/services/hyrax/actor_factory.rb
+++ b/app/services/hyrax/actor_factory.rb
@@ -6,7 +6,7 @@ module Hyrax
        Hyrax::Actors::OptimisticLockValidator,
        Hyrax::Actors::CreateWithRemoteFilesActor,
        Hyrax::Actors::CreateWithFilesActor,
-       Hyrax::Actors::AddAsMemberOfCollectionsActor,
+       Hyrax::Actors::CollectionsMembershipActor,
        Hyrax::Actors::AddToWorkActor,
        Hyrax::Actors::AssignRepresentativeActor,
        Hyrax::Actors::AttachFilesActor,

--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -1,26 +1,28 @@
 require 'spec_helper'
 
-RSpec.describe Hyrax::Actors::AddAsMemberOfCollectionsActor do
+RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
   let(:user) { create(:user) }
   let(:ability) { ::Ability.new(user) }
   let(:curation_concern) { GenericWork.new }
   let(:attributes) { {} }
+
   subject do
     Hyrax::Actors::ActorStack.new(curation_concern,
                                   ability,
                                   [described_class,
                                    Hyrax::Actors::GenericWorkActor])
   end
+
   describe 'the next actor' do
     let(:root_actor) { double }
+    let(:attributes) do
+      { member_of_collection_ids: ['123'], title: ['test'] }
+    end
+
     before do
       allow(Hyrax::Actors::RootActor).to receive(:new).and_return(root_actor)
       allow(Collection).to receive(:find).with(['123'])
       allow(curation_concern).to receive(:member_of_collections=)
-    end
-
-    let(:attributes) do
-      { member_of_collection_ids: ['123'], title: ['test'] }
     end
 
     it 'does not receive the member_of_collection_ids' do

--- a/spec/services/hyrax/actor_factory_spec.rb
+++ b/spec/services/hyrax/actor_factory_spec.rb
@@ -4,12 +4,13 @@ RSpec.describe Hyrax::ActorFactory, :no_clean do
 
   describe '.stack_actors' do
     subject { described_class.stack_actors(work) }
+
     it do
       is_expected.to eq [Hyrax::Actors::TransactionalRequest,
                          Hyrax::Actors::OptimisticLockValidator,
                          Hyrax::Actors::CreateWithRemoteFilesActor,
                          Hyrax::Actors::CreateWithFilesActor,
-                         Hyrax::Actors::AddAsMemberOfCollectionsActor,
+                         Hyrax::Actors::CollectionsMembershipActor,
                          Hyrax::Actors::AddToWorkActor,
                          Hyrax::Actors::AssignRepresentativeActor,
                          Hyrax::Actors::AttachFilesActor,
@@ -25,12 +26,13 @@ RSpec.describe Hyrax::ActorFactory, :no_clean do
 
   describe '.build' do
     subject { described_class.build(work, user) }
+
     it "has the correct stack frames" do
       expect(subject.more_actors).to eq [
         Hyrax::Actors::OptimisticLockValidator,
         Hyrax::Actors::CreateWithRemoteFilesActor,
         Hyrax::Actors::CreateWithFilesActor,
-        Hyrax::Actors::AddAsMemberOfCollectionsActor,
+        Hyrax::Actors::CollectionsMembershipActor,
         Hyrax::Actors::AddToWorkActor,
         Hyrax::Actors::AssignRepresentativeActor,
         Hyrax::Actors::AttachFilesActor,


### PR DESCRIPTION
This new name is more appropriate because the actor also removes access
from collections.
