### PR TITLE
Adjust layout of visibility section of Edit File, Permissions tab

### DIFF
--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -50,7 +50,27 @@ form {
 
 .set-access-controls {
   label { font-weight: normal; }
-  & .form-group { padding: 0 1.75em; }
+  & .form-group {
+    padding: 0 1.75em;
+
+    &.file_set_visibility_during_embargo,
+    &.file_set_visibility_during_lease {
+      padding-right: 0;
+    }
+
+    &.file_set_embargo_release_date,
+    &.file_set_lease_expiration_date,
+    &.file_set_visibility_after_embargo,
+    &.file_set_visibility_after_lease {
+      padding-left: 0;
+    }
+
+    &.file_set_visibility_after_embargo,
+    &.file_set_visibility_after_lease {
+      margin-bottom: 3px;
+      margin-top: 3px;
+    }
+  }
 
   #collapseEmbargo .form-group {
     padding: 0;


### PR DESCRIPTION
Fixes #874.

This is a pretty minor PR that just addresses the layout (spacing issues) of the embargo and lease controls, which was the original impetus for ticket #874, based on a comment by @hannahfrost in ticket #854. There are many other aspects of the File Edit, Permissions page that need improvement, but as I got into it I realized that it'll be a lot of work and would probably benefit from a design mockup to do efficiently. So I'll create a separate design needed ticket to address other needed improvements to this page.

### Before

![butterfly_jpg____file__qj72p712h_____hyrax 2](https://cloud.githubusercontent.com/assets/101482/25924428/8e515402-3597-11e7-83f9-bc1ab688871d.png)

### After
![butterfly_jpg____file__qj72p712h_____hyrax](https://cloud.githubusercontent.com/assets/101482/25924435/90cb4b34-3597-11e7-8fa1-dda5776863fc.png)
