### PR TITLE
works download as attachment

### DIFF
--- a/app/controllers/concerns/hyrax/download_behavior.rb
+++ b/app/controllers/concerns/hyrax/download_behavior.rb
@@ -29,6 +29,11 @@ module Hyrax
 
     protected
 
+      # Override the Hydra::Controller::DownloadBehavior#content_options
+      def content_options
+        super.merge(disposition: 'attachment')
+      end
+
       # Override this method if you want to change the options sent when downloading
       # a derivative file
       def derivative_download_options


### PR DESCRIPTION
- [x] Pending a successful demo that Chrome will prompt for a download (not sure how to spec that).


Proposed fix for https://github.com/projecthydra-labs/hyrax/issues/598

Changes proposed in this pull request:
  - override `Hydra::Controller::DownloadBehavior#content_options`
    - https://github.com/projecthydra/hydra-head/blob/master/hydra-core/app/controllers/concerns/hydra/controller/download_behavior.rb#L76
    - replace `disposition: 'inline'` with `disposition: 'attachment'`


@projecthydra-labs/hyrax-code-reviewers
