### PR TITLE
Fix issue where clientside JS required an embargo while AdminSet specified "no delay".

### DIFF
--- a/app/assets/javascripts/hyrax/save_work/visibility_component.es6
+++ b/app/assets/javascripts/hyrax/save_work/visibility_component.es6
@@ -55,14 +55,16 @@ export default class VisibilityComponent {
   restrictToVisibility(data) {
     // visibility requirement is in HTML5 'data-visibility' attr
     let visibility = data['visibility']
+    // if immediate release required, then 'data-release-no-delay' attr will be true
+    let release_no_delay = data['releaseNoDelay']
     // release date requirement is in HTML5 'data-release-date' attr
     let release_date = data['releaseDate']
     // if release_date is flexible (i.e. before date), then 'data-release-before-date' attr will be true
     let release_before = data['releaseBeforeDate']
 
-    // Restrictions require either a visibility requirement or a release_date requirement (or both)
-    if(visibility || release_date) {
-      this.applyRestrictions(visibility, release_date, release_before)
+    // Restrictions require either a visibility requirement or a date requirement (or both)
+    if(visibility || release_no_delay || release_date) {
+      this.applyRestrictions(visibility, release_no_delay, release_date, release_before)
     }
     else {
       this.enableAllOptions()
@@ -70,14 +72,14 @@ export default class VisibilityComponent {
   }
 
   // Apply visibility/release restrictions based on selected AdminSet
-  applyRestrictions(visibility, release_date, release_before)
+  applyRestrictions(visibility, release_no_delay, release_date, release_before)
   {
      // If immediate release required and visibility specified
-     if(this.isToday(release_date) && visibility) {
+     if(release_no_delay && visibility) {
        // Select required visibility
        this.selectVisibility(visibility)
      }
-     else if(this.isToday(release_date)) {
+     else if(release_no_delay) {
        // No visibility required, but must be released today. Disable embargo & lease.
        this.disableEmbargoAndLease();
      }
@@ -266,12 +268,5 @@ export default class VisibilityComponent {
       mm = '0' + mm
     }
     return yyyy + '-' + mm + '-' + dd
-  }
-
-  // Return true if datestring represents today's date
-  isToday(dateString) {
-    let today = new Date(this.getToday())
-    let date =  new Date(dateString)
-    return date.getTime() === today.getTime()
   }
 }

--- a/app/presenters/hyrax/admin_set_options_presenter.rb
+++ b/app/presenters/hyrax/admin_set_options_presenter.rb
@@ -30,7 +30,12 @@ module Hyrax
       def attributes_for(permission_template:)
         {}.tap do |attrs|
           attrs['data-sharing'] = sharing?(permission_template: permission_template)
-          attrs['data-release-date'] = permission_template.release_date if permission_template.release_date.present?
+          # Either add "no-delay" (if immediate release) or a specific release date, but not both.
+          if permission_template.release_no_delay?
+            attrs['data-release-no-delay'] = true
+          elsif permission_template.release_date.present?
+            attrs['data-release-date'] = permission_template.release_date
+          end
           attrs['data-release-before-date'] = true if permission_template.release_before_date?
           attrs['data-visibility'] = permission_template.visibility if permission_template.visibility.present?
         end

--- a/spec/javascripts/visibility_component_spec.js
+++ b/spec/javascripts/visibility_component_spec.js
@@ -45,33 +45,33 @@ describe("VisibilityComponent", function() {
       });
       it("calls applyRestrictions with specified visibility", function() {
         target.limitByAdminSet();
-        expect(target.applyRestrictions).toHaveBeenCalledWith('authenticated', undefined, undefined);
+        expect(target.applyRestrictions).toHaveBeenCalledWith('authenticated', undefined, undefined, undefined);
       });
     });
     describe("with selected admin set having release immediately restrictions (no visibility)", function() {
       beforeEach(function() {
-        var fixture = setFixtures(visibilityForm('<option data-release-date="' + target.getToday() + '" data-release-before-date="false" selected="selected">Release Immediately AdminSet</option>'));
+        var fixture = setFixtures(visibilityForm('<option data-release-no-delay="true" selected="selected">Release Immediately AdminSet</option>'));
         element = fixture.find('.visibility');
         admin_set = new AdminSetWidget(fixture.find('select'))
         target = new VisibilityComponent(element, admin_set);
         spyOn(target, 'applyRestrictions');
       });
-      it("calls applyRestrictions with specified date requirement", function() {
+      it("calls applyRestrictions with release_no_delay=true", function() {
         target.limitByAdminSet();
-        expect(target.applyRestrictions).toHaveBeenCalledWith(undefined, target.getToday(), false);
+        expect(target.applyRestrictions).toHaveBeenCalledWith(undefined, true, undefined, undefined);
       });
     });
     describe("with selected admin set having release publicly immediately restrictions", function() {
       beforeEach(function() {
-        var fixture = setFixtures(visibilityForm('<option data-visibility="open" data-release-date="' + target.getToday() + '" data-release-before-date="false" selected="selected">Release Publicly Immediately AdminSet</option>'));
+        var fixture = setFixtures(visibilityForm('<option data-visibility="open" data-release-no-delay="true" selected="selected">Release Publicly Immediately AdminSet</option>'));
         element = fixture.find('.visibility');
         admin_set = new AdminSetWidget(fixture.find('select'))
         target = new VisibilityComponent(element, admin_set);
         spyOn(target, 'applyRestrictions');
       });
-      it("calls applyRestrictions with specified date and visibility requirement", function() {
+      it("calls applyRestrictions with release_no_delay=true and visibility requirement", function() {
         target.limitByAdminSet();
-        expect(target.applyRestrictions).toHaveBeenCalledWith("open", target.getToday(), false);
+        expect(target.applyRestrictions).toHaveBeenCalledWith("open", true, undefined, undefined);
       });
     });
     describe("with selected admin set having release on future date set", function() {
@@ -84,7 +84,7 @@ describe("VisibilityComponent", function() {
       });
       it("calls applyRestrictions with specified date requirement", function() {
         target.limitByAdminSet();
-        expect(target.applyRestrictions).toHaveBeenCalledWith(undefined, getOneYearFromToday(), false);
+        expect(target.applyRestrictions).toHaveBeenCalledWith(undefined, undefined, getOneYearFromToday(), false);
       });
     });
     describe("with selected admin set having release to institution before one year set", function() {
@@ -97,7 +97,7 @@ describe("VisibilityComponent", function() {
       });
       it("calls applyRestrictions with specified date and visibility requirement", function() {
         target.limitByAdminSet();
-        expect(target.applyRestrictions).toHaveBeenCalledWith("authenticated", getOneYearFromToday(), true);
+        expect(target.applyRestrictions).toHaveBeenCalledWith("authenticated", undefined, getOneYearFromToday(), true);
       });
     });
   });
@@ -109,7 +109,7 @@ describe("VisibilityComponent", function() {
         spyOn(target, 'enableReleaseNowOrEmbargo');
       });
       it("enable that visibility option OR embargo, and limit embargo to any future date", function() {
-        target.applyRestrictions("authenticated", undefined, undefined);
+        target.applyRestrictions("authenticated", undefined, undefined, undefined);
         expect(target.enableReleaseNowOrEmbargo).toHaveBeenCalledWith("authenticated", undefined, undefined);
       });
     });
@@ -118,7 +118,7 @@ describe("VisibilityComponent", function() {
         spyOn(target, 'disableEmbargoAndLease');
       });
       it("disables embargo and lease options", function() {
-        target.applyRestrictions(undefined, target.getToday(), false);
+        target.applyRestrictions(undefined, true, undefined, undefined);
         expect(target.disableEmbargoAndLease).toHaveBeenCalled();
       });
     });
@@ -127,7 +127,7 @@ describe("VisibilityComponent", function() {
         spyOn(target, 'selectVisibility');
       });
       it("selects that visibility (disabling other options)", function() {
-        target.applyRestrictions("open", target.getToday(), false);
+        target.applyRestrictions("open", true, undefined, undefined);
         expect(target.selectVisibility).toHaveBeenCalledWith("open");
       });
     });
