### PR TITLE
ModelActor: don't split namespaced classes

### DIFF
--- a/app/actors/hyrax/actors/model_actor.rb
+++ b/app/actors/hyrax/actors/model_actor.rb
@@ -23,7 +23,7 @@ module Hyrax
       private
 
         def model_actor(env)
-          actor_identifier = env.curation_concern.class.to_s.split('::').last
+          actor_identifier = env.curation_concern.class
           klass = "Hyrax::Actors::#{actor_identifier}Actor".constantize
           klass.new(next_actor)
         end

--- a/spec/actors/hyrax/actors/model_actor_spec.rb
+++ b/spec/actors/hyrax/actors/model_actor_spec.rb
@@ -1,0 +1,28 @@
+# coding: utf-8
+
+require 'spec_helper'
+
+module MusicalWork
+  class Cover < ActiveFedora::Base
+  end
+end
+
+class Hyrax::Actors::MusicalWork
+  class CoverActor < ::Hyrax::Actors::AbstractActor
+  end
+end
+
+RSpec.describe Hyrax::Actors::ModelActor do
+  let(:work) { MusicalWork::Cover.new }
+  let(:depositor) { create(:user) }
+  let(:depositor_ability) { ::Ability.new(depositor) }
+  let(:env) { Hyrax::Actors::Environment.new(work, depositor_ability, {}) }
+
+  describe '#model_actor' do
+    subject { described_class.new('¯\_(ツ)_/¯').send(:model_actor, env) }
+
+    it "preserves the namespacing" do
+      is_expected.to be_kind_of Hyrax::Actors::MusicalWork::CoverActor
+    end
+  end
+end


### PR DESCRIPTION
Fixes #925 
Using namespaced works created with e.g.,
```shell
bundle exec rails g hyrax:work MusicalWork::Cover
```

Were failing because the namespace `MusicalWork` was being split off and Hyrax went looking for `Hyrax::Actors::CoverActor` instead of `Hyrax::Actors::MusicalWork::CoverActor`.

Thanks to @cazzerson for helping track this down.
@projecthydra-labs/hyrax-code-reviewers
