### PR TITLE
Adds the rights statement to the show page

### DIFF
--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -64,6 +64,7 @@ module Hyrax
         attribute :license, Solr::Array, solr_name('license')
         attribute :source, Solr::Array, solr_name('source')
         attribute :date_created, Solr::Array, solr_name('date_created')
+        attribute :rights_statement, Solr::Array, solr_name('rights_statement')
 
         attribute :mime_type, Solr::String, solr_name('mime_type', :stored_sortable)
         attribute :workflow_state, Solr::String, solr_name('workflow_state_name', :symbol)

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -36,7 +36,7 @@ module Hyrax
     # Metadata Methods
     delegate :title, :date_created, :description,
              :creator, :contributor, :subject, :publisher, :language, :embargo_release_date,
-             :lease_expiration_date, :license, :source, :thumbnail_id, :representative_id,
+             :lease_expiration_date, :license, :source, :rights_statement, :thumbnail_id, :representative_id,
              :member_of_collection_ids, to: :solr_document
 
     def workflow

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -10,3 +10,4 @@
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link) %>
 <%= presenter.attribute_to_html(:resource_type, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:source) %>
+<%= presenter.attribute_to_html(:rights_statement) %>

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -26,6 +26,17 @@ RSpec.describe ::SolrDocument, type: :model do
     end
   end
 
+  describe "rights_statement" do
+    let(:attributes) { { 'rights_statement_tesim' => ['A rights statement'] } }
+
+    it "responds to rights_statement" do
+      expect(document).to respond_to(:rights_statement)
+    end
+    it "returns the proper data" do
+      expect(document.rights_statement).to eq ['A rights statement']
+    end
+  end
+
   describe "create_date" do
     let(:attributes) { { 'system_create_dtsi' => '2013-03-14T00:00:00Z' } }
     subject { document.create_date }

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
   it { is_expected.to delegate_method(:date_created).to(:solr_document) }
   it { is_expected.to delegate_method(:date_modified).to(:solr_document) }
   it { is_expected.to delegate_method(:date_uploaded).to(:solr_document) }
+  it { is_expected.to delegate_method(:rights_statement).to(:solr_document) }
 
   it { is_expected.to delegate_method(:based_near).to(:solr_document) }
   it { is_expected.to delegate_method(:related_url).to(:solr_document) }

--- a/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attribute_rows.html.erb_spec.rb
@@ -2,8 +2,13 @@ require 'spec_helper'
 
 RSpec.describe 'hyrax/base/_attribute_rows.html.erb', type: :view do
   let(:url) { "http://example.com" }
+  let(:rights_statement_uri) { 'http://rightsstatements.org/vocab/InC/1.0/' }
   let(:ability) { double }
-  let(:work) { stub_model(GenericWork, related_url: [url]) }
+  let(:work) do
+    stub_model(GenericWork,
+               related_url: [url],
+               rights_statement: [rights_statement_uri])
+  end
   let(:solr_document) { SolrDocument.new(work.to_solr) }
   let(:presenter) { Hyrax::WorkShowPresenter.new(solr_document, ability) }
 
@@ -15,5 +20,9 @@ RSpec.describe 'hyrax/base/_attribute_rows.html.erb', type: :view do
   it 'shows external link with icon for related url field' do
     expect(page).to have_selector '.glyphicon-new-window'
     expect(page).to have_link(url)
+  end
+
+  it 'shows rights statement with link to statement URL' do
+    expect(page).to have_link(rights_statement_uri)
   end
 end


### PR DESCRIPTION
Fixes #886 

This gets the rights statement showing up on the show page. Very basic and mvp. Discussion about whether people want external links and what not to show up can happen, but this is the most basic fix for this issue.