### PR TITLE
Refactoring authorityselect to rely on data attributes in markup

### DIFF
--- a/app/assets/javascripts/hyrax/app.js
+++ b/app/assets/javascripts/hyrax/app.js
@@ -15,6 +15,7 @@ Hyrax = {
         this.adminStatisticsGraphs();
         this.tinyMCE();
         this.sidebar();
+        this.authoritySelect();
     },
 
     // Add WYSIWYG editor functionality to editable content blocks
@@ -133,14 +134,16 @@ Hyrax = {
         var FileManager = require('hyrax/file_manager');
         new FileManager();
     },
-
     // Used when you have a linked data field that can have terms from multiple
     // authorities.
     // TODO: should be moved to the editor()
-    authoritySelect: function(options) {
+    
+    authoritySelect: function() {
 	var AuthoritySelect = require('hyrax/authority_select');
-	var authoritySelect = new AuthoritySelect(options);
-	authoritySelect.initialize();
+        $("[data-authority-select]").each(function() {
+            var authoritySelect = $(this).data().authoritySelect
+            new AuthoritySelect({selectBox: 'select.' + authoritySelect, inputField: 'input.' + authoritySelect});
+        })
     },
 
     // Saved so that inline javascript can put data somewhere.

--- a/app/assets/javascripts/hyrax/authority_select.es6
+++ b/app/assets/javascripts/hyrax/authority_select.es6
@@ -5,58 +5,51 @@ export default class AuthoritySelect {
      * @param {string} selectBox - The selector for the select box
      * @param {string} inputField - The selector for the input field
      */
-    constructor(options) {
-	this.selectBox = options.selectBox;
-	this.inputField = options.inputField;
-    }
+  constructor (options) {
+    this.selectBox = options.selectBox
+    this.inputField = options.inputField
+    this.selectBoxChange()
+    this.observeAddedElement()
+    setupAutocomplete()
+  }
 
     /**
      * Bind behavior for select box
      */
-    selectBoxChange() {
-	var selectBox = this.selectBox;
-	var inputField = this.inputField;
-	
-	$(selectBox).on('change', function (data) {
-	    var selectBoxValue = $(this).val();
-	    $(inputField).each(function (data) { $(this).data('autocomplete-url', selectBoxValue);
-						 
-					       });
-	    setupAutocomplete();
-	});
-    }
+  selectBoxChange () {
+    var selectBox = this.selectBox
+    var inputField = this.inputField
+
+    $(selectBox).on('change', function (data) {
+	    var selectBoxValue = $(this).val()
+	    $(inputField).each(function (data) {
+      $(this).data('autocomplete-url', selectBoxValue)
+					       })
+	    setupAutocomplete()
+    })
+  }
     /**
      * Create an observer to watch for added input elements
      */
-    observeAddedElement() {
-	var selectBox = this.selectBox;
-	var inputField = this.inputField;
-	
-	
-	var observer = new MutationObserver(function (mutations) {
+  observeAddedElement () {
+    var selectBox = this.selectBox
+    var inputField = this.inputField
+
+    var observer = new MutationObserver(function (mutations) {
 	    mutations.forEach(function (mutation) {
-		$(inputField).each(function (data) { $(this).data('autocomplete-url', $(selectBox).val()) });
-		setupAutocomplete();
-	    });
-	});
+      $(inputField).each(function (data) { $(this).data('autocomplete-url', $(selectBox).val()) })
+      setupAutocomplete()
+	    })
+    })
 
-	var config = { childList: true };
-	observer.observe(document.body, config);
-    }
-
-    /**
-     * Initialize bindings
-     */
-    initialize() {
-	this.selectBoxChange();
-	this.observeAddedElement();
-	setupAutocomplete();
-    }
+    var config = { childList: true }
+    observer.observe(document.body, config)
+  }
 }
 
 /**
  * intialize the Hyrax autocomplete with the fields that you are using
  */
-function setupAutocomplete() {
+function setupAutocomplete () {
   Hyrax.autocomplete()
 };

--- a/spec/javascripts/authority_select_spec.js
+++ b/spec/javascripts/authority_select_spec.js
@@ -2,14 +2,14 @@ describe('authority select', () => {
     beforeEach(() =>  {
 	setFixtures(`
 <input class="string multi_value required form-control generic_work_creator form-control multi-text-field ui-autocomplete-input" data-autocomplete-url="/authorities/search/loc/names" data-autocomplete="creator" required="required" aria-required="true" name="generic_work[creator][]" value="" id="generic_work_creator" aria-labelledby="generic_work_creator_label" type="text" autocomplete="off">
-<select class="form-control select required" required="required" aria-required="Select an authority" name="generic_work[creator]" id="generic_work_creator"><option value="/authorities/search/loc/names">LOC Names</option>
+<select class="form-control select required generic_work_creator" data-authority-select="generic_work_creator" required="required" aria-required="Select an authority" name="generic_work[creator]" id="generic_work_creator"><option value="/authorities/search/loc/names">LOC Names</option>
 <option value="/authorities/search/assign_fast/all">FAST</option></select>
 `)
     })
     
     it('should change the data-autocomplete-url when you select an authority', () => {
-	Hyrax.authoritySelect({ selectBox : "select#generic_work_creator", inputField : "input.generic_work_creator" })
-	$('select#generic_work_creator').val('/authorities/search/assign_fast/all').change()
+        Hyrax.authoritySelect()
+	$('select.generic_work_creator').val('/authorities/search/assign_fast/all').change()
 	expect($('input.generic_work_creator').data('autocomplete-url')).toEqual('/authorities/search/assign_fast/all')
     })
 })


### PR DESCRIPTION
This refactors authority select so that it uses data attributes in markup instead of requiring you 
to initialize the class with selectors. 


@projecthydra-labs/hyrax-code-reviewers
