### PR TITLE
Move content blocks from edit-in-place to settings UI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,7 @@ Metrics/BlockLength:
   ExcludedMethods: ['included']
   Exclude:
     - 'hyrax.gemspec'
+    - 'app/models/concerns/hyrax/content_block_behavior.rb'
     - 'app/services/hyrax/workflow/workflow_schema.rb'
     - 'config/initializers/simple_form.rb'
     - 'config/routes.rb'

--- a/app/assets/stylesheets/hyrax/sidebar.scss
+++ b/app/assets/stylesheets/hyrax/sidebar.scss
@@ -36,8 +36,13 @@ $gutter-width: $grid-gutter-width/2;
       transform: rotate(-180deg);
     }
 
-    .nav-pills > li > a {
-      padding-left: 24px;
+    .nav-pills > li {
+      a {
+        padding-left: 24px;
+      }
+      ul > li a {
+        padding-left: 52px;
+      }
     }
   }
 

--- a/app/controllers/hyrax/content_blocks_controller.rb
+++ b/app/controllers/hyrax/content_blocks_controller.rb
@@ -1,33 +1,41 @@
 module Hyrax
   class ContentBlocksController < ApplicationController
     load_and_authorize_resource except: :index
-    before_action :load_featured_researchers, only: :index
     authorize_resource only: :index
+    layout 'dashboard'
 
-    def index; end
-
-    def create
-      @content_block.save
-      redirect_back fallback_location: hyrax.content_blocks_path
+    def edit
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.admin.sidebar.content_blocks'), hyrax.edit_content_blocks_path
     end
 
     def update
-      @content_block.update(update_params)
-      redirect_back fallback_location: hyrax.content_blocks_path
+      respond_to do |format|
+        if @content_block.update(value: update_value_from_params)
+          format.html { redirect_to hyrax.edit_content_blocks_path, notice: t(:'hyrax.content_blocks.updated') }
+        else
+          format.html { render :edit }
+        end
+      end
     end
 
     protected
 
-      def create_params
-        params.require(:content_block).permit([:name, :value, :external_key])
+      def permitted_params
+        params.require(:content_block).permit(:about_page,
+                                              :help_page,
+                                              :marketing_text,
+                                              :announcement_text,
+                                              :featured_researcher)
       end
 
-      def update_params
-        params.require(:content_block).permit([:value, :external_key])
-      end
-
-      def load_featured_researchers
-        @content_blocks = ContentBlock.recent_researchers.page(params[:page])
+      # When a request comes to the controller, it will be for one and
+      # only one of the content blocks. Params always looks like:
+      #   {'about_page' => 'Here is an awesome about page!'}
+      # So reach into permitted params and pull out the first value.
+      def update_value_from_params
+        permitted_params.values.first
       end
   end
 end

--- a/app/helpers/hyrax/content_block_helper_behavior.rb
+++ b/app/helpers/hyrax/content_block_helper_behavior.rb
@@ -1,20 +1,12 @@
 module Hyrax
   module ContentBlockHelperBehavior
-    def editable_content_block(content_block, show_new = false)
-      return raw(content_block.value) unless can? :update, content_block
-      capture do
-        concat content_tag(:div, id: dom_id(content_block, 'preview'), class: 'content_block_preview') {
-          concat raw(content_block.value)
-          concat edit_button(content_block)
-          concat new_button(content_block) if show_new
-        }
-        concat edit_form(content_block)
-        concat new_form(content_block.name) if show_new
-      end
+    def displayable_content_block(content_block, **options)
+      return if content_block.value.blank?
+      content_tag :div, raw(content_block.value), options
     end
 
-    def display_editable_content_block?(content_block)
-      content_block.value.present? || can?(:update, content_block)
+    def display_content_block?(content_block)
+      content_block.value.present?
     end
 
     def edit_button(content_block)

--- a/app/models/concerns/hyrax/content_block_behavior.rb
+++ b/app/models/concerns/hyrax/content_block_behavior.rb
@@ -5,6 +5,8 @@ module Hyrax
     MARKETING  = 'marketing_text'.freeze
     RESEARCHER = 'featured_researcher'.freeze
     ANNOUNCEMENT = 'announcement_text'.freeze