@@ -137,7 +137,7 @@ describe("VisibilityComponent", function() {
       });
       it("allows any date between now and future date", function() {
         var futureDate = getOneYearFromToday();
-        target.applyRestrictions("open", futureDate, true);
+        target.applyRestrictions("open", undefined, futureDate, true);
         expect(target.enableReleaseNowOrEmbargo).toHaveBeenCalledWith("open", futureDate, true);
       });
     });
@@ -147,7 +147,7 @@ describe("VisibilityComponent", function() {
       });
       it("require embargo until release_date and don't restrict visibility", function() {
         var futureDate = getOneYearFromToday();
-        target.applyRestrictions(undefined, futureDate, false);
+        target.applyRestrictions(undefined, undefined, futureDate, false);
         expect(target.requireEmbargo).toHaveBeenCalledWith(undefined, futureDate);
       });
     });
@@ -157,7 +157,7 @@ describe("VisibilityComponent", function() {
       });
       it("require embargo until release_date and require visibility", function() {
         var futureDate = getOneYearFromToday();
-        target.applyRestrictions("authenticated", futureDate, false);
+        target.applyRestrictions("authenticated", undefined, futureDate, false);
         expect(target.requireEmbargo).toHaveBeenCalledWith("authenticated", futureDate);
       });
     });
