### PR TITLE
Handle exception when no workflow action selected

### DIFF
--- a/app/forms/hyrax/forms/workflow_action_form.rb
+++ b/app/forms/hyrax/forms/workflow_action_form.rb
@@ -38,6 +38,7 @@ module Hyrax
       validate :authorized_for_processing
 
       def authorized_for_processing
+        return false if name.blank? # name is the action which converts to sipity_workflow_action
         return true if Hyrax::Workflow::PermissionQuery.authorized_for_processing?(
           user: subject.user,
           entity: subject.entity,
@@ -51,7 +52,7 @@ module Hyrax
 
         def convert_to_sipity_objects!
           @subject = WorkflowActionInfo.new(work, current_user)
-          @sipity_workflow_action = PowerConverter.convert_to_sipity_action(name, scope: subject.entity.workflow)
+          @sipity_workflow_action = PowerConverter.convert_to_sipity_action(name, scope: subject.entity.workflow) { nil }
         end
 
         attr_reader :subject, :sipity_workflow_action

--- a/spec/forms/hyrax/forms/workflow_action_form_spec.rb
+++ b/spec/forms/hyrax/forms/workflow_action_form_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe Hyrax::Forms::WorkflowActionForm, no_clean: true do
                     triggered_methods: Sipity::Method.none)
   end
 
-  before do
-    allow(PowerConverter).to receive(:convert_to_sipity_action).with('an_action', scope: sipity_entity.workflow).and_return(an_action)
-  end
-
   context 'if the given user cannot perform the given action' do
-    before { expect(Hyrax::Workflow::PermissionQuery).to receive(:authorized_for_processing?).and_return(false) }
+    before do
+      allow(PowerConverter).to receive(:convert_to_sipity_action).with('an_action', scope: sipity_entity.workflow).and_return(an_action)
+      expect(Hyrax::Workflow::PermissionQuery).to receive(:authorized_for_processing?).and_return(false)
+    end
+
     describe '#valid?' do
       subject { form.valid? }
       it { is_expected.to be false }
@@ -54,6 +54,7 @@ RSpec.describe Hyrax::Forms::WorkflowActionForm, no_clean: true do
 
   context 'if the given user can perform the given action' do
     before do
+      allow(PowerConverter).to receive(:convert_to_sipity_action).with('an_action', scope: sipity_entity.workflow).and_return(an_action)
       expect(Hyrax::Workflow::PermissionQuery).to receive(:authorized_for_processing?)
         .and_return(true)
     end
@@ -108,6 +109,20 @@ RSpec.describe Hyrax::Forms::WorkflowActionForm, no_clean: true do
         )
         subject
       end
+    end
+  end
+
+  context 'when no option is selected upon initialization' do
+    before do
+      sipity_entity
+    end
+    let(:form) do
+      described_class.new(current_ability: current_ability,
+                          work: work,
+                          attributes: { comment: '' })
+    end
+    it 'will be invalid' do
+      expect(form).not_to be_valid
     end
   end
 end


### PR DESCRIPTION
Related to https://github.com/projecthydra-labs/hyrax/issues/671

Handle the exception: PowerConverter::ConversionError - Unable to convert false to 'sipity_action' that occurred when save was selected without choosing a workflow action.

@projecthydra-labs/hyrax-code-reviewers
