### PR TITLE
Create the permission template if it doesn't exist

### DIFF
--- a/app/forms/hyrax/forms/admin_set_form.rb
+++ b/app/forms/hyrax/forms/admin_set_form.rb
@@ -17,7 +17,7 @@ module Hyrax
 
       def permission_template
         @permission_template ||= begin
-                                   template_model = PermissionTemplate.find_by!(admin_set_id: model.id)
+                                   template_model = PermissionTemplate.find_or_create_by(admin_set_id: model.id)
                                    PermissionTemplateForm.new(template_model)
                                  end
       end

--- a/spec/forms/hyrax/forms/admin_set_form_spec.rb
+++ b/spec/forms/hyrax/forms/admin_set_form_spec.rb
@@ -9,6 +9,26 @@ RSpec.describe Hyrax::Forms::AdminSetForm do
     end
   end
 
+  describe "#permission_template" do
+    subject { form.permission_template }
+    context "when the PermissionTemplate doesn't exist" do
+      let(:model) { create(:admin_set) }
+      it "gets created" do
+        expect(subject).to be_instance_of Hyrax::Forms::PermissionTemplateForm
+        expect(subject.model).to be_instance_of Hyrax::PermissionTemplate
+      end
+    end
+
+    context "when the PermissionTemplate exists" do
+      let(:permission_template) { Hyrax::PermissionTemplate.find_by(admin_set_id: model.id) }
+      let(:model) { create(:admin_set, with_permission_template: true) }
+      it "uses the existing template" do
+        expect(subject).to be_instance_of Hyrax::Forms::PermissionTemplateForm
+        expect(subject.model).to eq permission_template
+      end
+    end
+  end
+
   describe "model_attributes" do
     let(:raw_attrs) { ActionController::Parameters.new(title: 'test title') }
     subject { described_class.model_attributes(raw_attrs) }


### PR DESCRIPTION
This may happen if you dump your database, but still have date in your
Fedora instance.
