### PR TITLE
Label administrative sets consistently

### DIFF
--- a/app/views/hyrax/admin_sets/show.html.erb
+++ b/app/views/hyrax/admin_sets/show.html.erb
@@ -5,7 +5,7 @@
     <header>
       <h1><%= @presenter %>
           <%= link_to hyrax.admin_sets_path do %>
-            <span class="label label-info">Administrative Collection</span>
+            <span class="label label-info"><%= t('hyrax.admin_sets.show.header') %></span>
           <% end %>
       </h1>
     </header>

--- a/app/views/hyrax/dashboard/_admin_sets.html.erb
+++ b/app/views/hyrax/dashboard/_admin_sets.html.erb
@@ -9,7 +9,7 @@
         <table class="table table-striped">
           <thead>
             <tr>
-              <th><%= t('.collection') %></th>
+              <th><%= t('.admin_set') %></th>
               <th><%= t('.works') %></th>
               <th><%= t('.files') %></th>
             </tr>

--- a/app/views/hyrax/dashboard/show_admin.html.erb
+++ b/app/views/hyrax/dashboard/show_admin.html.erb
@@ -37,7 +37,7 @@
     </div>
 </div>
 
-<%= render 'collections' %>
+<%= render 'admin_sets' %>
 
 <div class="row">
   <div class="col-md-4">

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -10,12 +10,12 @@ en:
     search:
       fields:
         show:
-          admin_set: "In Admin Set:"
+          admin_set: "In Administrative Set:"
           based_near: Location
           contributor: Contributors
           keyword: Keyword
         facet:
-          admin_set_sim: "Administrative set"
+          admin_set_sim: "Collection"
           suppressed_bsi: "Status"
           resource_type_sim: "Resource type"
       filters:
@@ -218,7 +218,9 @@ en:
             under_review: "Under Review"
     admin_sets:
       index:
-        header:         "Administrative Collections"
+        header: "All Collections"
+      show:
+        header: "Collection"
     api:
       accepted:
         default: "Your request has been accepted for processing, but processing is not complete. See job for more info."
@@ -356,6 +358,12 @@ en:
       terms:            "Terms of Use"
     dashboard:
       additional_notifications: "See all notifications"
+      admin_sets:
+        admin_set:              "Administrative Set"
+        files:                  "Files"
+        subtitle:               "Recent activity"
+        title:                  "Administrative Sets"
+        works:                  "Works"
       all:
         collections:            "All Collections"
         works:                  "All Works"
@@ -363,12 +371,6 @@ en:
       breadcrumbs:
         admin:                  "Administration"
       create_work:              "Create Work"
-      collections:
-        collection:             "Collection"
-        subtitle:               "Recent collection activity"
-        title:                  "Collections"
-        works:                  "Works"
-        files:                  "Files"
       current_proxies:          "Current Proxies"
       heading_actions:
         close:                  "Close"
@@ -477,7 +479,7 @@ en:
       override_text: "Use app/views/static/help.html.erb to override this file."
     homepage:
       admin_sets:
-        link:               'View all administrative collections'
+        link:               'View all collections'
         tab_label:          'Explore Collections'
         title:              'Explore Collections'
       featured_researcher:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -15,7 +15,7 @@ es:
           contributor: "Colaboradores"
           keyword: "Palabra Clave"
         facet:
-          admin_set_sim: "Conjunto administrativo"
+          admin_set_sim: "Collección"
           suppressed_bsi: "Estadio"
           resource_type_sim: "Tipo de recurso"
       filters:
@@ -218,7 +218,9 @@ es:
           under_review: "En Revisión"
     admin_sets:
       index:
-        header: "Colecciones Administrativas"
+        header: "Todas las colecciones"
+      show:
+        header: "Collección"
     api:
       accepted:
         default: "Su solicitud se ha aceptado para su procesamiento, pero el procesamiento no está completo. Ver trabajo para más información."
@@ -356,6 +358,12 @@ es:
       terms:            "Términos de Uso"
     dashboard:
       additional_notifications: "ver todas las notificaciones"
+      admin_sets:
+        admin_set:              "Conjunto administrativo"
+        files:                  "Archivos"
+        subtitle:               "Actividad reciente"
+        title:                  "Conjuntos administrativos"
+        works:                  "Obras"
       all:
         collections:            "Todos los Colleccións"
         works:                  "Todos los Trabajos"
@@ -363,12 +371,6 @@ es:
       breadcrumbs:
         admin:                  "Administración"
       create_work:              "Crear Trabajo"
-      collections:
-        collection:             "Collección"
-        subtitle:               "Actividad reciente de la colección"
-        title:                  "Colleccións"
-        works:                  "Trabajos"
-        files:                  "Archivos"
       current_proxies:          "Proxies actuales"
       heading_actions:
         close:                  "Cerrar"
@@ -477,7 +479,7 @@ es:
       override_text: "Utilice app/views/static/help.html.erb para anular este archivo"
     homepage:
       admin_sets:
-        link:               'Ver todas las colecciones administrativas'
+        link:               'Ver todas las colecciones'
         tab_label:          'Explorar Colecciones'
         title:              'Explorar Colecciones'
       featured_researcher:

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -15,7 +15,7 @@ zh:
           contributor: "贡献者"
           keyword: "关键词"
         facet:
-          admin_set_sim: "管理集"
+          admin_set_sim: "集"
           suppressed_bsi: "状况"
           resource_type_sim: "资源类型"
       filters:
@@ -218,7 +218,9 @@ zh:
             under_review: "在审查中"
     admin_sets:
       index:
-        header: "管理集"
+        header: "所有收藏"
+      show:
+        header: "集"
     api:
       accepted:
         default: "您的请求已被接受，正在处理中。参见？？See job for more info。"
@@ -356,6 +358,12 @@ zh:
       terms:            "使用条款"
     dashboard:
       additional_notifications: "见所有通知"
+      admin_sets:
+        admin_set:              "管理集"
+        files:                  "文件"
+        subtitle:               "近期活动"
+        title:                  "管理集"
+        works:                  "作品"
       all:
         collections:            "所有收藏集"
         works:                  "所有作品"
@@ -363,12 +371,6 @@ zh:
       breadcrumbs:
         admin:                  "管理"
       create_work:              "创建作品"
-      collections:
-        collection:             "收藏集"
-        subtitle:               "近期收藏集操作"
-        title:                  "收藏集"
-        works:                  "作品"
-        files:                  "文件"
       current_proxies:          "目前代理"
       heading_actions:
         close:                  "关闭"
@@ -475,7 +477,7 @@ zh:
       override_text: "用 app/views/static/help.html.erb 覆盖此文件。"
     homepage:
       admin_sets:
-        link:               '阅览所有管理集'
+        link:               '查看所有收藏'
         tab_label:          '探索收藏集'
         title:              '探索收藏集'
       featured_researcher:

--- a/spec/features/user_admin_set_spec.rb
+++ b/spec/features/user_admin_set_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "The public view of admin sets" do
 
   scenario do
     visit root_path
-    click_link "View all administrative collections"
+    click_link "View all collections"
 
     # The list of AdminSets
     expect(page).to have_selector "img[src='/assets/admin-set-thumb.png']"


### PR DESCRIPTION
Call them "collections" in the public views and "administrative sets" in the dashboard views.

Fixes #844, #846, #830.

Cc: @hannahfrost @ggeisler 
