### PR TITLE
Improve layout of embargo options in Save Work panel

### DIFF
--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -52,6 +52,14 @@ form {
   label { font-weight: normal; }
   & .form-group { padding: 0 1.75em; }
 
+  #collapseEmbargo .form-group {
+    padding: 0;
+
+    &.generic_work_visibility_after_embargo {
+      margin-top: 6px;
+    }
+  }
+
   .form-inline {
     .control-label, label {
       padding-left: 0;

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -30,6 +30,7 @@
             <div class="collapse" id="collapseEmbargo">
               <div class="form-inline">
                 <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+                <%= t('hyrax.works.form.visibility_until') %>
                 <%= f.date_field :embargo_release_date, wrapper: :inline, value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker form-control' %>
                 <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
               </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -669,6 +669,7 @@ en:
         in_collections: This Work in Collections
         in_other_works: This Work in Other Works
         in_this_work: Other Works in this Work
+        visibility_until: 'until'
         tab:
           files:         "Files"
           metadata:      "Descriptions"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -669,6 +669,7 @@ es:
         in_collections: Este Obra en Colecciones
         in_other_works: Este Obra en otras Obras
         in_this_work: Otras Obras en este Obra
+        visibility_until: 'hasta'
         tab:
           files:         "Archivos"
           metadata:      "Descripciones"

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -655,6 +655,7 @@ zh:
         in_collections: 在收藏集中的这件作品
         in_other_works: 在其它作品中包括的这件作品
         in_this_work: 这件作品包括的其它作品
+        visibility_until: 直到
         tab:
           files:         "文件"
           metadata:      "描述"


### PR DESCRIPTION
Fixes #854 

Hard to do something really nice without a lot of work but this might be good enough. Some examples at different viewport widths (part of the challenge that would take time to really address is the wrapping at different viewport widths):

### Narrow
![butterfly_research____generic_work__m326m172d_____hyrax](https://cloud.githubusercontent.com/assets/101482/25640077/1072d786-2f43-11e7-9036-29e6e2a29bbd.png)

### Medium
![butterfly_research____generic_work__m326m172d_____hyrax 2](https://cloud.githubusercontent.com/assets/101482/25640082/1401fe7c-2f43-11e7-9154-2ab022c46928.png)

### Wide
![butterfly_research____generic_work__m326m172d_____hyrax 3](https://cloud.githubusercontent.com/assets/101482/25640083/1662bddc-2f43-11e7-8d2a-2e40f31c9a92.png)
