### PR TITLE
Log rspec examples that use a lot of LDP requests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,7 @@ require 'support/matchers/api_responses'
 require 'support/matchers/response_matchers'
 require 'support/input_support'
 require 'support/speedup'
+require 'support/logging_formatter'
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
 
@@ -230,6 +231,7 @@ RSpec.configure do |config|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
+  config.formatter = 'LoggingFormatter'
   config.default_formatter = 'doc' if config.files_to_run.one?
 
   config.order = :random

--- a/spec/support/logging_formatter.rb
+++ b/spec/support/logging_formatter.rb
@@ -1,0 +1,47 @@
+RSpec::Support.require_rspec_core "formatters/base_text_formatter"
+class LoggingFormatter < RSpec::Core::Formatters::ProgressFormatter
+  RSpec::Core::Formatters.register self, :example_started, :example_passed, :dump_profile
+  def initialize(output)
+    @profile = []
+    reset!
+    ActiveSupport::Notifications.subscribe("http.ldp", method(:record_request))
+    super
+  end
+
+  def record_request(*_unused, data)
+    @request_count += 1
+    @request_count_by_name[data[:name]] += 1
+  end
+
+  def example_passed(passed)
+    super
+    @profile << { description: passed.example.full_description,
+                  count: @request_count,
+                  count_by_name: @request_count_by_name }
+  end
+
+  def example_started(_passed)
+    reset!
+  end
+
+  def reset!
+    @request_count = 0
+    @request_count_by_name = { 'HEAD' => 0,
+                               'GET' => 0,
+                               'POST' => 0,
+                               'DELETE' => 0,
+                               'PUT' => 0,
+                               'PATCH' => 0 }
+  end
+
+  def dump_profile(_prof)
+    output.puts "Examples with the most LDP requests"
+    top = @profile.sort_by { |hash| hash[:count] }.last(10)
+    top.each do |hash|
+      result = hash[:count_by_name].select { |_, v| v > 0 }
+      next if result.empty?
+      output.puts "  #{hash[:description]}"
+      output.puts "    Total LDP: #{hash[:count]} #{result}"
+    end
+  end
+end


### PR DESCRIPTION
```
Examples with the most LDP requests

  Hyrax::Actors::FileSetActor#attach_file_to_work writes to the most up to date version

    Total LDP: 199 {"HEAD"=>108, "GET"=>64, "POST"=>7, "PUT"=>9, "PATCH"=>11}

  AttachFilesToWorkJob happy path with uploaded files at remote URLs creates ImportUrlJobs

    Total LDP: 210 {"HEAD"=>108, "GET"=>75, "POST"=>9, "PUT"=>7, "PATCH"=>11}

  Batch management of works editing and viewing multiple works edits each field and displays the changes

    Total LDP: 211 {"HEAD"=>111, "GET"=>80, "POST"=>10, "PUT"=>2, "PATCH"=>8}

  Hyrax::Actors::GenericWorkActor#update with in_works_ids attaches the parent

    Total LDP: 218 {"HEAD"=>118, "GET"=>75, "POST"=>7, "DELETE"=>1, "PUT"=>10, "PATCH"=>7}

  Hyrax::Actors::GenericWorkActor#create valid attributes with embargo with attached files applies embargo to attached files

    Total LDP: 223 {"HEAD"=>118, "GET"=>79, "POST"=>10, "PUT"=>8, "PATCH"=>8}

  Hyrax::Actors::GenericWorkActor#create valid attributes with multiple files authenticated visibility stamps each file with the access rights

    Total LDP: 239 {"HEAD"=>123, "GET"=>86, "POST"=>10, "PUT"=>8, "PATCH"=>12}

  The admin dashboard should text "3"

    Total LDP: 296 {"HEAD"=>156, "GET"=>85, "POST"=>23, "DELETE"=>2, "PUT"=>20, "PATCH"=>10}

  Hyrax::CollectionsController#update when moving members between collections moves the members

    Total LDP: 326 {"HEAD"=>182, "GET"=>108, "POST"=>11, "DELETE"=>2, "PUT"=>13, "PATCH"=>10}

  AttachFilesToWorkJob happy path with uploaded files on the filesystem attaches files, copies visibility and permissions and updates the uploaded files

    Total LDP: 343 {"HEAD"=>180, "GET"=>122, "POST"=>14, "PUT"=>11, "PATCH"=>16}

  collection show pages of a collection shows a collection with a listing of Descriptive Metadata and catalog-style search results

    Total LDP: 501 {"HEAD"=>298, "GET"=>122, "POST"=>28, "PUT"=>40, "PATCH"=>13}

```