### PR TITLE
Remove unused mixins from EventJob

### DIFF
--- a/app/jobs/event_job.rb
+++ b/app/jobs/event_job.rb
@@ -1,12 +1,11 @@
 # A generic job for sending events to a user.
 #
-# This class does not implement a usable action, so it must be implemented in a child class
-#
+# @abstract
 class EventJob < ActiveJob::Base
   include Rails.application.routes.url_helpers
+  # For link_to
   include ActionView::Helpers
-  include ActionView::Helpers::DateHelper
-  include Hydra::AccessControlsEnforcement
+  # For link_to_profile
   include HyraxHelper
 
   queue_as Hyrax.config.ingest_queue_name


### PR DESCRIPTION
Reverts part of
https://github.com/projecthydra-labs/hyrax/commit/a397bd67277bfc2ccb83e4a637e4a2f53850fd7a

I don't think these mixins were ever doing anything useful
