### PR TITLE
Use `column_exists?` to see if `:workflow_id` is present

### DIFF
--- a/db/migrate/20170307142607_tidy_up_because_of_bad_exception.rb
+++ b/db/migrate/20170307142607_tidy_up_because_of_bad_exception.rb
@@ -1,6 +1,6 @@
 class TidyUpBecauseOfBadException < ActiveRecord::Migration[4.2]
   def change
-    if Hyrax::PermissionTemplate.column_names.include?('workflow_id')
+    if column_exists?(Hyrax::PermissionTemplate.table_name, :workflow_id)
       Hyrax::PermissionTemplate.all.each do |permission_template|
         workflow_id = permission_template.workflow_id
         next unless workflow_id


### PR DESCRIPTION
Using the `column_names` method on the `Hyrax::PermissionTemplate` class leads to false positives, which lead to exceptions. Now it is possible for Hyrax-based apps to run `rails db:drop db:create db:migrate` without errors.

Tested in, and ported from, Hyku: https://github.com/projecthydra-labs/hyku/pull/1010

