### PR TITLE
FacetedAttributeRenderer should singly escape, not double

### DIFF
--- a/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
@@ -8,7 +8,7 @@ module Hyrax
         end
 
         def search_path(value)
-          Rails.application.routes.url_helpers.search_catalog_path(:"f[#{search_field}][]" => ERB::Util.h(value))
+          Rails.application.routes.url_helpers.search_catalog_path(:"f[#{search_field}][]" => value)
         end
 
         def search_field

--- a/spec/renderers/hyrax/renderers/faceted_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/faceted_attribute_renderer_spec.rb
@@ -20,4 +20,15 @@ RSpec.describe Hyrax::Renderers::FacetedAttributeRenderer do
     it { expect(renderer).not_to be_microdata(field) }
     it { expect(subject).to be_equivalent_to(expected) }
   end
+
+  describe "href generated" do
+    describe "escaping" do
+      let(:renderer) { described_class.new(field, ['John & Bob']) }
+      let(:rendered_link) { Nokogiri::HTML(renderer.render).at_css("a") }
+      let(:rendered_link_query) { URI.parse(rendered_link['href']).query }
+      it "escapes content properly" do
+        expect(rendered_link_query).to eq "#{CGI.escape('f[name_sim][]')}=#{CGI.escape('John & Bob')}"
+      end
+    end
+  end
 end


### PR DESCRIPTION
There is no need to escape the param _before_ passing to a Rails route helper,
the rails route helper will escape for you. Escaping first results in _double_
escaped content, and a broken search link.