### PR TITLE
Don't use a grid inside a list

### DIFF
--- a/app/assets/stylesheets/hyrax/_catalog.scss
+++ b/app/assets/stylesheets/hyrax/_catalog.scss
@@ -9,3 +9,14 @@
     width: 100%;
   }
 }
+
+.document {
+  .list-thumbnail {
+    width: 30%;
+    float: left;
+  }
+  .metadata {
+    width: 70%;
+    display: inline-block;
+  }
+}

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,5 +1,3 @@
 <li id="document_<%= document.to_param %>" class="document <%= render_document_class document %>" itemscope itemtype="<%= document.itemtype %>">
-  <div class="row">
-    <%= render_document_partials document, blacklight_config.view_config(document_index_view_type).partials, document_counter: document_counter %>
-  </div>
+  <%= render_document_partials document, blacklight_config.view_config(document_index_view_type).partials, document_counter: document_counter %>
 </li>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,4 +1,4 @@
-    <div class="col-sm-9">
+    <div class="metadata">
       <table class="table">
         <% doc_presenter = index_presenter(document) %>
         <% index_fields(document).each do |field_name, field| -%>
@@ -12,3 +12,4 @@
       </table>
     </div>
 
+    <div class="clearfix"></div>

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,4 +1,3 @@
-    <div class="col-sm-3">
+    <div class="list-thumbnail">
       <%= render_thumbnail_tag document %>
     </div>
-


### PR DESCRIPTION
The floats don't work well with a list and cause the numbers to be on
the preceeding line.
Before
<img width="826" alt="screen shot 2017-04-13 at 1 13 24 pm" src="https://cloud.githubusercontent.com/assets/92044/25020062/a3fef458-2052-11e7-881d-40ea4e0143a7.png">

After
<img width="867" alt="screen shot 2017-04-13 at 2 05 49 pm" src="https://cloud.githubusercontent.com/assets/92044/25020067/a822d284-2052-11e7-8111-a7b3fafc7360.png">

