### PR TITLE
Remove part_of metadata property

### DIFF
--- a/app/models/concerns/hyrax/basic_metadata.rb
+++ b/app/models/concerns/hyrax/basic_metadata.rb
@@ -11,8 +11,6 @@ module Hyrax
       property :relative_path, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#relativePath'), multiple: false
 
       property :import_url, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#importUrl'), multiple: false
-
-      property :part_of, predicate: ::RDF::Vocab::DC.isPartOf
       property :resource_type, predicate: ::RDF::Vocab::DC.type
       property :creator, predicate: ::RDF::Vocab::DC11.creator
       property :contributor, predicate: ::RDF::Vocab::DC11.contributor

--- a/spec/indexers/hyrax/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/file_set_indexer_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Hyrax::FileSetIndexer do
   let(:file_set) do
     FileSet.new(
       id: 'foo123',
-      part_of: ['Arabiana'],
       contributor: ['Mohammad'],
       creator: ['Allah'],
       title: ['The Work'],
@@ -60,7 +59,6 @@ RSpec.describe Hyrax::FileSetIndexer do
     it 'has fields' do
       expect(subject[Solrizer.solr_name('hasRelatedMediaFragment', :symbol)]).to eq 'foo123'
       expect(subject[Solrizer.solr_name('hasRelatedImage', :symbol)]).to eq 'foo123'
-      expect(subject[Solrizer.solr_name('part_of')]).to be_nil
       expect(subject[Solrizer.solr_name('date_uploaded')]).to be_nil
       expect(subject[Solrizer.solr_name('date_modified')]).to be_nil
       expect(subject[Solrizer.solr_name('date_uploaded', :stored_sortable, type: :date)]).to eq '2011-01-01T00:00:00Z'

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -81,7 +81,6 @@ RSpec.describe FileSet do
       expect(subject).to respond_to(:depositor)
       expect(subject).to respond_to(:related_url)
       expect(subject).to respond_to(:based_near)
-      expect(subject).to respond_to(:part_of)
       expect(subject).to respond_to(:contributor)
       expect(subject).to respond_to(:creator)
       expect(subject).to respond_to(:title)

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -132,7 +132,6 @@ RSpec.describe GenericWork do
       expect(subject).to respond_to(:depositor)
       expect(subject).to respond_to(:related_url)
       expect(subject).to respond_to(:based_near)
-      expect(subject).to respond_to(:part_of)
       expect(subject).to respond_to(:contributor)
       expect(subject).to respond_to(:creator)
       expect(subject).to respond_to(:title)


### PR DESCRIPTION
It collides with the AdminSet association which also uses `DC.isPartOf`.
The part_of association was not exposed in the UI.

Fixes #998 