### PR TITLE
Make sidebar a bit wider when maximized

### DIFF
--- a/app/assets/stylesheets/hyrax/sidebar.scss
+++ b/app/assets/stylesheets/hyrax/sidebar.scss
@@ -1,5 +1,5 @@
 $drawer-small: 40px;
-$drawer-large: 200px;
+$drawer-large: 260px;
 $gutter-width: $grid-gutter-width/2;
 
 .main-content {
@@ -35,6 +35,10 @@ $gutter-width: $grid-gutter-width/2;
     .sidebar-toggle {
       transform: rotate(-180deg);
     }
+
+    .nav-pills > li > a {
+      padding-left: 24px;
+    }
   }
 
   .sidebar-toggle {
@@ -64,7 +68,7 @@ $gutter-width: $grid-gutter-width/2;
     opacity: 0;
     font-size: 12px;
     margin: 15px 0 0 0;
-    padding: 10px 10px 5px 10px;
+    padding: 10px 10px 5px 20px;
     text-transform: uppercase;
   }
 
@@ -115,14 +119,6 @@ $gutter-width: $grid-gutter-width/2;
   }
 
   // submenu items
-  &.maximized ul.collapse > li > a {
-    // only indent when the drawer is maximized
-    padding-left: 25px;
-  }
-  ul.collapsing > li > a {
-    padding-left: 25px;
-  }
-
   .collapse-toggle {
     margin-bottom: 0;
 


### PR DESCRIPTION
The updated sidebar feels a bit cramped, with little whitespace on the left and right margins. Given that the user now has the option of collapsing the sidebar to maximize the main content area, I think we can widen the sidebar a bit to provide some breathing room and improve the visual appearance of the sidebar.

The collapsed version of the sidebar is not affected.

### Before
![before](https://cloud.githubusercontent.com/assets/101482/24929902/788905e4-1ebc-11e7-8e9f-fa3ecafae93b.png)

### After
![after](https://cloud.githubusercontent.com/assets/101482/24929915/7df02332-1ebc-11e7-8607-51c6799d5ccf.png)

### After - expanded section
![after-expanded](https://cloud.githubusercontent.com/assets/101482/24929945/989b0990-1ebc-11e7-9574-7926166b6e26.png)

### After - collapsed sidebar
![after-collapsed](https://cloud.githubusercontent.com/assets/101482/24929957/a2fadd8e-1ebc-11e7-93cb-a02540bb5e28.png)