+    ABOUT = 'about_page'.freeze
+    HELP = 'help_page'.freeze
 
     def external_key_name
       self.class.external_keys.fetch(name) { 'External Key' }
@@ -41,6 +43,22 @@ module Hyrax
 
       def external_keys
         { RESEARCHER => 'User' }
+      end
+
+      def about_page
+        find_or_create_by(name: ABOUT)
+      end
+
+      def about_page=(value)
+        about_page.update(value: value)
+      end
+
+      def help_page
+        find_or_create_by(name: HELP)
+      end
+
+      def help_page=(value)
+        help_page.update(value: value)
       end
     end
   end

--- a/app/presenters/hyrax/menu_presenter.rb
+++ b/app/presenters/hyrax/menu_presenter.rb
@@ -10,6 +10,12 @@ module Hyrax
     delegate :controller, :controller_name, :action_name, :content_tag,
              :current_page?, :link_to, :can?, to: :view_context
 
+    # Returns true if the current controller happens to be one of the controllers that deals
+    # with settings.  This is used to keep the parent section on the sidebar open.
+    def settings_section?
+      %w[appearances content_blocks features].include?(controller_name)
+    end
+
     # @param options [Hash, String] a hash or string representing the path. Hash is prefered as it
     #                              allows us to workaround https://github.com/rails/rails/issues/28253
     # @param also_active_for [Hash, String] a hash or string with alternative paths that should be 'active'

--- a/app/views/hyrax/content_blocks/_form.html.erb
+++ b/app/views/hyrax/content_blocks/_form.html.erb
@@ -1,0 +1,101 @@
+<div class="panel panel-default tabs">
+  <ul class="nav nav-tabs" role="tablist">
+    <li class="active">
+      <a href="#about_page" role="tab" data-toggle="tab"><%= t(:'hyrax.content_blocks.tabs.about_page') %></a>
+    </li>
+    <li>
+      <a href="#help_page" role="tab" data-toggle="tab"><%= t(:'hyrax.content_blocks.tabs.help_page') %></a>
+    </li>
+    <li>
+      <a href="#announcement_text" role="tab" data-toggle="tab"><%= t(:'hyrax.content_blocks.tabs.announcement_text') %></a>
+    </li>
+    <li>
+      <a href="#marketing_text" role="tab" data-toggle="tab"><%= t(:'hyrax.content_blocks.tabs.marketing_text') %></a>
+    </li>
+    <li>
+      <a href="#featured_researcher" role="tab" data-toggle="tab"><%= t(:'hyrax.content_blocks.tabs.featured_researcher') %></a>
+    </li>
+  </ul>
+  <div class="tab-content">
+    <div id="about_page" class="tab-pane active">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.about_page, url: hyrax.content_block_path(ContentBlock.about_page) do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+                <%= f.label :about_page %><br>
+                <%= f.text_area :about_page, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
+            <%= f.button :submit, class: 'btn btn-primary pull-right'%>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="help_page" class="tab-pane">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.help_page, url: hyrax.content_block_path(ContentBlock.help_page) do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+                <%= f.label :help_page %><br>
+                <%= f.text_area :help_page, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
+            <%= f.button :submit, class: 'btn btn-primary pull-right'%>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="marketing_text" class="tab-pane">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.marketing_text, url: hyrax.content_block_path(ContentBlock.marketing_text) do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+                <%= f.label :marketing_text %><br>
+                <%= f.text_area :marketing_text, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
+            <%= f.button :submit, class: 'btn btn-primary pull-right'%>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="announcement_text" class="tab-pane">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.announcement_text, url: hyrax.content_block_path(ContentBlock.announcement_text) do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+                <%= f.label :announcement_text %><br>
+                <%= f.text_area :announcement_text, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
+            <%= f.button :submit, class: 'btn btn-primary pull-right'%>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="featured_researcher" class="tab-pane">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.featured_researcher, url: hyrax.content_block_path(ContentBlock.featured_researcher) do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+                <%= f.label :featured_researcher %><br>
+                <%= f.text_area :featured_researcher, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
+            <%= f.button :submit, class: 'btn btn-primary pull-right'%>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/content_blocks/edit.html.erb
+++ b/app/views/hyrax/content_blocks/edit.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_header do %>
+  <h1><span class="fa fa-file-text-o"></span> <%= t(:'hyrax.admin.sidebar.content_blocks') %></h1>
+<% end %>
+
+<div class="row">
+  <div class="col-md-12">
+    <%= render 'form' %>
+  </div>
+</div>

