### PR TITLE
Improve styling of Admin Set index page when no admin sets exist

### DIFF
--- a/app/assets/stylesheets/hyrax/dashboard.scss
+++ b/app/assets/stylesheets/hyrax/dashboard.scss
@@ -91,12 +91,13 @@ body.dashboard {
       font-size: $font-size-h2;
       margin-left: $padding-xs-horizontal;
       margin-top: $padding-base-vertical;
+
+      .fa {
+        color: $gray;
+        margin-right: $padding-xs-horizontal;
+      }
     }
 
-    .fa {
-      color: $gray;
-      margin-right: $padding-xs-horizontal;
-    }
 
     .btn {
       margin-bottom: $padding-base-vertical;

--- a/app/views/hyrax/admin/admin_sets/index.html.erb
+++ b/app/views/hyrax/admin/admin_sets/index.html.erb
@@ -34,9 +34,6 @@
       </div>
       <% else %>
         <p>No administrative sets have been created.</p>
-        <%= link_to hyrax.new_admin_admin_set_path, class: 'btn btn-primary' do %>
-          <span class="fa fa-edit"></span> <%= t(:'helpers.action.admin_set.new') %>
-        <% end %>
       <% end %>
   </div>
 </div>


### PR DESCRIPTION
Currently when you have a repository with no admin sets you see two identical buttons (in close proximity) for creating a new admin set. I don't think duplicate buttons are necessary so this PR removes one of the buttons. It also makes a minor adjustment to the CSS so that icons in the page header are only made dark when part of the page title (so they will now be visible in buttons in the header).

(@hannahfrost @mjgiarlo: Not critical for this PR but I feel that ideally the scenario in this screenshot should never happen. Since at least one admin set is required for the repository and other actions are dependent on there being an admin set (e.g., depositing a work), couldn't we include a default admin set when creating new repository? The administrator would likely want to edit it to provide a better name than "Default Administrative Set" and maybe adjust its settings, but wouldn't doing that (along with including a prominent suggestion for editing the default admin set in whatever getting started documentation we produce) be better than creating a new repo that is missing a fundamental component? Maybe this has been discussed already and/or there is a good reason not to include a admin set by default, but I thought I'd mention it here just in case.)

### Before
![index_admin_set____hyrax](https://cloud.githubusercontent.com/assets/101482/25298536/9650fc62-26aa-11e7-80ba-afbdc841d6bd.png)

### After
![index_admin_set____hyrax](https://cloud.githubusercontent.com/assets/101482/25298551/bce0c4d4-26aa-11e7-9d03-22b0bcf45743.png)

