### PR TITLE
Hide additional fields button if there are no secondary terms.

### DIFF
--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -42,6 +42,12 @@ module Hyrax
          :resource_type]
       end
 
+      # Do not display additional fields if there are no secondary terms
+      # @return [Boolean] display additional fields on the form?
+      def display_additional_fields?
+        secondary_terms.any?
+      end
+
       private
 
         def all_files

--- a/app/forms/hyrax/forms/work_form.rb
+++ b/app/forms/hyrax/forms/work_form.rb
@@ -77,6 +77,12 @@ module Hyrax
            :member_of_collection_ids, :in_works_ids, :admin_set_id]
       end
 
+      # Do not display additional fields if there are no secondary terms
+      # @return [Boolean] display additional fields on the form?
+      def display_additional_fields?
+        secondary_terms.any?
+      end
+
       # @return [Array] a list of works that are members of the primary work on this form.
       def work_members
         model.works

--- a/app/views/hyrax/base/_form_metadata.html.erb
+++ b/app/views/hyrax/base/_form_metadata.html.erb
@@ -1,4 +1,3 @@
-
         <div class="form-instructions">
           <p>The more descriptive information you provide the better we can serve your needs.</p>
         </div>
@@ -7,17 +6,18 @@
             <%= render_edit_field_partial(term, f: f) %>
           <% end %>
         </div>
-        <%= link_to t('hyrax.works.form.additional_fields'),
-                    '#extended-terms',
-                    class: 'btn btn-default additional-fields',
-                    data: { toggle: 'collapse' },
-                    role: "button",
-                    'aria-expanded'=> "false",
-                    'aria-controls'=> "extended-terms" %>
-        <div id="extended-terms" class='collapse'>
-          <%= render 'form_media', f: f %>
-          <% f.object.secondary_terms.each do |term| %>
-            <%= render_edit_field_partial(term, f: f) %>
-          <% end %>
-        </div>
-
+        <% if f.object.display_additional_fields? %>
+          <%= link_to t('hyrax.works.form.additional_fields'),
+                      '#extended-terms',
+                      class: 'btn btn-default additional-fields',
+                      data: { toggle: 'collapse' },
+                      role: "button",
+                      'aria-expanded'=> "false",
+                      'aria-controls'=> "extended-terms" %>
+          <div id="extended-terms" class='collapse'>
+            <%= render 'form_media', f: f %>
+            <% f.object.secondary_terms.each do |term| %>
+              <%= render_edit_field_partial(term, f: f) %>
+            <% end %>
+          </div>
+        <% end %>

--- a/app/views/hyrax/collections/_form.html.erb
+++ b/app/views/hyrax/collections/_form.html.erb
@@ -6,18 +6,20 @@
         <%= render_edit_field_partial(term, f: f) %>
       <% end %>
     </div>
-    <%= link_to t('hyrax.collection.form.additional_fields'),
-            '#extended-terms',
-            class: 'btn btn-default additional-fields',
-            data: { toggle: 'collapse' },
-            role: "button",
-            'aria-expanded'=> "false",
-            'aria-controls'=> "extended-terms" %>
-    <div id="extended-terms" class='collapse'>
-      <% f.object.secondary_terms.each do |term| %>
-        <%= render_edit_field_partial(term, f: f) %>
-      <% end %>
-    </div>
+    <% if f.object.display_additional_fields? %>
+      <%= link_to t('hyrax.collection.form.additional_fields'),
+              '#extended-terms',
+              class: 'btn btn-default additional-fields',
+              data: { toggle: 'collapse' },
+              role: "button",
+              'aria-expanded'=> "false",
+              'aria-controls'=> "extended-terms" %>
+      <div id="extended-terms" class='collapse'>
+        <% f.object.secondary_terms.each do |term| %>
+          <%= render_edit_field_partial(term, f: f) %>
+        <% end %>
+      </div>
+    <% end %>
   </div>
   <%= hidden_field_tag :type, params[:type] %>
   <% if params[:batch_document_ids].present? %>

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -53,6 +53,22 @@ RSpec.describe Hyrax::Forms::CollectionForm do
     end
   end
 
+  describe '#display_additional_fields?' do
+    subject { form.display_additional_fields? }
+    context 'with no secondary terms' do
+      before do
+        allow(form).to receive(:secondary_terms).and_return([])
+      end
+      it { is_expected.to be false }
+    end
+    context 'with secondary terms' do
+      before do
+        allow(form).to receive(:secondary_terms).and_return([:foo, :bar])
+      end
+      it { is_expected.to be true }
+    end
+  end
+
   describe "#id" do
     subject { form.id }
     it { is_expected.to be_nil }

--- a/spec/forms/hyrax/forms/work_form_spec.rb
+++ b/spec/forms/hyrax/forms/work_form_spec.rb
@@ -166,6 +166,22 @@ RSpec.describe Hyrax::Forms::WorkForm do
     it { is_expected.to eq work.member_ids }
   end
 