--- a/app/views/hyrax/dashboard/_sidebar.html.erb
+++ b/app/views/hyrax/dashboard/_sidebar.html.erb
@@ -70,19 +70,27 @@
   <% end %>
 
   <% if menu.show_configuration? %>
-    <% if can?(:manage, Hyrax::Feature) %>
-      <li class="h5"><%= t('hyrax.admin.sidebar.configuration') %></li>
-      <%= menu.nav_link(hyrax.admin_features_path) do %>
-        <span class="fa fa-cog"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.settings') %></span>
+    <li class="h5"><%= t('hyrax.admin.sidebar.configuration') %></li>
+    <li>
+      <%= menu.collapsable_section t('hyrax.admin.sidebar.settings'),
+                                   icon_class: "fa fa-cog",
+                                   id: 'collapseSettings',
+                                   open: menu.settings_section? do %>
+        <% if can?(:update, :appearance) %>
+          <%= menu.nav_link(hyrax.admin_appearance_path) do %>
+            <span class="fa fa-paint-brush"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.appearance') %></span>
+          <% end %>
+        <% end %>
+        <% if can?(:manage, Hyrax::Feature) %>
+          <%= menu.nav_link(hyrax.edit_content_blocks_path) do %>
+            <span class="fa fa-file-text-o"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.content_blocks') %></span>
+          <% end %>
+          <%= menu.nav_link(hyrax.admin_features_path) do %>
+            <span class="fa fa-wrench"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.technical') %></span>
+          <% end %>
+        <% end %>
       <% end %>
-    <% end %>
-
-    <% if can?(:update, :appearance) %>
-      <%= menu.nav_link(hyrax.admin_appearance_path) do %>
-        <span class="fa fa-paint-brush"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.appearance') %></span>
-      <% end %>
-    <% end %>
-
+    </li>
     <% if can?(:manage, Sipity::WorkflowResponsibility) %>
       <%= menu.nav_link(hyrax.admin_workflow_roles_path) do %>
         <span class="fa fa-users"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_roles') %></span>

--- a/app/views/hyrax/homepage/_announcement.html.erb
+++ b/app/views/hyrax/homepage/_announcement.html.erb
@@ -1,5 +1,5 @@
-<% if display_editable_content_block? @announcement_text %>
+<% if display_content_block? @announcement_text %>
   <div id="announcement" class="row">
-    <%= editable_content_block @announcement_text %>
+    <%= displayable_content_block @announcement_text, class: 'row', id: 'announcement' %>
   </div>
 <% end %>

--- a/app/views/hyrax/homepage/_featured_researcher.html.erb
+++ b/app/views/hyrax/homepage/_featured_researcher.html.erb
@@ -1,7 +1,5 @@
-<%= editable_content_block @featured_researcher, true %>
-
-<ul class="list-inline collection-highlights-list">
-  <li>
-    <%= link_to t('hyrax.homepage.featured_researcher.view_more'), hyrax.featured_researchers_path, class: 'btn btn-default' %>
-  </li>
-</ul>
+<% if @featured_researcher.value.present? %>
+  <%= displayable_content_block @featured_researcher %>
+<% else %>
+  <%= t('hyrax.homepage.featured_researcher.missing') %>
+<% end %>

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -31,7 +31,7 @@
       </div>
     </div>
   <% else %>
