### PR TITLE
Change data from integer to boolean in db-independent way

### DIFF
--- a/db/migrate/20170504192714_change_checksum_audit_log.rb
+++ b/db/migrate/20170504192714_change_checksum_audit_log.rb
@@ -1,8 +1,18 @@
 class ChangeChecksumAuditLog < ActiveRecord::Migration[5.0]
   def change
     rename_column :checksum_audit_logs, :version, :checked_uri
-    change_column :checksum_audit_logs, :pass, :boolean
-    rename_column :checksum_audit_logs, :pass, :passed
+    add_column    :checksum_audit_logs, :pass, :passed
+
+    reversible do |dir|
+      dir.up do
+        ChecksumAuditLog.find_each { |log| log.update!(passed: log.pass ) }
+      end
+      dir.down do
+        ChecksumAuditLog.find_each { |log| log.update!(pass: log.passed ) }
+      end
+    end
+
+    remove_column :checksum_audit_log, :pass
     add_index     :checksum_audit_logs, :checked_uri
   end
 end

--- a/db/migrate/20170504192714_change_checksum_audit_log.rb
+++ b/db/migrate/20170504192714_change_checksum_audit_log.rb
@@ -12,7 +12,7 @@ class ChangeChecksumAuditLog < ActiveRecord::Migration[5.0]
       end
     end
 
-    remove_column :checksum_audit_log, :pass
+    remove_column :checksum_audit_logs, :pass
     add_index     :checksum_audit_logs, :checked_uri
   end
 end

--- a/db/migrate/20170504192714_change_checksum_audit_log.rb
+++ b/db/migrate/20170504192714_change_checksum_audit_log.rb
@@ -1,14 +1,14 @@
 class ChangeChecksumAuditLog < ActiveRecord::Migration[5.0]
   def change
     rename_column :checksum_audit_logs, :version, :checked_uri
-    add_column    :checksum_audit_logs, :pass, :passed
+    add_column    :checksum_audit_logs, :passed, :boolean
 
     reversible do |dir|
       dir.up do
-        ChecksumAuditLog.find_each { |log| log.update!(passed: log.pass ) }
+        execute 'UPDATE checksum_audit_logs SET passed = (pass = 1)'
       end
       dir.down do
-        ChecksumAuditLog.find_each { |log| log.update!(pass: log.passed ) }
+        execute 'UPDATE checksum_audit_logs SET pass = CASE WHEN passed THEN 1 ELSE 0 END'
       end
     end
 


### PR DESCRIPTION
previous migration from #984, postgres did not like.

This way could be slow, as it needs to fetch and save each object individually,
but I can't think of anything better.

Those who already generated this hyrax migration into a local app may have to manually
copy over the migration. If this hadn't been in a release yet, that wouldn't seem
like a problem -- but seems it made it into 1.0 somehow?

Fixes #1035

As a bonus, it's reversible now.