### PR TITLE
Generate the presenter into the local application

### DIFF
--- a/lib/generators/hyrax/work/templates/controller.rb.erb
+++ b/lib/generators/hyrax/work/templates/controller.rb.erb
@@ -7,5 +7,8 @@ module Hyrax
     include Hyrax::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
     self.curation_concern_type = ::<%= class_name %>
+
+    # Use this line if you want to use a custom presenter
+    self.show_presenter = Hyrax::<%= class_name %>Presenter
   end
 end

--- a/lib/generators/hyrax/work/templates/presenter.rb.erb
+++ b/lib/generators/hyrax/work/templates/presenter.rb.erb
@@ -1,0 +1,6 @@
+# Generated via
+#  `rails generate hyrax:work <%= class_name %>`
+module Hyrax
+  class <%= class_name %>Presenter < Hyrax::WorkShowPresenter
+  end
+end

--- a/lib/generators/hyrax/work/templates/presenter_spec.rb.erb
+++ b/lib/generators/hyrax/work/templates/presenter_spec.rb.erb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work <%= class_name %>`
+require 'rails_helper'
+
+RSpec.describe Hyrax::<%= class_name %>Presenter do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/lib/generators/hyrax/work/work_generator.rb
+++ b/lib/generators/hyrax/work/work_generator.rb
@@ -38,6 +38,10 @@ class Hyrax::WorkGenerator < Rails::Generators::NamedBase
     template('form.rb.erb', File.join('app/forms/hyrax', class_path, "#{file_name}_form.rb"))
   end
 
+  def create_presenter
+    template('presenter.rb.erb', File.join('app/presenters/hyrax', class_path, "#{file_name}_presenter.rb"))
+  end
+
   def create_model
     template('model.rb.erb', File.join('app/models/', class_path, "#{file_name}.rb"))
   end
@@ -89,6 +93,11 @@ class Hyrax::WorkGenerator < Rails::Generators::NamedBase
   def create_form_spec
     return unless rspec_installed?
     template('form_spec.rb.erb', File.join('spec/forms/hyrax/', class_path, "#{file_name}_form_spec.rb"))
+  end
+
+  def presenter_spec
+    return unless rspec_installed?
+    template('presenter_spec.rb.erb', File.join('spec/presenters/hyrax/', class_path, "#{file_name}_presenter_spec.rb"))
   end
 
   def create_model_spec

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Hyrax::GenericWorksController do
       get :show, params: { id: work }
       expect(response.code).to eq '401'
       expect(response).to render_template(:unavailable)
-      expect(assigns[:presenter]).to be_instance_of Hyrax::WorkShowPresenter
+      expect(assigns[:presenter]).to be_instance_of Hyrax::GenericWorkPresenter
       expect(flash[:notice]).to eq 'The work is not currently available because it has not yet completed the approval process'
     end
   end
@@ -71,7 +71,7 @@ RSpec.describe Hyrax::GenericWorksController do
         it "sets the parent presenter" do
           get :show, params: { id: work, parent_id: parent }
           expect(response).to be_success
-          expect(assigns[:parent_presenter]).to be_instance_of Hyrax::WorkShowPresenter
+          expect(assigns[:parent_presenter]).to be_instance_of Hyrax::GenericWorkPresenter
         end
       end
 

--- a/spec/features/work_generator_spec.rb
+++ b/spec/features/work_generator_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Creating a new Work' do
     Rails::Generators.invoke('hyrax:work', ['Catapult', '--quiet'], destination_root: Rails.root)
     load "#{EngineCart.destination}/app/indexers/catapult_indexer.rb"
     load "#{EngineCart.destination}/app/models/catapult.rb"
+    load "#{EngineCart.destination}/app/presenters/hyrax/catapult_presenter.rb"
     load "#{EngineCart.destination}/app/controllers/hyrax/catapults_controller.rb"
     load "#{EngineCart.destination}/app/actors/hyrax/actors/catapult_actor.rb"
     load "#{EngineCart.destination}/app/forms/hyrax/catapult_form.rb"
@@ -22,7 +23,7 @@ RSpec.feature 'Creating a new Work' do
   it 'catapults should behave like generic works' do
     expect(Hyrax.config.curation_concerns).to include Catapult
     expect(defined? Hyrax::Actors::CatapultActor).to eq 'constant'
-    expect(defined? Hyrax::CatapultsController).to eq 'constant'
+    expect(Hyrax::CatapultsController.show_presenter).to eq Hyrax::CatapultPresenter
     expect(defined? Hyrax::CatapultForm).to eq 'constant'
     expect(Catapult.indexer).to eq CatapultIndexer
   end


### PR DESCRIPTION
This makes it easier to add custom behavior to the local application in
the correct place. This follows the behavior of the form object.