-    <h2><%= t('hyrax.homepage.featured_researcher.title') %></h2>
+    <h2 class="sr-only"><%= t('hyrax.homepage.featured_researcher.title') %></h2>
     <%= render 'featured_researcher' %>
   <% end %>
 </div>

--- a/app/views/hyrax/homepage/_marketing.html.erb
+++ b/app/views/hyrax/homepage/_marketing.html.erb
@@ -1,6 +1,5 @@
-<% if display_editable_content_block? @marketing_text %>
+<% if display_content_block? @marketing_text %>
   <div class="home_marketing_text">
-    <%= editable_content_block @marketing_text %>
+    <%= displayable_content_block @marketing_text, class: 'col-sm-offset-2 col-sm-9 col-md-offset-1 home_marketing_text' %>
   </div>
 <% end %>
-

--- a/app/views/hyrax/pages/show.html.erb
+++ b/app/views/hyrax/pages/show.html.erb
@@ -1,1 +1,1 @@
-<%= editable_content_block @page %>
+<%= displayable_content_block @page, class: 'row', id: 'content_block_page' %>

--- a/app/views/hyrax/static/help.html.erb
+++ b/app/views/hyrax/static/help.html.erb
@@ -1,4 +1,0 @@
-<h1><%= t('hyrax.help.header') %></h1>
-<p>
-    <%= t('hyrax.help.override_text') %>
-</p>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -163,12 +163,14 @@ en:
         appearance:         "Appearance"
         collections:        "Collections"
         configuration:      "Configuration"
+        content_blocks:     "Content Blocks"
         notifications:      "Notifications"
         profile:            "Profile"
         repository_objects: "Repository Contents"
         settings:           "Settings"
         statistics:         "Reports"
         tasks:              "Tasks"
+        technical:          "Technical"
         transfers:          "Transfers"
         users:              "Manage Users"
         user_activity:      "Your activity"
@@ -351,6 +353,15 @@ en:
       select_type: "Select an Issue Type"
       subject_label: "Subject"
       type_label: "Issue Type"
+    content_blocks:
+      cancel:       "Cancel"
+      tabs:
+        about_page: "About Page"
+        announcement_text: "Announcement Text"
+        featured_researcher: "Featured Researcher"
+        help_page:  "Help Page"
+        marketing_text: "Marketing Text"
+      updated: "Content blocks updated."
     controls:
       about:            "About"
       contact:          "Contact"
@@ -484,6 +495,7 @@ en:
         tab_label:          'Explore Collections'
         title:              'Explore Collections'
       featured_researcher:
+        missing:            'No researchers have been featured.'
         tab_label:          'Featured Researcher'
         title:              'Featured Researcher'
         view_more:          'View other featured researchers'

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -163,12 +163,14 @@ es:
         appearance:         "Apariencia"
         collections:        "Colecciones"
         configuration:      "Configuración"
+        content_blocks:     "Bloques de Contenido"
         notifications:      "Notificaciones"
         profile:            "Perfil"
         repository_objects: "Contenido del repositorio"
         settings:           "Ajustes"
         statistics:         "Informes"
         tasks:              "Tareas"
+        technical:          "Técnico"
         transfers:          "Transferencias"
         users:              "Usarios"
         user_activity:      "Su actividad"
@@ -351,6 +353,15 @@ es:
       select_type: "Seleccionar el Tipo de Problema"
       subject_label: "Tema"
       type_label: "Tipo de Problema"
+    content_blocks:
+      cancel:       "Cancelar"
+      tabs:
+        about_page: "Acerca de la Página"
+        announcement_text: "Texto del Anuncio"
+        featured_researcher: "Investigador Destacado"
+        help_page:  "Página de Ayuda"
+        marketing_text: "Texto de Marketing"
+      updated: "Bloques de contenido actualizados."
     controls:
       about:            "Acerca de"
       contact:          "Contacto"
@@ -484,6 +495,7 @@ es:
         tab_label:          'Explorar Colecciones'
         title:              'Explorar Colecciones'
       featured_researcher:
