### PR TITLE
Cast ActionController::Parameters to HashWithIndifferentAccess

### DIFF
--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -82,7 +82,6 @@ module Hyrax
         #   self.attributes
         # => { 'title' => ['first', 'second'] }
         def remove_blank_attributes!(attributes)
-          # TODO: Don't use each_with_object here; Parameters no longer inherits from Hash
           multivalued_form_attributes(attributes).each_with_object(attributes) do |(k, v), h|
             h[k] = v.instance_of?(Array) ? v.select(&:present?) : v
           end

--- a/app/actors/hyrax/actors/environment.rb
+++ b/app/actors/hyrax/actors/environment.rb
@@ -7,7 +7,7 @@ module Hyrax
       def initialize(curation_concern, current_ability, attributes)
         @curation_concern = curation_concern
         @current_ability = current_ability
-        @attributes = attributes
+        @attributes = attributes.to_h.with_indifferent_access
       end
 
       attr_reader :curation_concern, :current_ability, :attributes

--- a/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
+++ b/spec/actors/hyrax/actors/collections_membership_actor_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Hyrax::Actors::CollectionsMembershipActor do
 
     it 'does not receive the member_of_collection_ids' do
       expect(terminator).to receive(:create).with(Hyrax::Actors::Environment) do |k|
-        expect(k.attributes).to eq(title: ["test"])
+        expect(k.attributes).to eq("title" => ["test"])
       end
       subject.create(env)
     end

--- a/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Hyrax::Actors::DefaultAdminSetActor do
 
       it "creates the default AdminSet with a PermissionTemplate and an ActiveWorkflow then calls the next actor with the default admin set id" do
         expect(terminator).to receive(:create).with(Hyrax::Actors::Environment) do |k|
-          expect(k.attributes).to eq(admin_set_id: default_id)
+          expect(k.attributes).to eq("admin_set_id" => default_id)
           true
         end
         expect(AdminSet).to receive(:find_or_create_default_admin_set_id).and_return(default_id)
@@ -36,7 +36,7 @@ RSpec.describe Hyrax::Actors::DefaultAdminSetActor do
 
       it "uses the provided id, ensures a permission template, and returns true" do
         expect(terminator).to receive(:create).with(Hyrax::Actors::Environment) do |k|
-          expect(k.attributes).to eq(attributes)
+          expect(k.attributes).to eq("admin_set_id" => admin_set.id)
           true
         end
         expect(AdminSet).not_to receive(:find_or_create_default_admin_set_id)

--- a/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
+++ b/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Hyrax::Actors::InterpretVisibilityActor do
 
       it 'does not receive the embargo attributes' do
         expect(terminator).to receive(:create).with(Hyrax::Actors::Environment) do |k|
-          expect(k.attributes).to eq(visibility: 'open')
+          expect(k.attributes).to eq("visibility" => 'open')
           false
         end
         subject.create(env)

--- a/spec/jobs/create_work_job_spec.rb
+++ b/spec/jobs/create_work_job_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe CreateWorkJob do
     context "when the update is successful" do
       it "logs the success" do
         expect(actor).to receive(:create).with(Hyrax::Actors::Environment) do |env|
-          expect(env.attributes).to eq(keyword: [],
-                                       title: ['File One'],
-                                       resource_type: ["Article"],
+          expect(env.attributes).to eq("keyword" => [],
+                                       "title" => ['File One'],
+                                       "resource_type" => ["Article"],
                                        "permissions_attributes" =>
                                                  [{ "type" => "group", "name" => "public", "access" => "read" }],
                                        "visibility" => "open",
-                                       uploaded_files: [upload1.id])
+                                       "uploaded_files" => [upload1.id])
         end.and_return(true)
         subject
         expect(log.reload.status).to eq 'success'


### PR DESCRIPTION
This avoids the deprecation warning that occurs when calling
`AC::Parameters#each_with_object` in the `BaseActor`
