### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/lib/hyrax/version.rb
+++ b/lib/hyrax/version.rb
@@ -1,3 +1,3 @@
 module Hyrax
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end


### PR DESCRIPTION
Version 1.0.0 was accidentally released from master.  Bump the version to re-release from 1-0-stable.