+        missing:            'No se han presentado investigadores.'
         tab_label:          'Investigador destacado'
         title:              'Investigador destacado'
         view_more:          'Ver otros investigadores destacados'

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -165,12 +165,14 @@ zh:
         appearance:         "表面"
         collections:        "收藏"
         configuration:      "配置"
+        content_blocks:     "内容块"
         notifications:      "通知"
         profile:            "个人资料"
         repository_objects: "储存库内容"
         settings:           "设置"
         statistics:         "统计"
         tasks:              "任务"
+        technical:          "技术"
         transfers:          "转让"
         users:              "管理用户"
         user_activity:      "你的操作"
@@ -353,6 +355,15 @@ zh:
       select_type: "选择问题类型"
       subject_label: "主题"
       type_label: "问题类型"
+    content_blocks:
+      cancel: "取消"
+      tabs:
+        about_page: "关于页面"
+        announcement_text: "公告文字"
+        featured_researcher: "特色研究员"
+        help_page:  "帮助页面"
+        marketing_text: "营销文字"
+      updated: "内容块已更新。"
     controls:
       about:            "关于"
       contact:          "联系"
@@ -484,6 +495,7 @@ zh:
         tab_label:          '探索收藏集'
         title:              '探索收藏集'
       featured_researcher:
+        missing:            '没有研究人员被特色。'
         tab_label:          '特色研究者'
         title:              '特色研究者'
         view_more:          '阅览其他特色研究者'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,10 +199,15 @@ Hyrax::Engine.routes.draw do
     resource :appearance
   end
 
-  resources :content_blocks, only: ['create', 'update']
-  get 'featured_researchers' => 'content_blocks#index', as: :featured_researchers
+  resources :content_blocks, only: [] do
+    member do
+      patch :update
+    end
+    collection do
+      get :edit
+    end
+  end
   post '/tinymce_assets' => 'tinymce_assets#create'
-
   get 'about' => 'pages#show', id: 'about_page'
   get 'help' => 'pages#show', id: 'help_page'
 

--- a/spec/helpers/hyrax/content_block_helper_spec.rb
+++ b/spec/helpers/hyrax/content_block_helper_spec.rb
@@ -1,66 +1,35 @@
 RSpec.describe Hyrax::ContentBlockHelper, type: :helper do
   let(:content_block) { FactoryGirl.create(:content_block, value: "<p>foo bar</p>") }
 
-  subject { helper.editable_content_block(content_block) }
+  describe '#displayable_content_block' do
+    let(:options) { {} }
 
-  context "for someone" do
-    context "with access" do
-      before do
-        expect(helper).to receive(:can?).with(:update, content_block).and_return(true)
-      end
-      let(:node) { Capybara::Node::Simple.new(subject) }
+    subject { helper.displayable_content_block(content_block, options) }
 
-      it "shows the preview and the form" do
-        expect(node).to have_selector "button[data-target='#edit_content_block_1'][data-behavior='reveal-editor']"
-        expect(node).to have_selector "form#edit_content_block_1[action='#{hyrax.content_block_path(content_block)}']"
-        expect(subject).to be_html_safe
-      end
-
-      context "with option to create new:" do
-        subject { helper.editable_content_block(content_block, true) }
-
-        it "shows the button & form for a new content block" do
-          expect(node).to have_selector "button[data-target='#new_content_block'][data-behavior='reveal-editor']"
-          expect(node).to have_selector "form#new_content_block[action='#{hyrax.content_blocks_path}']"
-        end
-      end
-    end
-  end
-
-  context "anonymous" do
-    before do
-      expect(helper).to receive(:can?).with(:update, content_block).and_return(false)
-    end
-    it "shows the content" do
-      expect(subject).to eq '<p>foo bar</p>'
-      expect(subject).to be_html_safe
-    end
-  end
-
-  describe '#display_editable_content_block?' do
-    context 'anonymous' do
-      before do
-        allow(helper).to receive(:can?).with(:update, content_block).and_return(false)
-      end
-
-      it 'is true if the content block has data' do
-        expect(helper.display_editable_content_block?(content_block)).to eq true
-      end
-
-      it 'is false if the content block is empty data' do
-        content_block.update(value: '')
-        expect(helper.display_editable_content_block?(content_block)).to eq false
-      end
+    it 'is defined' do
+      expect(helper).to respond_to(:displayable_content_block)
     end
 
