### PR TITLE
Fix visibility form collapse/expand for batches

### DIFF
--- a/app/views/hyrax/batch_uploads/_form.html.erb
+++ b/app/views/hyrax/batch_uploads/_form.html.erb
@@ -1,4 +1,9 @@
-<%= simple_form_for [hyrax, @form], html: { multipart: true } do |f| %>
+<%= simple_form_for [hyrax, @form],
+                    html: {
+                      data: { behavior: 'work-form',
+                              'param-key' => @form.model_name.param_key },
+                      multipart: true
+                    } do |f| %>
   <% provide :files_tab do %>
     <p class="instructions"><%= t("hyrax.batch_uploads.files.instructions") %></p>
     <p class="switch-upload-type"><%= t("hyrax.batch_uploads.files.upload_type_instructions") %>

--- a/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'hyrax/batch_uploads/_form.html.erb', type: :view do
 
   it "draws the page" do
     expect(page).to have_selector("form[action='/batch_uploads']")
+    expect(page).to have_selector("form[action='/batch_uploads'][data-behavior='work-form']")
+    expect(page).to have_selector("form[action='/batch_uploads'][data-param-key='batch_upload_item']")
     # No title, because it's captured per file (e.g. Display label)
     expect(page).not_to have_selector("input#generic_work_title")
     expect(view.content_for(:files_tab)).to have_link("New Work", href: "/concern/generic_works/new")


### PR DESCRIPTION
Fixes #930 

This fixes a bug in the visibility pane on the new batch form.  Clicking on the `Embargo` radio button will now expand and reveal the "Restricted to..." or "then open it up to.." options like it does on the single work form.  

@projecthydra-labs/hyrax-code-reviewers
