### PR TITLE
Gemfile - update engine cart stanza for v1.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,9 +36,9 @@ else
 
   case ENV['RAILS_VERSION']
   when /^4.2/
+    gem 'coffee-rails', '~> 4.1.0'
     gem 'responders', '~> 2.0'
     gem 'sass-rails', '>= 5.0'
-    gem 'coffee-rails', '~> 4.1.0'
   when /^4.[01]/
     gem 'sass-rails', '< 5.0'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development, :test do
 end
 
 # BEGIN ENGINE_CART BLOCK
-# engine_cart: 0.10.0
+# engine_cart: 1.1.0
 # engine_cart stanza: 0.10.0
 # the below comes from engine_cart, a gem used to test this Rails engine gem in the context of a Rails app.
 file = File.expand_path('Gemfile', ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path('.internal_test_app', File.dirname(__FILE__)))
@@ -36,9 +36,9 @@ else
 
   case ENV['RAILS_VERSION']
   when /^4.2/
-    gem 'coffee-rails', '~> 4.2.0'
     gem 'responders', '~> 2.0'
     gem 'sass-rails', '>= 5.0'
+    gem 'coffee-rails', '~> 4.1.0'
   when /^4.[01]/
     gem 'sass-rails', '< 5.0'
   end


### PR DESCRIPTION
Related to https://github.com/cbeer/engine_cart/issues/79 (does not fix it in engine_cart)

@projecthydra-labs/hyrax-code-reviewers

@mjgiarlo - I just discovered that this could undo a prior hack on the engine-cart stanza:
  - https://github.com/projecthydra-labs/hyrax/commit/8071e331a5d522c42dc104bbfaa7f64b7cb422c8
  - Is there another way to achieve that without hacking the engine-cart stanza?
    - attempted to do so in https://github.com/projecthydra-labs/hyrax/pull/1010/commits/fefd4901a85d4be13ec2ff2cb5a418a1d66d6b99
  - review commentary resolved to ignore overriding this gem version for rails 4.2 because hyrax needs rails 5.x now anyway, so the commit ^^ was removed.
