### PR TITLE
Workflow notifications should be sent individually

### DIFF
--- a/app/services/hyrax/workflow/abstract_notification.rb
+++ b/app/services/hyrax/workflow/abstract_notification.rb
@@ -19,7 +19,9 @@ module Hyrax
       end
 
       def call
-        user.send_message(users_to_notify.uniq, message, subject)
+        users_to_notify.uniq.each do |recipient|
+          user.send_message(recipient, message, subject)
+        end
       end
 
       protected

--- a/spec/services/hyrax/workflow/changes_required_notification_spec.rb
+++ b/spec/services/hyrax/workflow/changes_required_notification_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hyrax::Workflow::ChangesRequiredNotification do
         .with(anything,
               "Test title (<a href=\"/concern/generic_works/#{work.id}\">#{work.id}</a>) " \
               "requires additional changes before approval.\n\n 'A pleasant read'",
-              anything).once.and_call_original
+              anything).exactly(3).times.and_call_original
 
       expect { described_class.send_notification(entity: entity, user: approver, comment: comment, recipients: recipients) }
         .to change { depositor.mailbox.inbox.count }.by(1)
@@ -26,7 +26,7 @@ RSpec.describe Hyrax::Workflow::ChangesRequiredNotification do
     context 'without carbon-copied users' do
       let(:recipients) { { 'to' => [to_user] } }
       it 'sends a message to the to user(s)' do
-        expect(approver).to receive(:send_message).once.and_call_original
+        expect(approver).to receive(:send_message).exactly(2).times.and_call_original
         expect { described_class.send_notification(entity: entity, user: approver, comment: comment, recipients: recipients) }
           .to change { depositor.mailbox.inbox.count }.by(1)
           .and change { to_user.mailbox.inbox.count }.by(1)

--- a/spec/services/hyrax/workflow/deposited_notification_spec.rb
+++ b/spec/services/hyrax/workflow/deposited_notification_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hyrax::Workflow::DepositedNotification do
         .with(anything,
               "Test title (<a href=\"/concern/generic_works/#{work.id}\">#{work.id}</a>) " \
               "was approved by #{approver.user_key}. A pleasant read",
-              anything).once.and_call_original
+              anything).exactly(3).times.and_call_original
 
       expect { described_class.send_notification(entity: entity, user: approver, comment: comment, recipients: recipients) }
         .to change { depositor.mailbox.inbox.count }.by(1)
@@ -26,7 +26,7 @@ RSpec.describe Hyrax::Workflow::DepositedNotification do
     context 'without carbon-copied users' do
       let(:recipients) { { 'to' => [to_user] } }
       it 'sends a message to the to user(s)' do
-        expect(approver).to receive(:send_message).once.and_call_original
+        expect(approver).to receive(:send_message).exactly(2).times.and_call_original
         expect { described_class.send_notification(entity: entity, user: approver, comment: comment, recipients: recipients) }
           .to change { depositor.mailbox.inbox.count }.by(1)
           .and change { to_user.mailbox.inbox.count }.by(1)

--- a/spec/services/hyrax/workflow/pending_review_notification_spec.rb
+++ b/spec/services/hyrax/workflow/pending_review_notification_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hyrax::Workflow::PendingReviewNotification do
         .with(anything,
               "Test title (<a href=\"/concern/generic_works/#{work.id}\">#{work.id}</a>) "\
               "was deposited by #{depositor.user_key} and is awaiting approval A pleasant read",
-              anything).once.and_call_original
+              anything).exactly(3).times.and_call_original
 
       expect { described_class.send_notification(entity: entity, user: depositor, comment: comment, recipients: recipients) }
         .to change { depositor.mailbox.inbox.count }.by(1)
@@ -25,7 +25,7 @@ RSpec.describe Hyrax::Workflow::PendingReviewNotification do
     context 'without carbon-copied users' do
       let(:recipients) { { 'to' => [to_user] } }
       it 'sends a message to the to user(s)' do
-        expect(depositor).to receive(:send_message).once.and_call_original
+        expect(depositor).to receive(:send_message).exactly(2).times.and_call_original
         expect { described_class.send_notification(entity: entity, user: depositor, comment: comment, recipients: recipients) }
           .to change { depositor.mailbox.inbox.count }.by(1)
           .and change { to_user.mailbox.inbox.count }.by(1)


### PR DESCRIPTION
Otherwise, when a user removes one or more messages, they disappear from all user inboxes.

Backport of #950. Refs #944.

@projecthydra-labs/hyrax-code-reviewers
