### PR TITLE
Only use one copy of jquery

### DIFF
--- a/app/assets/javascripts/hyrax/browse_everything.js
+++ b/app/assets/javascripts/hyrax/browse_everything.js
@@ -1,4 +1,5 @@
-//= require browse_everything
+//= require jquery.treetable
+//= require browse_everything/behavior
 
 // Show the files in the queue
 Blacklight.onLoad( function() {


### PR DESCRIPTION
including `browse_everything` pulls in a second copy of jquery.  This
makes it impossible to switch the local application to use a different
version of jquery (2 or 3) than what browse_everything is using.