@@ -406,25 +406,6 @@ describe("VisibilityComponent", function() {
   describe("getVisibilityAfterEmbargoInput", function() {
     it("returns visibility after embargo selectbox", function() {
       expect(target.getVisibilityAfterEmbargoInput()).toHaveProp("name", "generic_work[visibility_after_embargo]");
-    });
-  });
-
-  // isToday(dateString)
-  describe("isToday", function() {
-    describe("with today's date", function() {
-      it("is true", function() {
-        expect(target.isToday(target.getToday())).toEqual(true);
-      });
-    });
-    describe("with past date", function() {
-      it("is false", function() {
-        expect(target.isToday("2016-12-31")).toEqual(false);
-      });
-    });
-    describe("with future date", function() {
-      it("is false", function() {
-        expect(target.isToday(getOneYearFromToday())).toEqual(false);
-      });
     });
   });
 });

--- a/spec/presenters/hyrax/admin_set_options_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_options_presenter_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Hyrax::AdminSetOptionsPresenter do
 
       it do
         is_expected.to eq [['Fixed Release Date Set', '123', { 'data-sharing' => false, 'data-release-date' => today + 2.days }],
-                           ['No Delay Set', '345', { 'data-sharing' => false, 'data-release-date' => today }],
+                           ['No Delay Set', '345', { 'data-sharing' => false, 'data-release-no-delay' => true }],
                            ['One Year Max Embargo Set', '567', { 'data-sharing' => false, 'data-release-date' => today + 1.year, 'data-release-before-date' => true }],
                            ['Release Before Date Set', '789', { 'data-sharing' => false, 'data-release-date' => today + 1.month, 'data-release-before-date' => true }]]
       end


### PR DESCRIPTION
Fixes projecthydra-labs/hyku#971. 

When selecting an AdminSet with Release="no delay", the server side code and client side code performed separate date calculations for today's date. In the situation where the server and client are in different timezones, this calculation would occasionally result in different dates for "today". This resulted in the odd behavior noted in projecthydra-labs/hyku#971 when an embargo was the only option even though the selected AdminSet specified Release="no delay"

This PR fixes this behavior by removing the client side calculations for today's date when Release="no delay". Instead, a new `data-release-no-delay=true` HTML5 attribute is used to identify if an AdminSet requires immediate release (and client side code has been updated to use that). I've also updated the existing RSpec and Jasmine tests to validate these code changes.

@projecthydra-labs/hyrax-code-reviewers