-    context 'for someone with access' do
-      before do
-        allow(helper).to receive(:can?).with(:update, content_block).and_return(true)
-      end
+    context 'when a block has a nil value' do
+      let(:content_block) { double(value: nil) }
+      it { is_expected.to be_nil }
+    end
 
-      it 'is true if the user can edit the field' do
-        content_block.update(value: '')
-        expect(helper.display_editable_content_block?(content_block)).to eq true
+    context 'when a block has an empty string value' do
+      let(:content_block) { double(value: '') }
+      it { is_expected.to be_nil }
+    end
+
+    context 'when a block has a non-empty string value' do
+      let(:content_block) { double(value: value) }
+      let(:value) { '<p>foobarbaz</p>' }
+
+      it { is_expected.to eq "<div>#{value}</div>" }
+
+      context 'with options' do
+        let(:options) { { id: 'my_id', class: 'huge' } }
+
+        it { is_expected.to eq "<div id=\"my_id\" class=\"huge\">#{value}</div>" }
       end
     end
   end

--- a/spec/models/content_block_spec.rb
+++ b/spec/models/content_block_spec.rb
@@ -86,4 +86,46 @@ RSpec.describe ContentBlock, type: :model do
       expect(described_class.featured_researcher.value).to eq new_researcher
     end
   end
+
+  context "the about page" do
+    before do
+      create(:content_block,
+             name: ContentBlock::ABOUT,
+             value: '<h1>About Page</h1>')
+    end
+
+    describe 'getter' do
+      subject { described_class.about_page.value }
+      it { is_expected.to eq '<h1>About Page</h1>' }
+    end
+
+    describe 'setter' do
+      let(:new_about) { '<h2>Foobarfoo</h2>' }
+      it 'sets a new about_page' do
+        described_class.about_page = new_about
+        expect(described_class.about_page.value).to eq new_about
+      end
+    end
+  end
+
+  context "the help page" do
+    before do
+      create(:content_block,
+             name: ContentBlock::HELP,
+             value: '<h1>Help Page</h1>')
+    end
+
+    describe 'getter' do
+      subject { described_class.help_page.value }
+      it { is_expected.to eq '<h1>Help Page</h1>' }
+    end
+
+    describe 'setter' do
+      let(:new_help) { '<h2>Foobarfoo</h2>' }
+      it 'sets a new help_page' do
+        described_class.help_page = new_help
+        expect(described_class.help_page.value).to eq new_help
+      end
+    end
+  end
 end

--- a/spec/presenters/hyrax/menu_presenter_spec.rb
+++ b/spec/presenters/hyrax/menu_presenter_spec.rb
@@ -5,6 +5,17 @@ RSpec.describe Hyrax::MenuPresenter do
   let(:context) { ActionView::TestCase::TestController.new.view_context }
   let(:controller_name) { controller.controller_name }
 
