### PR TITLE
Fix Browse Everything when work is being edited

### DIFF
--- a/app/views/hyrax/base/_browse_everything.html.erb
+++ b/app/views/hyrax/base/_browse_everything.html.erb
@@ -3,4 +3,4 @@
 </div>
 <%= button_tag(t('hyrax.upload.browse_everything.browse_files_button'), type: 'button', class: 'btn btn-lg btn-success', id: "browse-btn",
   'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,
-  'data-target' => "##{f.object.persisted? ? 'edit' : 'new'}_#{f.object.model.model_name.param_key}" ) %>
+  'data-target' => "#{f.object.persisted? ? "#edit_#{f.object.model.model_name.param_key}_#{f.object.model.id}" : "#new_#{f.object.model.model_name.param_key}"}" ) %>

--- a/spec/views/hyrax/base/_browse_everything.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_browse_everything.html.erb_spec.rb
@@ -9,5 +9,6 @@ RSpec.describe 'hyrax/base/_browse_everything.html.erb', type: :view do
     render 'hyrax/base/browse_everything', f: f
     page = Capybara::Node::Simple.new(rendered)
     expect(page).to have_selector('div.alert-success', text: /Please note that if you upload a large number of files/i, count: 1)
+    expect(page).to have_selector("button[id='browse-btn'][data-target='#edit_generic_work_#{form.model.id}']")
   end
 end


### PR DESCRIPTION
Fixes #931 

Appends the work pid to the Browse Everything `data-target` when editing a work so that browse everything can properly target the form (e.g. ` edit_generic_work_h989r335q` instead of `edit_generic_work`.  Without this fix, cloud files can't be added to an existing work.

@projecthydra-labs/hyrax-code-reviewers