+  describe '#display_additional_fields?' do
+    subject { form.display_additional_fields? }
+    context 'with no secondary terms' do
+      before do
+        allow(form).to receive(:secondary_terms).and_return([])
+      end
+      it { is_expected.to be false }
+    end
+    context 'with secondary terms' do
+      before do
+        allow(form).to receive(:secondary_terms).and_return([:foo, :bar])
+      end
+      it { is_expected.to be true }
+    end
+  end
+
   describe "#embargo_release_date" do
     let(:work) { create(:work, embargo_release_date: 5.days.from_now) }
     subject { form.embargo_release_date }

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
+  before do
+    allow(form).to receive(:display_additional_fields?).and_return(additional_fields)
+  end
+  let(:ability) { double }
+  let(:work) { GenericWork.new }
+  let(:form) do
+    Hyrax::GenericWorkForm.new(work, ability, controller)
+  end
+
+  let(:form_template) do
+    %(
+      <%= simple_form_for [main_app, @form] do |f| %>
+        <%= render "hyrax/base/form_metadata", f: f %>
+      <% end %>
+     )
+  end
+
+  let(:page) do
+    assign(:form, form)
+    render inline: form_template
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  context 'with secondary terms' do
+    let(:additional_fields) { true }
+    it "renders the additional fields button" do
+      expect(page).to have_content('Additional fields')
+    end
+  end
+
+  context 'without secondary terms' do
+    let(:additional_fields) { false }
+    it 'does not render the addtional fields button' do
+      expect(page).not_to have_content('Additional fields')
+    end
+  end
+end

--- a/spec/views/hyrax/collections/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/_form.html.erb_spec.rb
@@ -9,26 +9,42 @@ RSpec.describe 'hyrax/collections/_form.html.erb', type: :view do
     # Stub route because view specs don't handle engine routes
     allow(view).to receive(:collections_path).and_return("/collections")
     allow(controller).to receive(:current_user).and_return(stub_model(User))
-    render
+    allow(collection_form).to receive(:display_additional_fields?).and_return(additional_fields)
   end
 
-  it "draws the metadata fields for collection" do
-    expect(rendered).to have_selector("input#collection_title")
-    expect(rendered).to have_selector("span.required-tag", text: "required")
-    expect(rendered).not_to have_selector("div#additional_title.multi_value")
-    expect(rendered).to have_selector("input#collection_creator.multi_value")
-    expect(rendered).to have_selector("textarea#collection_description")
-    expect(rendered).to have_selector("input#collection_contributor")
-    expect(rendered).to have_selector("input#collection_keyword")
-    expect(rendered).to have_selector("input#collection_subject")
-    expect(rendered).to have_selector("input#collection_publisher")
-    expect(rendered).to have_selector("input#collection_date_created")
-    expect(rendered).to have_selector("input#collection_language")
-    expect(rendered).to have_selector("input#collection_identifier")
-    expect(rendered).to have_selector("input#collection_based_near")
-    expect(rendered).to have_selector("input#collection_related_url")
-    expect(rendered).to have_selector("select#collection_license")
-    expect(rendered).to have_selector("select#collection_resource_type")
-    expect(rendered).not_to have_selector("input#collection_visibility")
+  context 'with secondary terms' do
+    let(:additional_fields) { true }
+    before do
+      render
+    end
+    it "draws the metadata fields for collection" do
+      expect(rendered).to have_selector("input#collection_title")
+      expect(rendered).to have_selector("span.required-tag", text: "required")
+      expect(rendered).not_to have_selector("div#additional_title.multi_value")
+      expect(rendered).to have_selector("input#collection_creator.multi_value")
+      expect(rendered).to have_selector("textarea#collection_description")
+      expect(rendered).to have_selector("input#collection_contributor")
+      expect(rendered).to have_selector("input#collection_keyword")
+      expect(rendered).to have_selector("input#collection_subject")
+      expect(rendered).to have_selector("input#collection_publisher")
+      expect(rendered).to have_selector("input#collection_date_created")
+      expect(rendered).to have_selector("input#collection_language")
+      expect(rendered).to have_selector("input#collection_identifier")
+      expect(rendered).to have_selector("input#collection_based_near")
+      expect(rendered).to have_selector("input#collection_related_url")
+      expect(rendered).to have_selector("select#collection_license")
+      expect(rendered).to have_selector("select#collection_resource_type")
+      expect(rendered).not_to have_selector("input#collection_visibility")
+      expect(rendered).to have_content('Additional fields')
+    end
+  end
+  context 'with no secondary terms' do
+    let(:additional_fields) { false }
+    before do
+      render
+    end
+    it 'does not render additional fields button' do
+      expect(rendered).not_to have_content('Additional fields')
+    end
   end
 end


### PR DESCRIPTION
Fixes #481
