### PR TITLE
No need to load workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Jump in: [![Slack Status](http://slack.projecthydra.org/badge.svg)](http://slack
     * [Start servers](#start-servers)
     * [Start background workers](#start-background-workers)
     * [Create default administrative set](#create-default-administrative-set)
-    * [Load workflows](#load-workflows)
     * [Generate a work type](#generate-a-work-type)
   * [Managing a Hyrax\-based app](#managing-a-hyrax-based-app)
     * [Toggling features](#toggling-features)
@@ -197,13 +196,6 @@ bin/rails hyrax:default_admin_set:create
 ```
 
 **NOTE**: You will want to run this command the first time this code is deployed to a new environment as well.
-
-## Load workflows
-Load workflows from the json files in `config/workflows` by running the following rake task:
-
-```
-bin/rails hyrax:workflow:load
-```
 
 ## Generate a work type
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ end
 bin/rails hyrax:default_admin_set:create
 ```
 
+This command also makes sure that Hyrax's built-in workflows are loaded for your application and available for the default administrative set.
+
 **NOTE**: You will want to run this command the first time this code is deployed to a new environment as well.
 
 ## Generate a work type


### PR DESCRIPTION
Creating the default admin set calls the `AdminSetCreateService` which automatically loads workflows.
