### PR TITLE
Split page-type content blocks into new controller and route

### DIFF
--- a/app/controllers/hyrax/admin/features_controller.rb
+++ b/app/controllers/hyrax/admin/features_controller.rb
@@ -10,7 +10,8 @@ module Hyrax
       def index
         add_breadcrumb t(:'hyrax.controls.home'), root_path
         add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-        add_breadcrumb t(:'hyrax.admin.sidebar.settings'), hyrax.admin_features_path
+        add_breadcrumb t(:'hyrax.admin.sidebar.configuration'), '#'
+        add_breadcrumb t(:'hyrax.admin.sidebar.technical'), hyrax.admin_features_path
         super
       end
     end

--- a/app/controllers/hyrax/content_blocks_controller.rb
+++ b/app/controllers/hyrax/content_blocks_controller.rb
@@ -6,6 +6,7 @@ module Hyrax
     def edit
       add_breadcrumb t(:'hyrax.controls.home'), root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.admin.sidebar.configuration'), '#'
       add_breadcrumb t(:'hyrax.admin.sidebar.content_blocks'), hyrax.edit_content_blocks_path
     end
 
@@ -22,9 +23,7 @@ module Hyrax
     protected
 
       def permitted_params
-        params.require(:content_block).permit(:about_page,
-                                              :help_page,
-                                              :marketing_text,
+        params.require(:content_block).permit(:marketing_text,
                                               :announcement_text,
                                               :featured_researcher)
       end

--- a/app/controllers/hyrax/pages_controller.rb
+++ b/app/controllers/hyrax/pages_controller.rb
@@ -1,12 +1,50 @@
 module Hyrax
   # Shows the about and help page
   class PagesController < ApplicationController
-    helper Hyrax::ContentBlockHelper
+    load_and_authorize_resource class: ContentBlock, except: :show
+    layout :pages_layout
 
-    layout 'homepage'
+    helper Hyrax::ContentBlockHelper
 
     def show
       @page = ContentBlock.find_or_create_by(name: params[:id])
     end
+
+    def edit
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.admin.sidebar.configuration'), '#'
+      add_breadcrumb t(:'hyrax.admin.sidebar.pages'), hyrax.edit_pages_path
+    end
+
+    def update
+      respond_to do |format|
+        if @page.update(value: update_value_from_params)
+          format.html { redirect_to hyrax.edit_pages_path, notice: t(:'hyrax.pages.updated') }
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    protected
+
+      def permitted_params
+        params.require(:content_block).permit(:about_page, :help_page)
+      end
+
+      # When a request comes to the controller, it will be for one and
+      # only one of the content blocks. Params always looks like:
+      #   {'about_page' => 'Here is an awesome about page!'}
+      # So reach into permitted params and pull out the first value.
+      def update_value_from_params
+        permitted_params.values.first
+      end
+
+    private
+
+      def pages_layout
+        action_name == 'show' ? 'homepage' : 'dashboard'
+      end
   end
 end

--- a/app/presenters/hyrax/menu_presenter.rb
+++ b/app/presenters/hyrax/menu_presenter.rb
@@ -13,7 +13,7 @@ module Hyrax
     # Returns true if the current controller happens to be one of the controllers that deals
     # with settings.  This is used to keep the parent section on the sidebar open.
     def settings_section?
-      %w[appearances content_blocks features].include?(controller_name)
+      %w[appearances content_blocks features pages].include?(controller_name)
     end
 
     # @param options [Hash, String] a hash or string representing the path. Hash is prefered as it

--- a/app/views/hyrax/content_blocks/_form.html.erb
+++ b/app/views/hyrax/content_blocks/_form.html.erb
@@ -1,11 +1,5 @@
 <div class="panel panel-default tabs">
   <ul class="nav nav-tabs" role="tablist">
-    <li class="active">
-      <a href="#about_page" role="tab" data-toggle="tab"><%= t(:'hyrax.content_blocks.tabs.about_page') %></a>
-    </li>
-    <li>
-      <a href="#help_page" role="tab" data-toggle="tab"><%= t(:'hyrax.content_blocks.tabs.help_page') %></a>
-    </li>
     <li>
       <a href="#announcement_text" role="tab" data-toggle="tab"><%= t(:'hyrax.content_blocks.tabs.announcement_text') %></a>
     </li>
@@ -17,29 +11,13 @@
     </li>
   </ul>
   <div class="tab-content">
-    <div id="about_page" class="tab-pane active">
+    <div id="announcement_text" class="tab-pane active">
       <div class="panel panel-default labels">
-        <%= simple_form_for ContentBlock.about_page, url: hyrax.content_block_path(ContentBlock.about_page) do |f| %>
+        <%= simple_form_for ContentBlock.announcement_text, url: hyrax.content_block_path(ContentBlock.announcement_text) do |f| %>
           <div class="panel-body">
             <div class="field form-group">
-                <%= f.label :about_page %><br>
-                <%= f.text_area :about_page, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
-            </div>
-          </div>
-          <div class="panel-footer">
-            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
-            <%= f.button :submit, class: 'btn btn-primary pull-right'%>
-          </div>
-        <% end %>
-      </div>
-    </div>
-    <div id="help_page" class="tab-pane">
-      <div class="panel panel-default labels">
-        <%= simple_form_for ContentBlock.help_page, url: hyrax.content_block_path(ContentBlock.help_page) do |f| %>
-          <div class="panel-body">
-            <div class="field form-group">
-                <%= f.label :help_page %><br>
-                <%= f.text_area :help_page, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+                <%= f.label :announcement_text %><br>
+                <%= f.text_area :announcement_text, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
             </div>
           </div>
           <div class="panel-footer">
@@ -56,22 +34,6 @@
             <div class="field form-group">
                 <%= f.label :marketing_text %><br>
                 <%= f.text_area :marketing_text, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
-            </div>
-          </div>
-          <div class="panel-footer">
-            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
-            <%= f.button :submit, class: 'btn btn-primary pull-right'%>
-          </div>
-        <% end %>
-      </div>
-    </div>
-    <div id="announcement_text" class="tab-pane">
-      <div class="panel panel-default labels">
-        <%= simple_form_for ContentBlock.announcement_text, url: hyrax.content_block_path(ContentBlock.announcement_text) do |f| %>
-          <div class="panel-body">
-            <div class="field form-group">
-                <%= f.label :announcement_text %><br>
-                <%= f.text_area :announcement_text, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
             </div>
           </div>
           <div class="panel-footer">

--- a/app/views/hyrax/dashboard/_sidebar.html.erb
+++ b/app/views/hyrax/dashboard/_sidebar.html.erb
@@ -82,8 +82,11 @@
           <% end %>
         <% end %>
         <% if can?(:manage, Hyrax::Feature) %>
+          <%= menu.nav_link(hyrax.edit_pages_path) do %>
+            <span class="fa fa-file-text-o"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.pages') %></span>
+          <% end %>
           <%= menu.nav_link(hyrax.edit_content_blocks_path) do %>
-            <span class="fa fa-file-text-o"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.content_blocks') %></span>
+            <span class="fa fa-square-o"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.content_blocks') %></span>
           <% end %>
           <%= menu.nav_link(hyrax.admin_features_path) do %>
             <span class="fa fa-wrench"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.technical') %></span>

--- a/app/views/hyrax/pages/_form.html.erb
+++ b/app/views/hyrax/pages/_form.html.erb
@@ -1,0 +1,44 @@
+<div class="panel panel-default tabs">
+  <ul class="nav nav-tabs" role="tablist">
+    <li class="active">
+      <a href="#about_page" role="tab" data-toggle="tab"><%= t(:'hyrax.pages.tabs.about_page') %></a>
+    </li>
+    <li>
+      <a href="#help_page" role="tab" data-toggle="tab"><%= t(:'hyrax.pages.tabs.help_page') %></a>
+    </li>
+  </ul>
+  <div class="tab-content">
+    <div id="about_page" class="tab-pane active">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.about_page, url: hyrax.page_path(ContentBlock.about_page) do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+                <%= f.label :about_page %><br>
+                <%= f.text_area :about_page, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
+            <%= f.button :submit, class: 'btn btn-primary pull-right'%>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="help_page" class="tab-pane">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.help_page, url: hyrax.page_path(ContentBlock.help_page) do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+                <%= f.label :help_page %><br>
+                <%= f.text_area :help_page, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
+            <%= f.button :submit, class: 'btn btn-primary pull-right'%>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/pages/edit.html.erb
+++ b/app/views/hyrax/pages/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_header do %>
-  <h1><span class="fa fa-square-o"></span> <%= t(:'hyrax.admin.sidebar.content_blocks') %></h1>
+  <h1><span class="fa fa-file-text-o"></span> <%= t(:'hyrax.admin.sidebar.pages') %></h1>
 <% end %>
 
 <div class="row">

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -167,6 +167,7 @@ en:
         configuration:      "Configuration"
         content_blocks:     "Content Blocks"
         notifications:      "Notifications"
+        pages:              "Pages"
         profile:            "Profile"
         repository_objects: "Repository Contents"
         settings:           "Settings"
@@ -358,10 +359,8 @@ en:
     content_blocks:
       cancel:       "Cancel"
       tabs:
-        about_page: "About Page"
         announcement_text: "Announcement Text"
         featured_researcher: "Featured Researcher"
-        help_page:  "Help Page"
         marketing_text: "Marketing Text"
       updated: "Content blocks updated."
     controls:
@@ -535,6 +534,12 @@ en:
         single: "has been saved."
         subject: "Batch upload complete"
         title:  "Files uploaded successfully"
+    pages:
+      cancel:       "Cancel"
+      tabs:
+        about_page: "About Page"
+        help_page:  "Help Page"
+      updated: "Pages updated."
     passive_consent_to_agreement: "By saving this work I agree to the"
     search:
       button:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -167,6 +167,7 @@ es:
         configuration:      "Configuración"
         content_blocks:     "Bloques de Contenido"
         notifications:      "Notificaciones"
+        pages:              "Páginas"
         profile:            "Perfil"
         repository_objects: "Contenido del repositorio"
         settings:           "Ajustes"
@@ -358,10 +359,8 @@ es:
     content_blocks:
       cancel:       "Cancelar"
       tabs:
-        about_page: "Acerca de la Página"
         announcement_text: "Texto del Anuncio"
         featured_researcher: "Investigador Destacado"
-        help_page:  "Página de Ayuda"
         marketing_text: "Texto de Marketing"
       updated: "Bloques de contenido actualizados."
     controls:
@@ -535,6 +534,12 @@ es:
         single: "ha sido guardado."
         subject: "Carga en lote completa"
         title:  "Archivos cargados satisfactoriamente"
+    pages:
+      cancel:       "Cancelar"
+      tabs:
+        about_page: "Acerca de la Página"
+        help_page:  "Página de Ayuda"
+      updated: "Páginas actualizadas."
     passive_consent_to_agreement: "Al salvar este trabajo yo acepto a"
     search:
       button:

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -169,6 +169,7 @@ zh:
         configuration:      "配置"
         content_blocks:     "内容块"
         notifications:      "通知"
+        pages:              "网页"
         profile:            "个人资料"
         repository_objects: "储存库内容"
         settings:           "设置"
@@ -360,10 +361,8 @@ zh:
     content_blocks:
       cancel: "取消"
       tabs:
-        about_page: "关于页面"
         announcement_text: "公告文字"
         featured_researcher: "特色研究员"
-        help_page:  "帮助页面"
         marketing_text: "营销文字"
       updated: "内容块已更新。"
     controls:
@@ -535,6 +534,12 @@ zh:
         single: "已保存。"
         subject: "批量上传完成"
         title:  "文件上传成功"
+    pages:
+      cancel: "取消"
+      tabs:
+        about_page: "关于页面"
+        help_page:  "帮助页面"
+      updated: "页面更新。"
     passive_consent_to_agreement: "保存这件作品表明我同意"
     search:
       button:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,6 +210,14 @@ Hyrax::Engine.routes.draw do
       get :edit
     end
   end
+  resources :pages, only: [] do
+    member do
+      patch :update
+    end
+    collection do
+      get :edit
+    end
+  end
   get 'about' => 'pages#show', id: 'about_page'
   get 'help' => 'pages#show', id: 'help_page'
 

--- a/spec/controllers/hyrax/admin/features_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/features_controller_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe Hyrax::Admin::FeaturesController do
       end
 
       it "is successful" do
+        expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+        expect(controller).to receive(:add_breadcrumb).with('Administration', dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Configuration', '#')
+        expect(controller).to receive(:add_breadcrumb).with('Technical', admin_features_path)
         get :index
         expect(response).to be_success
       end

--- a/spec/controllers/hyrax/content_blocks_controller_spec.rb
+++ b/spec/controllers/hyrax/content_blocks_controller_spec.rb
@@ -8,12 +8,6 @@ RSpec.describe Hyrax::ContentBlocksController, type: :controller do
   let!(:featured_researcher) do
     FactoryGirl.create(:content_block, name: 'featured_researcher')
   end
-  let!(:about_page) do
-    FactoryGirl.create(:content_block, name: 'about_page')
-  end
-  let!(:help_page) do
-    FactoryGirl.create(:content_block, name: 'help_page')
-  end
 
   before do
     sign_in user
@@ -41,27 +35,17 @@ RSpec.describe Hyrax::ContentBlocksController, type: :controller do
     let(:user) { FactoryGirl.create(:admin) }
 
     describe "GET #edit" do
-      it "assigns the requested site as @site" do
+      it "renders breadcrumbs" do
+        expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+        expect(controller).to receive(:add_breadcrumb).with('Administration', dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Configuration', '#')
+        expect(controller).to receive(:add_breadcrumb).with('Content Blocks', edit_content_blocks_path)
         get :edit
         expect(response).to have_http_status(200)
       end
     end
 
     describe "PATCH #update" do
-      it "updates the about page" do
-        patch :update, params: { id: about_page.id, content_block: { about_page: 'This is a new page about us!' } }
-        expect(response).to redirect_to(edit_content_blocks_path)
-        expect(flash[:notice]).to include 'Content blocks updated'
-        expect(ContentBlock.about_page.value).to eq "This is a new page about us!"
-      end
-
-      it "updates the help page" do
-        patch :update, params: { id: help_page.id, content_block: { help_page: 'This page will provide more of the help you need.' } }
-        expect(response).to redirect_to(edit_content_blocks_path)
-        expect(flash[:notice]).to include 'Content blocks updated'
-        expect(ContentBlock.help_page.value).to eq 'This page will provide more of the help you need.'
-      end
-
       it "updates the announcement text" do
         patch :update, params: { id: announcement_text.id, content_block: { announcement_text: 'Now Hiring!' } }
         expect(response).to redirect_to(edit_content_blocks_path)

--- a/spec/controllers/hyrax/pages_controller_spec.rb
+++ b/spec/controllers/hyrax/pages_controller_spec.rb
@@ -1,22 +1,82 @@
 RSpec.describe Hyrax::PagesController, type: :controller do
-  let(:page_name) { "about_page" }
-  context "content exists" do
-    describe "GET #show" do
-      let(:page) { ContentBlock.create!(name: page_name, value: "foo bar") }
+  let(:user) { FactoryGirl.create(:user) }
 
-      it "updates the node" do
+  before do
+    sign_in user
+  end
+
+  context "when content exists" do
+    describe "GET #show" do
+      let(:page) { ContentBlock.create!(name: 'about_page', value: "foo bar") }
+
+      it "updates the node and renders homepage layout" do
         get :show, params: { id: page.name }
+        expect(response).to render_template('layouts/homepage')
         expect(response).to be_successful
         expect(assigns[:page]).to eq page
       end
     end
   end
-  context "content does not exist" do
+  context "when content does not exist" do
     describe "GET #show" do
       it "creates the node" do
         get :show, params: { id: "about_page" }
         expect(response).to be_successful
         expect(assigns[:page]).not_to be_nil
+      end
+    end
+  end
+  context 'when editing pages' do
+    let!(:about_page) do
+      FactoryGirl.create(:content_block, name: 'about_page')
+    end
+    let!(:help_page) do
+      FactoryGirl.create(:content_block, name: 'help_page')
+    end
+    context 'with an unprivileged user' do
+      describe "GET #edit" do
+        it "denies the request" do
+          get :edit
+          expect(response).to have_http_status(401)
+        end
+      end
+
+      describe "PATCH #update" do
+        it "denies the request" do
+          patch :update, params: { id: 1 }
+          expect(response).to have_http_status(401)
+        end
+      end
+    end
+    context 'with an administrator' do
+      let(:user) { FactoryGirl.create(:admin) }
+
+      describe "GET #edit" do
+        it "renders breadcrumbs and dashboard layout" do
+          expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+          expect(controller).to receive(:add_breadcrumb).with('Administration', dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Configuration', '#')
+          expect(controller).to receive(:add_breadcrumb).with('Pages', edit_pages_path)
+          get :edit
+          expect(response).to have_http_status(200)
+          expect(response).to render_template('layouts/dashboard')
+        end
+      end
+
+      describe "PATCH #update" do
+        it "updates the about page" do
+          patch :update, params: { id: about_page.id, content_block: { about_page: 'This is a new page about us!' } }
+          expect(response).to redirect_to(edit_pages_path)
+          expect(flash[:notice]).to include 'Pages updated'
+          expect(ContentBlock.about_page.value).to eq "This is a new page about us!"
+        end
+
+        it "updates the help page" do
+          patch :update, params: { id: help_page.id, content_block: { help_page: 'This page will provide more of the help you need.' } }
+          expect(response).to redirect_to(edit_pages_path)
+          expect(flash[:notice]).to include 'Pages updated'
+          expect(ContentBlock.help_page.value).to eq 'This page will provide more of the help you need.'
+        end
       end
     end
   end

--- a/spec/presenters/hyrax/menu_presenter_spec.rb
+++ b/spec/presenters/hyrax/menu_presenter_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Hyrax::MenuPresenter do
       let(:controller_name) { Hyrax::ContentBlocksController.controller_name }
       it { is_expected.to be true }
     end
+    context "for the PagesController" do
+      let(:controller_name) { Hyrax::PagesController.controller_name }
+      it { is_expected.to be true }
+    end
   end
 
   describe "#collapsable_section" do

--- a/spec/routing/route_spec.rb
+++ b/spec/routing/route_spec.rb
@@ -149,12 +149,27 @@ RSpec.describe 'Routes', type: :routing do
     end
   end
 
+  describe 'Content Blocks' do
+    it 'routes to update' do
+      expect(patch: '/content_blocks/1').to route_to(controller: 'hyrax/content_blocks', action: 'update', id: '1')
+    end
+    it 'routes to edit' do
+      expect(get: '/content_blocks/edit').to route_to(controller: 'hyrax/content_blocks', action: 'edit')
+    end
+  end
+
   describe "Dynamically edited pages" do
     it "routes to about" do
       expect(get: '/about').to route_to(controller: 'hyrax/pages', action: 'show', id: 'about_page')
     end
     it "routes to help" do
       expect(get: '/help').to route_to(controller: 'hyrax/pages', action: 'show', id: 'help_page')
+    end
+    it 'routes to update' do
+      expect(patch: '/pages/1').to route_to(controller: 'hyrax/pages', action: 'update', id: '1')
+    end
+    it 'routes to edit' do
+      expect(get: '/pages/edit').to route_to(controller: 'hyrax/pages', action: 'edit')
     end
   end
 

--- a/spec/views/content_blocks/edit.html.erb_spec.rb
+++ b/spec/views/content_blocks/edit.html.erb_spec.rb
@@ -1,18 +1,6 @@
 RSpec.describe "hyrax/content_blocks/edit", type: :view do
   before { render }
 
-  it "renders the about_page form" do
-    assert_select "form[action=?][method=?]", hyrax.content_block_path(ContentBlock.about_page), "post" do
-      assert_select "textarea#content_block_about_page[name=?]", "content_block[about_page]"
-    end
-  end
-
-  it "renders the help_page form" do
-    assert_select "form[action=?][method=?]", hyrax.content_block_path(ContentBlock.help_page), "post" do
-      assert_select "textarea#content_block_help_page[name=?]", "content_block[help_page]"
-    end
-  end
-
   it "renders the announcement_text form" do
     assert_select "form[action=?][method=?]", hyrax.content_block_path(ContentBlock.announcement_text), "post" do
       assert_select "textarea#content_block_announcement_text[name=?]", "content_block[announcement_text]"

--- a/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
@@ -1,0 +1,90 @@
+RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
+  let(:user) { stub_model(User, user_key: 'mjg', name: 'Foobar') }
+  let(:read_admin_dashboard) { false }
+  let(:manage_any_admin_set) { false }
+  let(:review_submissions) { false }
+  let(:manage_user) { false }
+  let(:update_appearance) { false }
+  let(:manage_feature) { false }
+  let(:manage_workflow) { false }
+
+  before do
+    allow(view).to receive(:signed_in?).and_return(true)
+    allow(view).to receive(:current_user).and_return(user)
+    assign(:user, user)
+    allow(view).to receive(:can?).with(:read, :admin_dashboard).and_return(read_admin_dashboard)
+    allow(view).to receive(:can?).with(:manage_any, AdminSet).and_return(manage_any_admin_set)
+    allow(view).to receive(:can?).with(:review, :submissions).and_return(review_submissions)
+    allow(view).to receive(:can?).with(:manage, User).and_return(manage_user)
+    allow(view).to receive(:can?).with(:update, :appearance).and_return(update_appearance)
+    allow(view).to receive(:can?).with(:manage, Hyrax::Feature).and_return(manage_feature)
+    allow(view).to receive(:can?).with(:manage, Sipity::WorkflowResponsibility).and_return(manage_workflow)
+  end
+
+  context 'with any user' do
+    before { render }
+    subject { rendered }
+    it { is_expected.to have_content 'Foobar' }
+    it { is_expected.to have_content t('hyrax.admin.sidebar.activity') }
+    it { is_expected.to have_content t('hyrax.admin.sidebar.user_activity') }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.profile') }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.notifications') }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.transfers') }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.collections') }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.works') }
+  end
+
+  context 'with a user who can read the admin dash' do
+    let(:read_admin_dashboard) { true }
+    before { render }
+    subject { rendered }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.statistics') }
+  end
+
+  context 'with a user who can manage any admin set' do
+    let(:manage_any_admin_set) { true }
+    before { render }
+    subject { rendered }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.admin_sets') }
+  end
+
+  context 'with a user who can review submissions' do
+    let(:review_submissions) { true }
+    before { render }
+    subject { rendered }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.workflow_review') }
+  end
+
+  context 'with a user who can manage users' do
+    let(:manage_user) { true }
+    before { render }
+    subject { rendered }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.users') }
+  end
+
+  context 'with a user who can update appearance' do
+    let(:update_appearance) { true }
+    before { render }
+    subject { rendered }
+    it { is_expected.to have_content t('hyrax.admin.sidebar.configuration') }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.appearance') }
+  end
+
+  context 'with a user who can manage features' do
+    let(:manage_feature) { true }
+    before { render }
+    subject { rendered }
+    it { is_expected.to have_content t('hyrax.admin.sidebar.configuration') }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.pages') }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.content_blocks') }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.technical') }
+  end
+
+  context 'with a user who can manage workflow' do
+    let(:manage_workflow) { true }
+    before { render }
+    subject { rendered }
+    it { is_expected.to have_content t('hyrax.admin.sidebar.configuration') }
+    it { is_expected.to have_link t('hyrax.admin.sidebar.workflow_roles') }
+  end
+end

--- a/spec/views/pages/edit.html.erb_spec.rb
+++ b/spec/views/pages/edit.html.erb_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe "hyrax/pages/edit", type: :view do
+  before { render }
+
+  it "renders the about_page form" do
+    assert_select "form[action=?][method=?]", hyrax.page_path(ContentBlock.about_page), "post" do
+      assert_select "textarea#content_block_about_page[name=?]", "content_block[about_page]"
+    end
+  end
+
+  it "renders the help_page form" do
+    assert_select "form[action=?][method=?]", hyrax.page_path(ContentBlock.help_page), "post" do
+      assert_select "textarea#content_block_help_page[name=?]", "content_block[help_page]"
+    end
+  end
+end


### PR DESCRIPTION
Refs #406

This work sets up #406, the ability to edit the Terms of Use page in the UI, in a way that does not crowd the UI with too many controls.

@projecthydra-labs/hyrax-code-reviewers
