### PR TITLE
Render workflow state as a label

### DIFF
--- a/app/presenters/hyrax/workflow_presenter.rb
+++ b/app/presenters/hyrax/workflow_presenter.rb
@@ -1,5 +1,7 @@
 module Hyrax
   class WorkflowPresenter
+    include ActionView::Helpers::TagHelper
+
     def initialize(solr_document, current_ability)
       @solr_document = solr_document
       @current_ability = current_ability
@@ -26,6 +28,11 @@ module Hyrax
     def comments
       return [] unless sipity_entity
       sipity_entity.comments
+    end
+
+    def badge
+      return unless state
+      content_tag(:span, state_label, class: "state state-#{state} label label-primary")
     end
 
     private

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -4,8 +4,6 @@
     <header>
       <%= render 'work_title', presenter: @presenter %>
     </header>
-
-    <span class="state state-<%= @presenter.workflow.state %>"><%= @presenter.workflow.state_label %></span>
   </div>
   <div class="col-sm-8">
     <%= render 'work_description', presenter: @presenter %>

--- a/app/views/hyrax/base/unavailable.html.erb
+++ b/app/views/hyrax/base/unavailable.html.erb
@@ -1,5 +1,6 @@
-<h1><%= @presenter %> </h1>
-<span class="state state-<%= @presenter.workflow.state %>"><%= @presenter.workflow.state_label %></span>
+<h1>
+    <%= @presenter %> <%= @presenter.workflow.badge %>
+</h1>
 <% if @parent_presenter %>
     <ul class="breadcrumb">
         <li><%= link_to @parent_presenter, polymorphic_path([main_app, @parent_presenter]) %></li>

--- a/app/views/hyrax/file_sets/_file_set_title.erb
+++ b/app/views/hyrax/file_sets/_file_set_title.erb
@@ -1,7 +1,7 @@
 <% presenter.title.each_with_index do |title, index| %>
     <% if index == 0 %>
         <h1>
-            <%= title %> <%= presenter.permission_badge %> <%= presenter.workflow.badge %>
+            <%= title %> <%= presenter.permission_badge %>
         </h1>
     <% else %>
         <h1><%= title %></h1>

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -9,7 +9,7 @@
     </div>
     <div itemscope itemtype="<%= @presenter.itemtype %>" class="col-xs-12 col-sm-8">
       <header>
-        <%= render 'work_title', presenter: @presenter %>
+        <%= render 'file_set_title', presenter: @presenter %>
       </header>
 
       <%# TODO: render 'show_descriptions' See https://github.com/projecthydra/hyrax/issues/1481 %>

--- a/spec/presenters/hyrax/workflow_presenter_spec.rb
+++ b/spec/presenters/hyrax/workflow_presenter_spec.rb
@@ -33,6 +33,24 @@ RSpec.describe Hyrax::WorkflowPresenter, no_clean: true do
     end
   end
 
+  describe "#badge" do
+    let(:workflow) { create(:workflow, name: 'testing') }
+    subject { presenter.badge }
+    context 'with a Sipity::Entity' do
+      before do
+        allow(entity).to receive(:workflow_state_name).and_return('complete')
+        allow(presenter).to receive(:sipity_entity).and_return(entity)
+      end
+      it { is_expected.to eq '<span class="state state-complete label label-primary">Complete</span>' }
+    end
+    context 'without a Sipity::Entity' do
+      before do
+        allow(presenter).to receive(:sipity_entity).and_return(nil)
+      end
+      it { is_expected.to be nil }
+    end
+  end
+
   describe "#comments" do
     subject { presenter.comments }
     context 'with a Sipity::Entity' do

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 RSpec.describe 'hyrax/base/show.html.erb', type: :view do
   let(:solr_document) do
     SolrDocument.new(id: '999',
+                     title_tesim: ['Title of the Work'],
                      date_modified_dtsi: '2011-04-01',
                      has_model_ssim: ['GenericWork'])
   end
@@ -10,8 +11,12 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
   let(:presenter) do
     Hyrax::WorkShowPresenter.new(solr_document, ability)
   end
+  let(:workflow_presenter) do
+    double('workflow_presenter', badge: 'Foobar')
+  end
   let(:page) { Capybara::Node::Simple.new(rendered) }
   before do
+    allow(presenter).to receive(:workflow).and_return(workflow_presenter)
     stub_template 'hyrax/base/_metadata.html.erb' => ''
     stub_template 'hyrax/base/_relationships.html.erb' => ''
     stub_template 'hyrax/base/_show_actions.html.erb' => ''
@@ -19,11 +24,16 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
     stub_template 'hyrax/base/_social_media.html.erb' => ''
     stub_template 'hyrax/base/_citations.html.erb' => ''
     stub_template 'hyrax/base/_items.html.erb' => ''
+    stub_template 'hyrax/base/_workflow_actions_widget.html.erb' => ''
     assign(:presenter, presenter)
     render
   end
 
   it 'shows last saved' do
     expect(page).to have_content 'Last modified: 04/01/2011'
+  end
+
+  it 'shows workflow badge' do
+    expect(page).to have_content 'Foobar'
   end
 end

--- a/spec/views/hyrax/base/unavailable.html.erb_spec.rb
+++ b/spec/views/hyrax/base/unavailable.html.erb_spec.rb
@@ -7,13 +7,14 @@ RSpec.describe 'hyrax/base/unavailable.html.erb', type: :view do
            to_param: '123',
            model_name: GenericWork.model_name)
   end
-  let(:workflow) do
-    double('workflow', state: 'deposited', state_label: 'really deposited')
+  let(:workflow_presenter) do
+    double('workflow_presenter',
+           badge: '<span class="label label-primary state state-deposited">really deposited</span>')
   end
   let(:presenter) do
     double('presenter',
            to_s: 'super cool',
-           workflow: workflow,
+           workflow: workflow_presenter,
            human_readable_type: 'Generic Work')
   end
   let(:parent_presenter) do


### PR DESCRIPTION
Prior to this commit, workflow states displayed as unstyled text immediately below the work title. We discussed alternatives in #225, and this is not that full solution; this is a quick (arguable) improvement. 

Refs #225.

Before:

![workflow_label](https://cloud.githubusercontent.com/assets/131982/21829044/c910c864-d748-11e6-936f-af90dfe0c0ff.png)

After: 

![screenshot from 2017-05-12 15-11-34](https://cloud.githubusercontent.com/assets/131982/26018797/9dfbadd0-3736-11e7-9411-e373bf82049b.png)

@projecthydra-labs/hyrax-code-reviewers @projecthydra-labs/hyrax-ui-ux-advisors 
