### PR TITLE
rename Enable batch upload feature to Batch upload

### DIFF
--- a/app/controllers/concerns/hyrax/batch_uploads_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/batch_uploads_controller_behavior.rb
@@ -17,7 +17,7 @@ module Hyrax
     # @note we don't call `authorize!` directly, since `authorized_models` already checks `user.can? :create, ...`
     def create
       authenticate_user!
-      unless Flipflop.enable_batch_upload?
+      unless Flipflop.batch_upload?
         respond_to do |wants|
           wants.json do
             return render_json_response(response_type: :forbidden,

--- a/app/views/hyrax/base/_form.html.erb
+++ b/app/views/hyrax/base/_form.html.erb
@@ -12,7 +12,7 @@
       <%= render 'form_ordered_members_error', f: f %>
     </div>
   <% end %>
-  <% if Flipflop.enable_batch_upload? && f.object.new_record? %>
+  <% if Flipflop.batch_upload? && f.object.new_record? %>
     <% provide :metadata_tab do %>
       <p class="switch-upload-type">To create a separate work for each of the files, go to <%= link_to "Batch upload", hyrax.new_batch_upload_path %></p>
     <% end %>

--- a/app/views/hyrax/my/works/index.html.erb
+++ b/app/views/hyrax/my/works/index.html.erb
@@ -14,7 +14,7 @@
   <% if current_ability.can_create_any_work? %>
     <div class="pull-right">
       <% if create_work_presenter.many? %>
-        <% if Flipflop.enable_batch_upload? %>
+        <% if Flipflop.batch_upload? %>
           <%= link_to(
                 t(:'helpers.action.batch.new'),
                 '#',
@@ -29,7 +29,7 @@
               class: 'btn btn-primary'
             ) %>
       <% else # simple link to the first work type %>
-        <% if Flipflop.enable_batch_upload? %>
+        <% if Flipflop.batch_upload? %>
           <%= link_to(
               t(:'helpers.action.batch.new'),
               hyrax.new_batch_upload_path(payload_concern: create_work_presenter.first_model),

--- a/config/features.rb
+++ b/config/features.rb
@@ -27,7 +27,7 @@ Flipflop.configure do
           default: Hyrax.config.active_deposit_agreement_acceptance?,
           description: "Require an active acceptance of the deposit agreement by checking a checkbox"
 
-  feature :enable_batch_upload,
+  feature :batch_upload,
           default: true,
           description: "Enable uploading batches of works"
 end

--- a/spec/controllers/hyrax/batch_uploads_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_uploads_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Hyrax::BatchUploadsController do
   describe "#create" do
     context 'when feature is disabled' do
       before do
-        allow(Flipflop).to receive(:enable_batch_upload?).and_return(false)
+        allow(Flipflop).to receive(:batch_upload?).and_return(false)
       end
       it 'redirects with an error message' do
         post :create, params: post_params.merge(format: :html)

--- a/spec/models/flipflop_spec.rb
+++ b/spec/models/flipflop_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Flipflop do
     end
   end
 
-  describe "enable_batch_upload?" do
-    subject { described_class.enable_batch_upload? }
+  describe "batch_upload?" do
+    subject { described_class.batch_upload? }
     it "defaults to true" do
       is_expected.to be true
     end

--- a/spec/views/hyrax/base/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form.html.erb_spec.rb
@@ -27,17 +27,17 @@ RSpec.describe 'hyrax/base/_form.html.erb', type: :view do
 
   context "for a new object" do
     let(:work) { GenericWork.new }
-    context 'with enable_batch_upload on' do
+    context 'with batch_upload on' do
       before do
-        allow(Flipflop).to receive(:enable_batch_upload?).and_return(true)
+        allow(Flipflop).to receive(:batch_upload?).and_return(true)
       end
       it 'shows batch uploads' do
         expect(page).to have_link('Batch upload')
       end
     end
-    context 'with enable_batch_upload off' do
+    context 'with batch_upload off' do
       before do
-        allow(Flipflop).to receive(:enable_batch_upload?).and_return(false)
+        allow(Flipflop).to receive(:batch_upload?).and_return(false)
       end
       it 'hides batch uploads' do
         expect(page).not_to have_link('Batch upload')

--- a/spec/views/hyrax/my/works/index.html.erb_spec.rb
+++ b/spec/views/hyrax/my/works/index.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'hyrax/my/works/index.html.erb', type: :view do
     allow(view).to receive(:provide).with(:page_title, String)
     allow(view).to receive(:create_work_presenter).and_return(presenter)
     allow(view).to receive(:can?).and_return(true)
-    allow(Flipflop).to receive(:enable_batch_upload?).and_return(batch_enabled)
+    allow(Flipflop).to receive(:batch_upload?).and_return(batch_enabled)
     stub_template 'hyrax/my/works/_tabs.html.erb' => 'tabs'
     stub_template 'hyrax/my/works/_search_header.html.erb' => 'search'
     stub_template 'hyrax/my/works/_document_list.html.erb' => 'list'
@@ -29,7 +29,7 @@ RSpec.describe 'hyrax/my/works/index.html.erb', type: :view do
         expect(rendered).to have_link('Add new work')
       end
 
-      context 'with enable_batch_upload off' do
+      context 'with batch_upload off' do
         let(:batch_enabled) { false }
 
         it 'hides batch creation button' do
@@ -54,7 +54,7 @@ RSpec.describe 'hyrax/my/works/index.html.erb', type: :view do
         expect(rendered).to have_link('Add new work')
       end
 
-      context 'with enable_batch_upload off' do
+      context 'with batch_upload off' do
         let(:batch_enabled) { false }
 
         it 'hides batch creation button' do


### PR DESCRIPTION
Fixes #949

Renamed references of enable batch upload to batch upload.

New UI for features is shown below:

![screen shot 2017-05-15 at 12 09 21 pm](https://cloud.githubusercontent.com/assets/67506/26074670/8494cf74-3967-11e7-8bcb-1022140e887e.png)

Changes proposed in this pull request:
* renamed `enable_batch_upload?` flipflop feature to `batch_upload?`

@projecthydra-labs/hyrax-code-reviewers