+  describe "#settings_section?" do
+    before do
+      allow(context).to receive(:controller_name).and_return(controller_name)
+    end
+    subject { instance.settings_section? }
+    context "for the ContentBlocksController" do
+      let(:controller_name) { Hyrax::ContentBlocksController.controller_name }
+      it { is_expected.to be true }
+    end
+  end
+
   describe "#collapsable_section" do
     subject do
       instance.collapsable_section('link title',

--- a/spec/views/content_blocks/edit.html.erb_spec.rb
+++ b/spec/views/content_blocks/edit.html.erb_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe "hyrax/content_blocks/edit", type: :view do
+  before { render }
+
+  it "renders the about_page form" do
+    assert_select "form[action=?][method=?]", hyrax.content_block_path(ContentBlock.about_page), "post" do
+      assert_select "textarea#content_block_about_page[name=?]", "content_block[about_page]"
+    end
+  end
+
+  it "renders the help_page form" do
+    assert_select "form[action=?][method=?]", hyrax.content_block_path(ContentBlock.help_page), "post" do
+      assert_select "textarea#content_block_help_page[name=?]", "content_block[help_page]"
+    end
+  end
+
+  it "renders the announcement_text form" do
+    assert_select "form[action=?][method=?]", hyrax.content_block_path(ContentBlock.announcement_text), "post" do
+      assert_select "textarea#content_block_announcement_text[name=?]", "content_block[announcement_text]"
+    end
+  end
+
+  it "renders the marketing_text form" do
+    assert_select "form[action=?][method=?]", hyrax.content_block_path(ContentBlock.marketing_text), "post" do
+      assert_select "textarea#content_block_marketing_text[name=?]", "content_block[marketing_text]"
+    end
+  end
+
+  it "renders the featured_researcher form" do
+    assert_select "form[action=?][method=?]", hyrax.content_block_path(ContentBlock.featured_researcher), "post" do
+      assert_select "textarea#content_block_featured_researcher[name=?]", "content_block[featured_researcher]"
+    end
+  end
+end

--- a/spec/views/hyrax/homepage/_announcement.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/_announcement.html.erb_spec.rb
@@ -9,42 +9,19 @@ RSpec.describe "hyrax/homepage/_announcement.html.erb", type: :view do
     view.extend Hyrax::ContentBlockHelper
     assign(:announcement_text, announcement)
     allow(controller).to receive(:current_ability).and_return(ability)
-    allow(ability).to receive(:can?).with(:update, ContentBlock).and_return(can_update_content_block)
     render
   end
 
   context "when there is an announcement" do
     let(:announcement_value) { "I have an announcement!" }
 
-    context "when the user can update content" do
-      let(:can_update_content_block) { true }
-
-      it { is_expected.to have_content announcement_value }
-      it { is_expected.to have_button("Edit") }
-    end
-
-    context "when the user can't update content" do
-      let(:can_update_content_block) { false }
-
-      it { is_expected.to have_content announcement_value }
-      it { is_expected.not_to have_button("Edit") }
-    end
+    it { is_expected.to have_content announcement_value }
+    it { is_expected.not_to have_button("Edit") }
   end
 
   context "when there is no announcement" do
     let(:announcement_value) { "" }
 
-    context "when the user can update content" do
-      let(:can_update_content_block) { true }
-
-      it { is_expected.to have_selector "#announcement" }
-      it { is_expected.to have_button("Edit") }
-    end
-
-    context "when the user can't update content" do
-      let(:can_update_content_block) { false }
-
-      it { is_expected.not_to have_selector "#announcement" }
-    end
+    it { is_expected.not_to have_selector "#announcement" }
   end
 end


### PR DESCRIPTION
Fixes #538

**N.B.** This pull request removes part of the ContentBlocks implementation that seems to be an incomplete feature. I am removing it partly because of its incompleteness and also because it no longer fits the UI.

Prior to this commit, a user could create multiple ContentBlocks with a `name` of `:featured_researcher` (unlike any of the other ContentBlocks). This allows an administrative user to create a page, linked previously from the homepage, where many featured researchers can be viewed. The feature is incomplete, AFAICT, because it only allows creating new featured researcher. It doesn't allow deleting former featured researchers, re-featuring former researchers, editing researchers, re-ordering researchers, or any other functionality.

After pinging the Penn State folks on Slack and hearing back from @kestlund, who was supportive of removing the feature (though she cautioned that we wait to hear more from @olendorf), I recommend that we move forward with removing this feature in Hyrax 2.0.0, and write up a new set of tickets that build this functionality back in more fully and in a way that matches the Hyrax UI better. This will require one or more new user stories (@vantuyls? @hannahfrost? @kestlund?), and, after that, some design work (@mtribone? @ggeisler?), depending on who all is invested in this feature. I imagine this can be taken up in a 2.x feature release (2.1, 2.2, etc.) depending on when the above is complete.

Thoughts?

@projecthydra-labs/hyrax-code-reviewers @projecthydra-labs/hyrax-ui-ux-advisors 
