### PR TITLE
Improve styling of Admin Set show page

### DIFF
--- a/app/views/hyrax/admin/admin_sets/_show_document_list.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_show_document_list.html.erb
@@ -7,7 +7,7 @@
     <th>Date Uploaded</th>
     <th>Visibility</th>
     <th>Status</th>
-    <th>Action</th>
+    <th>Actions</th>
   </tr>
   </thead>
   <tbody>

--- a/app/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb
@@ -20,7 +20,7 @@
       </div>
     </div>
   </td>
-  <td class="text-center"><%= document.date_uploaded %> </td>
+  <td class="text-center date"><%= document.date_uploaded %> </td>
   <td class="text-center">
     <%= render_visibility_link(document) %>
   </td>

--- a/app/views/hyrax/admin/admin_sets/show.html.erb
+++ b/app/views/hyrax/admin/admin_sets/show.html.erb
@@ -6,22 +6,28 @@
   <div class="col-md-12">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h2 class="panel-title display-page"><%= @presenter.to_s %></h2>
-        <div class="pull-right">
-          <%= link_to edit_admin_admin_set_path(@presenter), class: 'btn btn-primary' do %>
-            <span class="fa fa-edit"></span> <%= t(:'helpers.action.edit') %>
-          <% end %>
-          <% if @presenter.disable_delete? %>
-            <span title="<%= @presenter.disabled_message %>">
-              <%= link_to admin_admin_set_path(@presenter), class: 'btn btn-danger disabled' do %>
-                <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
+        <div class="row">
+          <div class="col-sm-8">
+            <h2 class="panel-title display-page"><%= @presenter.to_s %></h2>
+          </div>
+          <div class="col-sm-4">
+            <div class="pull-right">
+              <%= link_to edit_admin_admin_set_path(@presenter), class: 'btn btn-primary' do %>
+                <span class="fa fa-edit"></span> <%= t(:'helpers.action.edit') %>
               <% end %>
-            </span>
-          <% else %>
-            <%= link_to admin_admin_set_path(@presenter), class: 'btn btn-danger', data: { confirm: t('.confirm_delete'), method: :delete } do %>
-              <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
-            <% end %>
-          <% end %>
+              <% if @presenter.disable_delete? %>
+                <span title="<%= @presenter.disabled_message %>">
+                  <%= link_to admin_admin_set_path(@presenter), class: 'btn btn-danger disabled' do %>
+                    <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
+                  <% end %>
+                </span>
+              <% else %>
+                <%= link_to admin_admin_set_path(@presenter), class: 'btn btn-danger', data: { confirm: t('.confirm_delete'), method: :delete } do %>
+                  <span class="fa fa-remove"></span> <%= t(:'helpers.action.delete') %>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/app/views/hyrax/collections/_show_document_list_menu.html.erb
+++ b/app/views/hyrax/collections/_show_document_list_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="btn-group">
-  <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">Select an action<span class="caret"></span>
+  <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">Select <span class="caret"></span>
   </button>
   <ul class="dropdown-menu dropdown-menu-right">
     <% if can? :edit, document %>

--- a/spec/views/hyrax/collections/_show_document_list_menu.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_show_document_list_menu.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'hyrax/collections/_show_document_list_menu.html.erb', type: :vie
     it "displays the action list in a drop down for an individual work the user can edit" do
       allow(ability).to receive(:can?).with(:edit, document).and_return(true)
       render('hyrax/collections/show_document_list_menu.html.erb', document: document, current_user: user)
-      expect(rendered).to have_content 'Select an action'
+      expect(rendered).to have_content 'Select'
       expect(rendered).to have_content 'Edit'
       expect(rendered).not_to have_content 'Download File'
       expect(rendered).to have_content 'Highlight Work on Profile'
@@ -22,7 +22,7 @@ RSpec.describe 'hyrax/collections/_show_document_list_menu.html.erb', type: :vie
     it "displays the action list in a drop down for an individual work the user cannot edit" do
       allow(ability).to receive(:can?).with(:edit, document).and_return(false)
       render('hyrax/collections/show_document_list_menu', document: document, current_user: user)
-      expect(rendered).to have_content 'Select an action'
+      expect(rendered).to have_content 'Select'
       expect(rendered).not_to have_content 'Edit'
       expect(rendered).not_to have_content 'Download File'
       expect(rendered).to have_content 'Highlight Work on Profile'


### PR DESCRIPTION
Some minor updates to the Admin Set show page:

* Adjust layout of panel header so the set title and action buttons are on the same line (at larger than extra small viewport)
* Prevent values in the date column from wrapping
* Update Actions column label and select label

### Before
![before](https://cloud.githubusercontent.com/assets/101482/25363038/b3da4522-290c-11e7-8bc8-10ba7d255731.png)

### After
![show_admin_set____hyrax](https://cloud.githubusercontent.com/assets/101482/25363041/b7fdaa04-290c-11e7-9fcd-5824bc60c79c.png)
